### PR TITLE
getDefinitelyTyped: better error when command fails

### DIFF
--- a/packages/definitions-parser/src/.#get-definitely-typed.ts
+++ b/packages/definitions-parser/src/.#get-definitely-typed.ts
@@ -1,1 +1,0 @@
-nathansa@nathansa-singer.15347:1584372029

--- a/packages/definitions-parser/src/get-definitely-typed.ts
+++ b/packages/definitions-parser/src/get-definitely-typed.ts
@@ -2,7 +2,7 @@ import { ensureDir } from "fs-extra";
 import { DiskFS, downloadAndExtractFile, LoggerWithErrors, FS, exec } from "@definitelytyped/utils";
 
 import { dataDirPath, definitelyTypedZipUrl } from "./lib/settings";
-import type { ExecException } from "child_process";
+import { ExecException } from "child_process";
 
 /** Settings that may be determined dynamically. */
 export interface ParseDefinitionsOptions {


### PR DESCRIPTION
ExecExceptions have useless stacks and basically useless messages. Instead, create a new Error with the command getDefinitelyTyped was trying to exec, and the stack from getDefinitelyTyped.

Note that prettier crashes on `import type` -- I'm going to update to latest, but that may cause more problems than it's worth.