### PR TITLE
Let dtslint handle TypeScript installation, ensure it gets `--onlyTestTsNext` as argument

### DIFF
--- a/packages/dtslint-runner/src/main.ts
+++ b/packages/dtslint-runner/src/main.ts
@@ -51,15 +51,19 @@ export async function runDTSLint({
   const allPackages = [...packageNames, ...dependents];
   const testedPackages = shard ? allPackages.filter((_, i) => i % shard.count === shard.id - 1) : allPackages;
 
+  const dtslintArgs = [
+    "--listen",
+    ...(onlyTestTsNext ? ["--onlyTestTsNext"] : []),
+    ...(localTypeScriptPath ? ["--localTs", localTypeScriptPath] : [])
+  ];
+
   await runWithListeningChildProcesses({
     inputs: testedPackages.map(path => ({
       path,
       onlyTestTsNext: onlyTestTsNext || !packageNames.includes(path),
       expectOnly: expectOnly || !packageNames.includes(path)
     })),
-    commandLineArgs: ["--listen", onlyTestTsNext ? "--onlyTestTsNext" : ""].concat(
-      localTypeScriptPath ? ["--localTs", localTypeScriptPath] : []
-    ),
+    commandLineArgs: dtslintArgs,
     workerFile: require.resolve("dtslint"),
     nProcesses,
     cwd: typesPath,


### PR DESCRIPTION
- I don’t think there’s any reason this ever needed to try to install TypeScript, since dtslint has always handled that.
- Ensures `--onlyTestTsNext` is passed to dtslint as a CLI argument, not just in the child process message, to avoid unnecessarily installing more TypeScript versions (needs https://github.com/microsoft/dtslint/pull/289 to take effect)