### PR TITLE
Add isTypeScriptVersion

### DIFF
--- a/packages/header-parser/test/index.test.ts
+++ b/packages/header-parser/test/index.test.ts
@@ -139,6 +139,18 @@ describe("isSupported", () => {
   });
 });
 
+describe("isTypeScriptVersion", () => {
+  it("accepts in-range", () => {
+    expect(TypeScriptVersion.isTypeScriptVersion("3.8")).toBeTruthy();
+  });
+  it("rejects out-of-range", () => {
+    expect(TypeScriptVersion.isTypeScriptVersion("101.1")).toBeFalsy();
+  });
+  it("rejects garbage", () => {
+    expect(TypeScriptVersion.isTypeScriptVersion("it'sa me, luigi")).toBeFalsy();
+  });
+});
+
 describe("range", () => {
   it("works", () => {
     expect(TypeScriptVersion.range("3.5")).toEqual(["3.5", "3.6", "3.7", "3.8", "3.9", "4.0"]);

--- a/packages/typescript-versions/src/index.ts
+++ b/packages/typescript-versions/src/index.ts
@@ -108,4 +108,8 @@ export namespace TypeScriptVersion {
   export function isRedirectable(v: TypeScriptVersion): boolean {
     return all.indexOf(v) >= all.indexOf("3.1");
   }
+
+  export function isTypeScriptVersion(str: string): str is TypeScriptVersion {
+    return all.includes(str as TypeScriptVersion);
+  }
 }


### PR DESCRIPTION
Which type-asserts that a string is a TypeScriptVersion. I think it was incorrectly dropped during the header-parser/typescript-versions refactor.