### PR TITLE
Run parsing in child process even when there’s only 1 CPU

### DIFF
--- a/packages/definitions-parser/src/parse-definitions.ts
+++ b/packages/definitions-parser/src/parse-definitions.ts
@@ -26,7 +26,7 @@ export async function parseDefinitions(
   const typings: { [name: string]: TypingsVersionsRaw } = {};
 
   const start = Date.now();
-  if (parallel && parallel.nProcesses > 1) {
+  if (parallel) {
     log.info("Parsing in parallel...");
     await runWithChildProcesses({
       inputs: packageNames,

--- a/packages/dtslint-runner/src/prepareAffectedPackages.ts
+++ b/packages/dtslint-runner/src/prepareAffectedPackages.ts
@@ -24,7 +24,7 @@ export async function prepareAffectedPackages({
     parseInParallel: nProcesses > 1
   };
   const dt = await getDefinitelyTyped(options, log);
-  await parseDefinitions(dt, { definitelyTypedPath, nProcesses }, log);
+  await parseDefinitions(dt, nProcesses ? { definitelyTypedPath, nProcesses } : undefined, log);
   try {
     await checkParseResults(/*includeNpmChecks*/ false, dt, options);
   } catch (err) {


### PR DESCRIPTION
I think this was stopping us from responding to webhooks in a timely manner. Probably publisher should be in charge of forking this process out, but 🤷‍♂️ 