### PR TITLE
Use a child process for parsing in production, make log messages better

### DIFF
--- a/packages/definitions-parser/src/parse-definitions.ts
+++ b/packages/definitions-parser/src/parse-definitions.ts
@@ -27,7 +27,7 @@ export async function parseDefinitions(
 
   const start = Date.now();
   if (parallel) {
-    log.info("Parsing in parallel...");
+    log.info(`Parsing in ${parallel.nProcesses} child process(es)...`);
     await runWithChildProcesses({
       inputs: packageNames,
       commandLineArgs: [`${parallel.definitelyTypedPath}/types`],
@@ -38,7 +38,7 @@ export async function parseDefinitions(
       }
     });
   } else {
-    log.info("Parsing non-parallel...");
+    log.info("Parsing in main process...");
     for (const packageName of packageNames) {
       typings[packageName] = getTypingInfo(packageName, typesFS.subDir(packageName));
     }

--- a/packages/publisher/src/util/util.ts
+++ b/packages/publisher/src/util/util.ts
@@ -11,4 +11,4 @@ export function outputDirectory(pkg: AnyPackage) {
   return joinPaths(outputDirPath, pkg.desc);
 }
 
-export const numberOfOsProcesses = process.env.TRAVIS === "true" ? 2 : os.cpus().length;
+export const numberOfOsProcesses = os.cpus().length;

--- a/packages/publisher/src/webhook.ts
+++ b/packages/publisher/src/webhook.ts
@@ -27,7 +27,7 @@ export default async function main(): Promise<void> {
       const s = await webhookServer(key, githubAccessToken, dry, fetcher, {
         definitelyTypedPath: undefined,
         progress: false,
-        parseInParallel: false
+        parseInParallel: true
       });
       console.log(`Listening on port ${port}`);
       s.listen(port);


### PR DESCRIPTION
Follow up on #49—we were never parsing in a child process on Azure, apparently:

https://github.com/microsoft/types-publisher/blob/4ea4d10166d732e294afc8cf755537acd53e02b2/src/lib/common.ts#L38