### PR TITLE
Move @type dependencies to devDependencies

### DIFF
--- a/packages/header-parser/package.json
+++ b/packages/header-parser/package.json
@@ -21,8 +21,10 @@
   },
   "dependencies": {
     "@definitelytyped/typescript-versions": "^0.0.38",
-    "@types/parsimmon": "^1.10.1",
     "parsimmon": "^1.13.0"
+  },
+  "devDependencies": {
+    "@types/parsimmon": "^1.10.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -20,7 +20,6 @@
   },
   "dependencies": {
     "@definitelytyped/typescript-versions": "^0.0.38",
-    "@types/node": "^12.12.29",
     "charm": "^1.0.2",
     "fs-extra": "^8.1.0",
     "fstream": "^1.0.12",
@@ -31,6 +30,7 @@
   "devDependencies": {
     "@types/charm": "^1.0.1",
     "@types/fs-extra": "^8.1.0",
+    "@types/node": "^12.12.29",
     "@types/tar": "^4.0.3",
     "@types/tar-stream": "^2.1.0"
   },


### PR DESCRIPTION
Moves the following dependencies to `devDependencies`

- in `@dt/utils`: `@types/node`
- in `@dt/header-parser`: `@types/parsimmon`

## Motivation

When using `dtslint` in a project, these two packages get pulled in, and consequently also the `@types/…` packages that they depend on.

Additional types in `node_modules` affect type checking, with unintended consequences:

- for projects that have their own definition of the global `require`, that is going to clash with the definition in `@types/node`
- if typescript 2.x support is desired, `@types/parsimmon` will trigger an error (TS2370: A rest parameter must be of an array type).

Looking at the source, it looks as if these types are used to support development of `@dt/utils`/ `@dt/header-parser` themselves, so moving them seemed like a viable solution.