### PR TITLE
Fix crash in inverted version packages

### DIFF
--- a/packages/publisher/.vscode/launch.json
+++ b/packages/publisher/.vscode/launch.json
@@ -9,7 +9,7 @@
             "request": "launch",
             "name": "calculate-versions.js",
             "cwd": "${workspaceFolder}",
-            "program": "${workspaceFolder}/bin/calculate-versions.js",
+            "program": "${workspaceFolder}/dist/calculate-versions.js",
             "args": [],
             "sourceMaps": true
         },
@@ -18,9 +18,18 @@
             "request": "launch",
             "name": "publish-packages.js --dry",
             "cwd": "${workspaceFolder}",
-            "program": "${workspaceFolder}/bin/publish-packages.js",
+            "program": "${workspaceFolder}/dist/publish-packages.js",
             "args": ["--dry"],
             "sourceMaps": true
-        }
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "generate-packages.js",
+            "cwd": "${workspaceFolder}",
+            "program": "${workspaceFolder}/dist/generate-packages.js",
+            "args": [],
+            "sourceMaps": true
+        },
     ]
 }

--- a/packages/publisher/src/generate-packages.ts
+++ b/packages/publisher/src/generate-packages.ts
@@ -89,7 +89,10 @@ async function generateTypingPackage(
   dt: FS
 ): Promise<void> {
   const typesDirectory = dt.subDir("types").subDir(typing.name);
-  const packageFS = typing.isLatest || !typing.versionDirectoryName ? typesDirectory : typesDirectory.subDir(typing.versionDirectoryName);
+  const packageFS =
+    typing.isLatest || !typing.versionDirectoryName
+      ? typesDirectory
+      : typesDirectory.subDir(typing.versionDirectoryName);
 
   await writeCommonOutputs(
     typing,

--- a/packages/publisher/src/generate-packages.ts
+++ b/packages/publisher/src/generate-packages.ts
@@ -89,7 +89,7 @@ async function generateTypingPackage(
   dt: FS
 ): Promise<void> {
   const typesDirectory = dt.subDir("types").subDir(typing.name);
-  const packageFS = typing.isLatest ? typesDirectory : typesDirectory.subDir(typing.versionDirectoryName!);
+  const packageFS = typing.isLatest || !typing.versionDirectoryName ? typesDirectory : typesDirectory.subDir(typing.versionDirectoryName);
 
   await writeCommonOutputs(
     typing,


### PR DESCRIPTION
Packages with inverted versions -- where the toplevel index.d.ts has a lower version than some /v[0-9]+ subdirectory -- are unexpected by generate-packages. It expects that non-latest versions are always in a subdirectory.

This is not true for react-bootstrap, and no other packages that I'm aware of. I can't remember how react-bootstrap got into this state, but it should not stay there until the issue is actually fixed.

This is just a crash fix, not a complete fix. There aren't any tests because I didn't want to have to add testing infrastructure for generateTypingPackage on short notice -- all the existing tests just test that the correct file contents are generated, not the structure of the generated package itself.

This is not really a complete change, since I'm trying to get a fix out quickly. Either CI needs to prevent this state from happening, or publishing needs to support it.