### PR TITLE
Update READMEs and messages

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "typescript.tsdk": "/Developer/microsoft/TypeScript/built/local"
 }

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # DefinitelyTyped-tools
 
-_✨ Under construction ✨_
-
 A monorepo for formerly disparate DefinitelyTyped-related tools:
 
-- [header-parser](packages/header-parser): [microsoft/definitelytyped-header-parser](https://github.com/microsoft/definitelytyped-header-parser)
 - [definitions-parser](packages/definitions-parser): the part of [microsoft/types-publisher](https://github.com/microsoft/types-publisher) that reads DefinitelyTyped repository data
+- [dtslint-runner](packages/dtslint-runner): [DefinitelyTyped/dtslint-runner](https://github.com/DefinitelyTyped/dtslint-runner)
+- [header-parser](packages/header-parser): [microsoft/definitelytyped-header-parser](https://github.com/microsoft/definitelytyped-header-parser)
+- [perf](packages/perf): [andrewbranch/definitely-not-slow](https://github.com/andrewbranch/definitely-not-slow)
 - [publisher](packages/publisher): the rest of [microsoft/types-publisher](https://github.com/microsoft/types-publisher)
+- [retag](packages/retag): [DefinitelyTyped/dt-retag](https://github.com/DefinitelyTyped/dt-retag)
+- [typescript-versions]: the part of [definitelytyped-header-parser](https://github.com/microsoft/definitelytyped-header-parser) that tracked which TypeScript versions are published to npm and supported on DefinitelyTyped
 - [utils](packages/utils): shared utilities, mostly extracted from [microsoft/types-publisher](https://github.com/microsoft/types-publisher)
 
 ## Disclaimer
@@ -15,31 +17,14 @@ These tools are not intended for public consumption, so we may break the API whe
 
 ## Development
 
-This is a monorepo managed with [lerna](https://github.com/lerna/lerna). After cloning, run `npm install`. `lerna bootstrap` will be run automatically to install dependencies in each of the individual packages.
-
-### Adding/updating dependencies
-
-Rather than using `npm install` in individual packages, use [`lerna add`](https://github.com/lerna/lerna/tree/master/commands/add#readme) from the root. Examples:
-
-```sh
-# To add `glob` to definitions-parser:
-lerna add glob packages/definitions-parser
-
-# To add testdouble as a devDependency to publisher:
-lerna add --dev testdouble packages/publisher
-
-# To add typescript to all packages:
-lerna add typescript
-```
-
-The exception to this rule is devDependencies that are shared between all packages: those can added to the root package.json with `npm` directly.
+This is a monorepo managed with [yarn workspaces](https://classic.yarnpkg.com/en/docs/workspaces) and [lerna](https://github.com/lerna/lerna). After cloning, run `yarn` to install dependencies for each package and link them to each other.
 
 ### Testing
 
-All packages use [jest](https://github.com/facebook/jest), with a single configuration set up to be run from the monorepo root. `npm test` is an alias for `jest`, so you can run tests with any of [jest’s CLI options](https://jestjs.io/docs/en/cli). For example, to run tests for a single package:
+All packages use [jest](https://github.com/facebook/jest), with a single configuration set up to be run from the monorepo root. `yarn test` is an alias for `jest`, so you can run tests with any of [jest’s CLI options](https://jestjs.io/docs/en/cli). For example, to run tests for a single package:
 
 ```sh
-npm test -- packages/utils
+yarn test packages/utils
 ```
 
 ## Contributing

--- a/packages/definitions-parser/src/lib/definition-parser.ts
+++ b/packages/definitions-parser/src/lib/definition-parser.ts
@@ -325,11 +325,11 @@ an old version of types that have since been moved to the source repo.
 For example, if package *P* used to have types on Definitely Typed at @types/P,
 but now has its own types, a dependent package *D* will need to use package.json
 to refer to @types/P if it relies on old versions of P's types.
-In this case, please make a pull request to types-publisher adding @types/P to \`dependenciesWhitelist.txt\`.`
+In this case, please make a pull request to microsoft/DefinitelyTyped-tools adding @types/P to \`packages/definitions-parser/dependenciesWhitelist.txt\`.`
         : `Dependency ${dependencyName} not in whitelist.
 If you are depending on another \`@types\` package, do *not* add it to a \`package.json\`. Path mapping should make the import work.
 For namespaced dependencies you then have to add a \`paths\` mapping from \`@namespace/library\` to \`namespace__library\` in \`tsconfig.json\`.
-If this is an external library that provides typings,  please make a pull request to types-publisher adding it to \`dependenciesWhitelist.txt\`.`;
+If this is an external library that provides typings,  please make a pull request to microsoft/DefinitelyTyped-tools adding it to \`packages/definitions-parser/dependenciesWhitelist.txt\`.`;
       throw new Error(`In ${path}: ${msg}`);
     }
 


### PR DESCRIPTION
- Removes "under construction" message in root README
- Removes lerna-specific directions since yarn can be used as usual
- Updates an error message for the new location of dependenciesWhitelist.txt