### PR TITLE
Extends the error messaging

### DIFF
--- a/packages/utils/src/process.ts
+++ b/packages/utils/src/process.ts
@@ -85,7 +85,7 @@ export function runWithChildProcesses<In>({
       for (const child of allChildren) {
         child.kill();
       }
-      reject(new Error("Parsing failed."));
+      reject(new Error(`Parsing failed \nInputs: ${inputs}\nCLI Args: ${commandLineArgs}\n\n`));
     }
   });
 }


### PR DESCRIPTION
Looking at this error: https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/results?buildId=44369&view=logs&j=275f1d19-1bd8-5591-b06b-07d489ea915a&t=40b1ee41-44d6-5bba-aa04-4b76a5c732e5&l=25

I wasn't sure what to make of it, so I've expanded the error reporting in the throw - I assume this is fine, but open to not 