### PR TITLE
Map "next" to latest TS version

### DIFF
--- a/packages/utils/src/typescript-installer.ts
+++ b/packages/utils/src/typescript-installer.ts
@@ -48,6 +48,7 @@ export function typeScriptPath(version: TsVersion, tsLocal: string | undefined):
 
 function installDir(version: TsVersion): string {
   assert(version !== "local");
+  if (version === "next") version = TypeScriptVersion.latest;
   return path.join(installsDir, version);
 }
 

--- a/packages/utils/test/typescript-installer.test.ts
+++ b/packages/utils/test/typescript-installer.test.ts
@@ -1,0 +1,17 @@
+import { typeScriptPath } from "../src/typescript-installer";
+import { TypeScriptVersion } from "@definitelytyped/typescript-versions";
+import * as os from "os";
+import * as path from "path";
+
+describe("typeScriptPath", () => {
+  it("maps to temp folder", () => {
+    expect(typeScriptPath("3.4", undefined)).toEqual(
+      path.join(os.homedir(), ".dts", "typescript-installs", "3.4", "node_modules", "typescript")
+    );
+  });
+  it("maps next to latest typescript version", () => {
+    expect(typeScriptPath("next", undefined)).toEqual(
+      path.join(os.homedir(), ".dts", "typescript-installs", TypeScriptVersion.latest, "node_modules", "typescript")
+    );
+  });
+});


### PR DESCRIPTION
typescript-installer.install accepts "next" so that it can install `typescript@next`, but should install it to `typescript-installs/4.0/` (to use the current `next` as an example).

perf (currently) and dtslint (soon) rely on typescript-installer.typeScriptPath to do this translation &mdash; it calls `installDir` &mdash; so that's where I added the test.