### PR TITLE
Update @azure/cosmos to 3

### DIFF
--- a/packages/perf/package.json
+++ b/packages/perf/package.json
@@ -15,7 +15,7 @@
     "url": "git://github.com/andrewbranch/definitely-not-slow.git"
   },
   "dependencies": {
-    "@azure/cosmos": "^2.1.7",
+    "@azure/cosmos": "^3.6.3",
     "@definitelytyped/definitions-parser": "^0.0.38",
     "@definitelytyped/header-parser": "^0.0.38",
     "@definitelytyped/utils": "^0.0.38",

--- a/packages/perf/src/cli/compareTypeScript.ts
+++ b/packages/perf/src/cli/compareTypeScript.ts
@@ -232,17 +232,15 @@ async function getPackagesToTestAndPriorResults(
   packageList?: PackageId[]
 ) {
   const iterator: AsyncIterable<FeedResponse<QueryResult<Document<PackageBenchmarkSummary>>>> = await container.items
-    .query(
-      {
-        query:
-          `SELECT * FROM ${config.database.packageBenchmarksContainerId} b` +
-          `  WHERE b.body.typeScriptVersionMajorMinor = @typeScriptVersion` +
-          (packageList
-            ? `  AND b.body.packageName IN (${packageList!.map(({ name }) => `"${name}"`).join(", ")})` // Couldn’t figure out how to do this with parameters
-            : ""),
-        parameters: [{ name: "@typeScriptVersion", value: typeScriptVersion }]
-      }
-    )
+    .query({
+      query:
+        `SELECT * FROM ${config.database.packageBenchmarksContainerId} b` +
+        `  WHERE b.body.typeScriptVersionMajorMinor = @typeScriptVersion` +
+        (packageList
+          ? `  AND b.body.packageName IN (${packageList!.map(({ name }) => `"${name}"`).join(", ")})` // Couldn’t figure out how to do this with parameters
+          : ""),
+      parameters: [{ name: "@typeScriptVersion", value: typeScriptVersion }]
+    })
     .getAsyncIterator();
 
   const packageKeys = packageList && packageList.map(toPackageKey);

--- a/packages/perf/src/cli/compareTypeScript.ts
+++ b/packages/perf/src/cli/compareTypeScript.ts
@@ -27,7 +27,7 @@ import {
   TypeScriptComparisonRun,
   getSourceVersion
 } from "../common";
-import { Container, Response } from "@azure/cosmos";
+import { Container, FeedResponse } from "@azure/cosmos";
 import { benchmarkPackage } from "./benchmark";
 import { getTypeScript } from "../measure/getTypeScript";
 import { postTypeScriptComparisonResults } from "../github/postTypeScriptComparisonResult";
@@ -231,7 +231,7 @@ async function getPackagesToTestAndPriorResults(
   getAllPackages: ReturnType<typeof createGetAllPackages>,
   packageList?: PackageId[]
 ) {
-  const iterator: AsyncIterable<Response<QueryResult<Document<PackageBenchmarkSummary>>>> = await container.items
+  const iterator: AsyncIterable<FeedResponse<QueryResult<Document<PackageBenchmarkSummary>>>> = await container.items
     .query(
       {
         query:
@@ -241,45 +241,45 @@ async function getPackagesToTestAndPriorResults(
             ? `  AND b.body.packageName IN (${packageList!.map(({ name }) => `"${name}"`).join(", ")})` // Couldn’t figure out how to do this with parameters
             : ""),
         parameters: [{ name: "@typeScriptVersion", value: typeScriptVersion }]
-      },
-      {
-        enableCrossPartitionQuery: true
       }
     )
     .getAsyncIterator();
 
   const packageKeys = packageList && packageList.map(toPackageKey);
   const packages = new Map<string, QueryResult<Document<PackageBenchmarkSummary>>>();
-  for await (const { result } of iterator) {
-    if (!result) continue;
-    const packageKey = toPackageKey(result.body.packageName, result.body.packageVersion);
-    if (packageKeys && !packageKeys.includes(packageKey)) {
-      continue;
-    }
 
-    const candidate = packages.get(packageKey);
-    if (candidate && candidate.createdAt > result.createdAt) {
-      continue;
-    }
-
-    const packageId: PackageId = {
-      name: result.body.packageName,
-      version: parseVersionFromDirectoryName(result.body.packageVersion) || ("*" as const)
-    };
-    const changedPackages = await getChangedPackages({ diffTo: result.body.sourceVersion, definitelyTypedPath });
-    if (changedPackages && changedPackages.some(packageIdsAreEqual(packageId))) {
-      console.log(`Skipping ${packageKey} because it changed`);
-      continue;
-    } else if (changedPackages) {
-      const { allPackages } = await getAllPackages();
-      const dependencies = allPackages.getTypingsData(packageId).dependencies;
-      if (dependencies.some(dep => changedPackages.some(packageIdsAreEqual(dep)))) {
-        console.log(`Skipping ${packageKey} because one or more of its dependencies changed`);
+  for await (const x of iterator) {
+    for (const result of x.resources) {
+      if (!result) continue;
+      const packageKey = toPackageKey(result.body.packageName, result.body.packageVersion);
+      if (packageKeys && !packageKeys.includes(packageKey)) {
         continue;
       }
-    }
 
-    packages.set(packageKey, result);
+      const candidate = packages.get(packageKey);
+      if (candidate && candidate.createdAt > result.createdAt) {
+        continue;
+      }
+
+      const packageId: PackageId = {
+        name: result.body.packageName,
+        version: parseVersionFromDirectoryName(result.body.packageVersion) || ("*" as const)
+      };
+      const changedPackages = await getChangedPackages({ diffTo: result.body.sourceVersion, definitelyTypedPath });
+      if (changedPackages && changedPackages.some(packageIdsAreEqual(packageId))) {
+        console.log(`Skipping ${packageKey} because it changed`);
+        continue;
+      } else if (changedPackages) {
+        const { allPackages } = await getAllPackages();
+        const dependencies = allPackages.getTypingsData(packageId).dependencies;
+        if (dependencies.some(dep => changedPackages.some(packageIdsAreEqual(dep)))) {
+          console.log(`Skipping ${packageKey} because one or more of its dependencies changed`);
+          continue;
+        }
+      }
+
+      packages.set(packageKey, result);
+    }
   }
 
   return packages;

--- a/packages/perf/src/common/db.ts
+++ b/packages/perf/src/common/db.ts
@@ -37,7 +37,6 @@ export async function getDatabase(
   const { container: packageBenchmarks } = await database.containers.createIfNotExists({
     id: config.database.packageBenchmarksContainerId,
     partitionKey: {
-      kind: "Hash",
       paths: ["/body/packageName"]
     }
   });

--- a/packages/perf/src/query/index.ts
+++ b/packages/perf/src/query/index.ts
@@ -15,21 +15,19 @@ export async function getLatestBenchmark({
   typeScriptVersionMajorMinor
 }: GetLatestBenchmarkOptions): Promise<QueryResult<Document<PackageBenchmarkSummary>> | undefined> {
   const response = await container.items
-    .query<QueryResult<Document<PackageBenchmarkSummary>>>(
-      {
-        query:
-          `SELECT TOP 1 * FROM ${config.database.packageBenchmarksContainerId} b` +
-          `  WHERE b.body.packageName = @packageName` +
-          `  AND b.body.packageVersion = @packageVersion` +
-          `  AND b.body.typeScriptVersionMajorMinor = @tsVersion` +
-          `  ORDER BY b.createdAt DESC`,
-        parameters: [
-          { name: "@packageName", value: packageName },
-          { name: "@packageVersion", value: packageVersion.toString() },
-          { name: "@tsVersion", value: typeScriptVersionMajorMinor }
-        ]
-      },
-    )
+    .query<QueryResult<Document<PackageBenchmarkSummary>>>({
+      query:
+        `SELECT TOP 1 * FROM ${config.database.packageBenchmarksContainerId} b` +
+        `  WHERE b.body.packageName = @packageName` +
+        `  AND b.body.packageVersion = @packageVersion` +
+        `  AND b.body.typeScriptVersionMajorMinor = @tsVersion` +
+        `  ORDER BY b.createdAt DESC`,
+      parameters: [
+        { name: "@packageName", value: packageName },
+        { name: "@packageVersion", value: packageVersion.toString() },
+        { name: "@tsVersion", value: typeScriptVersionMajorMinor }
+      ]
+    })
     .fetchNext();
   return response.resources[0];
 }

--- a/packages/perf/src/query/index.ts
+++ b/packages/perf/src/query/index.ts
@@ -15,7 +15,7 @@ export async function getLatestBenchmark({
   typeScriptVersionMajorMinor
 }: GetLatestBenchmarkOptions): Promise<QueryResult<Document<PackageBenchmarkSummary>> | undefined> {
   const response = await container.items
-    .query(
+    .query<QueryResult<Document<PackageBenchmarkSummary>>>(
       {
         query:
           `SELECT TOP 1 * FROM ${config.database.packageBenchmarksContainerId} b` +
@@ -29,9 +29,7 @@ export async function getLatestBenchmark({
           { name: "@tsVersion", value: typeScriptVersionMajorMinor }
         ]
       },
-      { enableCrossPartitionQuery: true }
     )
-    .current();
-
-  return response.result;
+    .fetchNext();
+  return response.resources[0];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,18 +2,21 @@
 # yarn lockfile v1
 
 
-"@azure/cosmos@^2.1.7":
-  version "2.1.7"
-  resolved "https://registry.yarnpkg.com/@azure/cosmos/-/cosmos-2.1.7.tgz#8fcd609417a77603b0007a519ef1b24690bfa9d4"
-  integrity sha512-kIfpgTM7q7o059NDQuGrr0ZrNUx7PaazUgyBLwu4rQhokVG3wWY2xsh1VzGJasPvkOBXxX3lHRmApQm3jY1CBA==
+"@azure/cosmos@^3.6.3":
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/@azure/cosmos/-/cosmos-3.6.3.tgz#bb53bde35fbf338160691d2b6a62f47b4a9a1cbb"
+  integrity sha512-JoCDxl0TnL6EHL4xD3KC9r2bMivK13q1jl7h69wd/YFLlt3aBTTCehtAX+y4alNSENpL53XdRdw/cna0mI2XDw==
   dependencies:
-    binary-search-bounds "2.0.3"
-    create-hmac "^1.1.7"
-    priorityqueuejs "1.0.0"
-    semaphore "1.0.5"
-    stream-http "^2.8.3"
-    tslib "^1.9.3"
-    tunnel "0.0.5"
+    "@types/debug" "^4.1.4"
+    debug "^4.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    node-abort-controller "^1.0.4"
+    node-fetch "^2.6.0"
+    os-name "^3.1.0"
+    priorityqueuejs "^1.0.0"
+    semaphore "^1.0.5"
+    tslib "^1.10.0"
+    uuid "^3.3.2"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.8.3":
   version "7.8.3"
@@ -1438,6 +1441,11 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/debug@^4.1.4":
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
+  integrity sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
@@ -2192,11 +2200,6 @@ bin-links@^1.1.2, bin-links@^1.1.7:
     npm-normalize-package-bin "^1.0.0"
     write-file-atomic "^2.3.0"
 
-binary-search-bounds@2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/binary-search-bounds/-/binary-search-bounds-2.0.3.tgz#5ff8616d6dd2ca5388bc85b2d6266e2b9da502dc"
-  integrity sha1-X/hhbW3SylOIvIWy1iZuK52lAtw=
-
 bl@^1.0.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.2.tgz#a160911717103c07410cef63ef51b397c025af9c"
@@ -2329,11 +2332,6 @@ builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
   integrity sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
-
-builtin-status-codes@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
-  integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
 builtins@^1.0.3:
   version "1.0.3"
@@ -2530,14 +2528,6 @@ cidr-regex@^2.0.10:
   integrity sha512-sB3ogMQXWvreNPbJUZMRApxuRYd+KoIo4RGQ81VatjmMW6WJPo+IJZ2846FGItr9VzKo5w7DXzijPLGtSd0N3Q==
   dependencies:
     ip-regex "^2.1.0"
-
-cipher-base@^1.0.1, cipher-base@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
-  integrity sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==
-  dependencies:
-    inherits "^2.0.1"
-    safe-buffer "^5.0.1"
 
 class-utils@^0.3.5:
   version "0.3.6"
@@ -2944,29 +2934,6 @@ create-error-class@^3.0.0:
   integrity sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=
   dependencies:
     capture-stack-trace "^1.0.0"
-
-create-hash@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
-  integrity sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==
-  dependencies:
-    cipher-base "^1.0.1"
-    inherits "^2.0.1"
-    md5.js "^1.3.4"
-    ripemd160 "^2.0.1"
-    sha.js "^2.4.0"
-
-create-hmac@^1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.7.tgz#69170c78b3ab957147b2b8b04572e47ead2243ff"
-  integrity sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==
-  dependencies:
-    cipher-base "^1.0.3"
-    create-hash "^1.1.0"
-    inherits "^2.0.1"
-    ripemd160 "^2.0.0"
-    safe-buffer "^5.0.1"
-    sha.js "^2.4.8"
 
 cross-spawn@^5.0.1:
   version "5.1.0"
@@ -6105,15 +6072,6 @@ md5.js@1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-md5.js@^1.3.4:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
-  integrity sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==
-  dependencies:
-    hash-base "^3.0.0"
-    inherits "^2.0.1"
-    safe-buffer "^5.1.2"
-
 meant@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/meant/-/meant-1.0.1.tgz#66044fea2f23230ec806fb515efea29c44d2115d"
@@ -6437,6 +6395,11 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+node-abort-controller@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/node-abort-controller/-/node-abort-controller-1.0.4.tgz#4095e41d58b2fae169d2f9892904d603e11c7a39"
+  integrity sha512-7cNtLKTAg0LrW3ViS2C7UfIzbL3rZd8L0++5MidbKqQVJ8yrH6+1VRSHl33P0ZjBTbOJd37d9EYekvHyKkB0QQ==
+
 node-fetch-npm@^2.0.2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/node-fetch-npm/-/node-fetch-npm-2.0.4.tgz#6507d0e17a9ec0be3bec516958a497cec54bf5a4"
@@ -6446,7 +6409,7 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-fetch@^2.3.0, node-fetch@^2.5.0:
+node-fetch@^2.3.0, node-fetch@^2.5.0, node-fetch@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
@@ -7377,7 +7340,7 @@ pretty-format@^25.2.1, pretty-format@^25.5.0:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
-priorityqueuejs@1.0.0:
+priorityqueuejs@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/priorityqueuejs/-/priorityqueuejs-1.0.0.tgz#2ee4f23c2560913e08c07ce5ccdd6de3df2c5af8"
   integrity sha1-LuTyPCVgkT4IwHzlzN1t498sWvg=
@@ -7945,14 +7908,6 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-ripemd160@^2.0.0, ripemd160@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
-  integrity sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==
-  dependencies:
-    hash-base "^3.0.0"
-    inherits "^2.0.1"
-
 rsvp@^4.8.4:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
@@ -8026,10 +7981,10 @@ saxes@^3.1.9:
   dependencies:
     xmlchars "^2.1.1"
 
-semaphore@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/semaphore/-/semaphore-1.0.5.tgz#b492576e66af193db95d65e25ec53f5f19798d60"
-  integrity sha1-tJJXbmavGT25XWXiXsU/Xxl5jWA=
+semaphore@^1.0.5:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/semaphore/-/semaphore-1.1.0.tgz#aaad8b86b20fe8e9b32b16dc2ee682a8cd26a8aa"
+  integrity sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA==
 
 semver-diff@^2.0.0:
   version "2.1.0"
@@ -8062,14 +8017,6 @@ set-value@^2.0.0, set-value@^2.0.1:
     is-extendable "^0.1.1"
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
-
-sha.js@^2.4.0, sha.js@^2.4.8:
-  version "2.4.11"
-  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
-  integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
-  dependencies:
-    inherits "^2.0.1"
-    safe-buffer "^5.0.1"
 
 sha@^3.0.0:
   version "3.0.0"
@@ -8393,17 +8340,6 @@ stream-each@^1.1.0:
   dependencies:
     end-of-stream "^1.1.0"
     stream-shift "^1.0.0"
-
-stream-http@^2.8.3:
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.8.3.tgz#b2d242469288a5a27ec4fe8933acf623de6514fc"
-  integrity sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==
-  dependencies:
-    builtin-status-codes "^3.0.0"
-    inherits "^2.0.1"
-    readable-stream "^2.3.6"
-    to-arraybuffer "^1.0.0"
-    xtend "^4.0.0"
 
 stream-iterate@^1.1.0:
   version "1.2.0"
@@ -8806,11 +8742,6 @@ tmpl@1.0.x:
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
   integrity sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=
 
-to-arraybuffer@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
-  integrity sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=
-
 to-buffer@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/to-buffer/-/to-buffer-1.1.1.tgz#493bd48f62d7c43fcded313a03dcadb2e1213a80"
@@ -8919,7 +8850,7 @@ tslib@^1.10.0, tslib@^1.8.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
-tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.8.1, tslib@^1.9.0:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==


### PR DESCRIPTION
This gets rid of a transitive dependency on md5.js

The biggest change is that `query` returns a nested iterator, so it exposes the chunking nature of requesting results.

I think. That's inferred from the type changes. This passes all the tests, but I'm not sure if that's sufficient.