### PR TITLE
Deduplicate dependencies

### DIFF
--- a/packages/definitions-parser/src/check-parse-results.ts
+++ b/packages/definitions-parser/src/check-parse-results.ts
@@ -43,8 +43,8 @@ export async function checkParseResults(
   const packages = allPackages.allPackages();
   for (const pkg of packages) {
     if (pkg instanceof TypingsData) {
-      for (const dep of pkg.dependencies) {
-        dependedOn.add(dep.name);
+      for (const dep of Object.keys(pkg.dependencies)) {
+        dependedOn.add(dep);
       }
       for (const dep of pkg.testDependencies) {
         dependedOn.add(dep);

--- a/packages/definitions-parser/src/get-affected-packages.ts
+++ b/packages/definitions-parser/src/get-affected-packages.ts
@@ -87,8 +87,8 @@ function getReverseDependencies(
     }
   }
   for (const typing of allPackages.allTypings()) {
-    for (const dependency of typing.dependencies) {
-      const dependencies = map.get(packageIdToKey(allPackages.tryResolve(dependency)));
+    for (const [name, version] of Object.entries(typing.dependencies)) {
+      const dependencies = map.get(packageIdToKey(allPackages.tryResolve({ name, version })));
       if (dependencies) {
         dependencies[1].add(typing.id);
       }

--- a/packages/definitions-parser/src/lib/definition-parser.ts
+++ b/packages/definitions-parser/src/lib/definition-parser.ts
@@ -2,9 +2,9 @@ import * as ts from "typescript";
 import { parseHeaderOrFail } from "@definitelytyped/header-parser";
 import { allReferencedFiles, createSourceFile, getModuleInfo, getTestDependencies } from "./module-info";
 import {
+  DependencyVersion,
   formatTypingVersion,
   getLicenseFromPackageJson,
-  PackageId,
   PackageJsonDependency,
   PathMapping,
   TypingsDataRaw,
@@ -216,7 +216,7 @@ function combineDataForAllTypesVersions(
     typesVersions,
     files,
     license,
-    dependencies: getAllUniqueValues<"dependencies", PackageId>(allTypesVersions, "dependencies"),
+    dependencies: Object.assign({}, ...allTypesVersions.map(v => v.dependencies)),
     testDependencies: getAllUniqueValues<"testDependencies", string>(allTypesVersions, "testDependencies"),
     pathMappings: getAllUniqueValues<"pathMappings", PathMapping>(allTypesVersions, "pathMappings"),
     packageJsonDependencies,
@@ -237,7 +237,7 @@ function getAllUniqueValues<K extends string, T>(records: readonly Record<K, rea
 interface TypingDataFromIndividualTypeScriptVersion {
   /** Undefined for root (which uses `// TypeScript Version: ` comment instead) */
   readonly typescriptVersion: TypeScriptVersion | undefined;
-  readonly dependencies: readonly PackageId[];
+  readonly dependencies: { readonly [name: string]: DependencyVersion };
   readonly testDependencies: readonly string[];
   readonly pathMappings: readonly PathMapping[];
   readonly declFiles: readonly string[];
@@ -388,7 +388,7 @@ interface TsConfig {
 
 /** In addition to dependencies found in source code, also get dependencies from tsconfig. */
 interface DependenciesAndPathMappings {
-  readonly dependencies: readonly PackageId[];
+  readonly dependencies:  { readonly [name: string]: DependencyVersion };
   readonly pathMappings: readonly PathMapping[];
 }
 function calculateDependencies(
@@ -399,7 +399,7 @@ function calculateDependencies(
 ): DependenciesAndPathMappings {
   const paths = (tsconfig.compilerOptions && tsconfig.compilerOptions.paths) || {};
 
-  const dependencies: PackageId[] = [];
+  const dependencies: { [name: string]: DependencyVersion } = {};
   const pathMappings: PathMapping[] = [];
 
   for (const dependencyName of Object.keys(paths)) {
@@ -440,7 +440,7 @@ function calculateDependencies(
       }
     } else {
       if (dependencyNames.has(dependencyName)) {
-        dependencies.push({ name: dependencyName, version: pathMappingVersion });
+        dependencies[dependencyName] = pathMappingVersion;
       }
     }
     // Else, the path mapping may be necessary if it is for a transitive dependency. We will check this in check-parse-results.
@@ -457,8 +457,8 @@ function calculateDependencies(
   }
 
   for (const dependency of dependencyNames) {
-    if (!dependencies.some(d => d.name === dependency) && !nodeBuiltins.has(dependency)) {
-      dependencies.push({ name: dependency, version: "*" });
+    if (!dependencies[dependency] && !nodeBuiltins.has(dependency)) {
+      dependencies[dependency] = "*";
     }
   }
 

--- a/packages/definitions-parser/src/lib/definition-parser.ts
+++ b/packages/definitions-parser/src/lib/definition-parser.ts
@@ -388,7 +388,7 @@ interface TsConfig {
 
 /** In addition to dependencies found in source code, also get dependencies from tsconfig. */
 interface DependenciesAndPathMappings {
-  readonly dependencies:  { readonly [name: string]: DependencyVersion };
+  readonly dependencies: { readonly [name: string]: DependencyVersion };
   readonly pathMappings: readonly PathMapping[];
 }
 function calculateDependencies(

--- a/packages/definitions-parser/src/packages.ts
+++ b/packages/definitions-parser/src/packages.ts
@@ -119,7 +119,7 @@ export class AllPackages {
 
   /** Returns all of the dependences *that have typings*, ignoring others, and including test dependencies. */
   *allDependencyTypings(pkg: TypingsData): Iterable<TypingsData> {
-    for (const [ name, version ] of Object.entries(pkg.dependencies)) {
+    for (const [name, version] of Object.entries(pkg.dependencies)) {
       const versions = this.data.get(getMangledNameForScopedPackage(name));
       if (versions) {
         yield versions.get(version);
@@ -572,7 +572,7 @@ export class TypingsData extends PackageBase {
     return this.data.pathMappings;
   }
 
-  get dependencies(): { readonly [name: string]: DependencyVersion }  {
+  get dependencies(): { readonly [name: string]: DependencyVersion } {
     return this.data.dependencies;
   }
 

--- a/packages/definitions-parser/src/packages.ts
+++ b/packages/definitions-parser/src/packages.ts
@@ -119,7 +119,7 @@ export class AllPackages {
 
   /** Returns all of the dependences *that have typings*, ignoring others, and including test dependencies. */
   *allDependencyTypings(pkg: TypingsData): Iterable<TypingsData> {
-    for (const { name, version } of pkg.dependencies) {
+    for (const [ name, version ] of Object.entries(pkg.dependencies)) {
       const versions = this.data.get(getMangledNameForScopedPackage(name));
       if (versions) {
         yield versions.get(version);
@@ -327,7 +327,7 @@ export interface TypingsDataRaw extends BaseRaw {
    *
    * These will refer to *package names*, not *folder names*.
    */
-  readonly dependencies: readonly PackageId[];
+  readonly dependencies: { readonly [name: string]: DependencyVersion };
 
   /**
    * Other definitions, that exist in the same typings repo, that the tests, but not the types, of this package depend on.
@@ -572,7 +572,7 @@ export class TypingsData extends PackageBase {
     return this.data.pathMappings;
   }
 
-  get dependencies(): readonly PackageId[] {
+  get dependencies(): { readonly [name: string]: DependencyVersion }  {
     return this.data.dependencies;
   }
 

--- a/packages/definitions-parser/test/get-affected-packages.test.ts
+++ b/packages/definitions-parser/test/get-affected-packages.test.ts
@@ -3,12 +3,12 @@ import { NotNeededPackage, TypesDataFile, AllPackages } from "../src/packages";
 import { testo, createTypingsVersionRaw } from "./utils";
 
 const typesData: TypesDataFile = {
-  jquery: createTypingsVersionRaw("jquery", [], []),
-  known: createTypingsVersionRaw("known", [{ name: "jquery", version: { major: 1 } }], []),
-  "known-test": createTypingsVersionRaw("known-test", [], ["jquery"]),
-  "most-recent": createTypingsVersionRaw("most-recent", [{ name: "jquery", version: "*" }], []),
-  unknown: createTypingsVersionRaw("unknown", [{ name: "COMPLETELY-UNKNOWN", version: { major: 1 } }], []),
-  "unknown-test": createTypingsVersionRaw("unknown-test", [], ["WAT"])
+  jquery: createTypingsVersionRaw("jquery", {}, []),
+  known: createTypingsVersionRaw("known", { "jquery": { major: 1 } }, []),
+  "known-test": createTypingsVersionRaw("known-test", {}, ["jquery"]),
+  "most-recent": createTypingsVersionRaw("most-recent", { "jquery": "*" }, []),
+  unknown: createTypingsVersionRaw("unknown", { "COMPLETELY-UNKNOWN": { major: 1 } }, []),
+  "unknown-test": createTypingsVersionRaw("unknown-test", {}, ["WAT"])
 };
 
 const notNeeded = [

--- a/packages/definitions-parser/test/get-affected-packages.test.ts
+++ b/packages/definitions-parser/test/get-affected-packages.test.ts
@@ -4,9 +4,9 @@ import { testo, createTypingsVersionRaw } from "./utils";
 
 const typesData: TypesDataFile = {
   jquery: createTypingsVersionRaw("jquery", {}, []),
-  known: createTypingsVersionRaw("known", { "jquery": { major: 1 } }, []),
+  known: createTypingsVersionRaw("known", { jquery: { major: 1 } }, []),
   "known-test": createTypingsVersionRaw("known-test", {}, ["jquery"]),
-  "most-recent": createTypingsVersionRaw("most-recent", { "jquery": "*" }, []),
+  "most-recent": createTypingsVersionRaw("most-recent", { jquery: "*" }, []),
   unknown: createTypingsVersionRaw("unknown", { "COMPLETELY-UNKNOWN": { major: 1 } }, []),
   "unknown-test": createTypingsVersionRaw("unknown-test", {}, ["WAT"])
 };

--- a/packages/definitions-parser/test/utils.ts
+++ b/packages/definitions-parser/test/utils.ts
@@ -1,4 +1,4 @@
-import { TypingsVersionsRaw, License, PackageId } from "../src/packages";
+import { TypingsVersionsRaw, License, DependencyVersion } from "../src/packages";
 
 export function testo(o: { [s: string]: () => void }) {
   for (const k of Object.keys(o)) {
@@ -8,7 +8,7 @@ export function testo(o: { [s: string]: () => void }) {
 
 export function createTypingsVersionRaw(
   name: string,
-  dependencies: PackageId[],
+  dependencies: { readonly [name: string]: DependencyVersion },
   testDependencies: string[]
 ): TypingsVersionsRaw {
   return {

--- a/packages/perf/src/cli/compareTypeScript.ts
+++ b/packages/perf/src/cli/compareTypeScript.ts
@@ -270,7 +270,7 @@ async function getPackagesToTestAndPriorResults(
       } else if (changedPackages) {
         const { allPackages } = await getAllPackages();
         const dependencies = allPackages.getTypingsData(packageId).dependencies;
-        if (dependencies.some(dep => changedPackages.some(packageIdsAreEqual(dep)))) {
+        if (Object.entries(dependencies).some(([name, version]) => changedPackages.some(packageIdsAreEqual({ name, version })))) {
           console.log(`Skipping ${packageKey} because one or more of its dependencies changed`);
           continue;
         }

--- a/packages/perf/src/cli/compareTypeScript.ts
+++ b/packages/perf/src/cli/compareTypeScript.ts
@@ -270,7 +270,11 @@ async function getPackagesToTestAndPriorResults(
       } else if (changedPackages) {
         const { allPackages } = await getAllPackages();
         const dependencies = allPackages.getTypingsData(packageId).dependencies;
-        if (Object.entries(dependencies).some(([name, version]) => changedPackages.some(packageIdsAreEqual({ name, version })))) {
+        if (
+          Object.entries(dependencies).some(([name, version]) =>
+            changedPackages.some(packageIdsAreEqual({ name, version }))
+          )
+        ) {
           console.log(`Skipping ${packageKey} because one or more of its dependencies changed`);
           continue;
         }

--- a/packages/publisher/README.md
+++ b/packages/publisher/README.md
@@ -112,12 +112,9 @@ This file is a key/value mapping used by other steps in the process.
                 "misc.d.ts"
             ],
             "license": "MIT",
-            "dependencies": [
-                {
-                    "name": "sizzle",
-                    "version": "*"
-                }
-            ],
+            "dependencies": {
+                "sizzle": "*"
+            }
             "testDependencies": [],
             "pathMappings": [],
             "packageJsonDependencies": [],

--- a/packages/publisher/src/generate-packages.ts
+++ b/packages/publisher/src/generate-packages.ts
@@ -217,7 +217,7 @@ function getDependencies(
     // A dependency "foo" is already handled if we already have a dependency on the package "foo" or "@types/foo".
     if (
       !packageJsonDependencies.some(d => d.name === name || d.name === typesDependency) &&
-        allPackages.hasTypingFor({ name, version })
+      allPackages.hasTypingFor({ name, version })
     ) {
       dependencies[typesDependency] = dependencySemver(version);
     }

--- a/packages/publisher/src/generate-packages.ts
+++ b/packages/publisher/src/generate-packages.ts
@@ -212,14 +212,14 @@ function getDependencies(
     dependencies[name] = version;
   }
 
-  for (const dependency of typing.dependencies) {
-    const typesDependency = getFullNpmName(dependency.name);
+  for (const [name, version] of Object.entries(typing.dependencies)) {
+    const typesDependency = getFullNpmName(name);
     // A dependency "foo" is already handled if we already have a dependency on the package "foo" or "@types/foo".
     if (
-      !packageJsonDependencies.some(d => d.name === dependency.name || d.name === typesDependency) &&
-      allPackages.hasTypingFor(dependency)
+      !packageJsonDependencies.some(d => d.name === name || d.name === typesDependency) &&
+        allPackages.hasTypingFor({ name, version })
     ) {
-      dependencies[typesDependency] = dependencySemver(dependency.version);
+      dependencies[typesDependency] = dependencySemver(version);
     }
   }
   return sortObjectKeys(dependencies);
@@ -274,7 +274,7 @@ export function createReadme(typing: TypingsData): string {
   lines.push("");
   lines.push("### Additional Details");
   lines.push(` * Last updated: ${new Date().toUTCString()}`);
-  const dependencies = Array.from(typing.dependencies).map(d => getFullNpmName(d.name));
+  const dependencies = Object.keys(typing.dependencies).map(getFullNpmName);
   lines.push(
     ` * Dependencies: ${
       dependencies.length ? dependencies.map(d => `[${d}](https://npmjs.com/package/${d})`).join(", ") : "none"

--- a/packages/publisher/test/generate-packages.test.ts
+++ b/packages/publisher/test/generate-packages.test.ts
@@ -21,7 +21,7 @@ function createRawPackage(license: License): TypingsDataRaw {
   return {
     libraryName: "jquery",
     typingsPackageName: "jquery",
-    dependencies: { "madeira": { major: 1 } },
+    dependencies: { madeira: { major: 1 } },
     testDependencies: [],
     pathMappings: [],
     contributors: [{ name: "A", url: "b@c.d", githubUsername: "e" }],

--- a/packages/publisher/test/generate-packages.test.ts
+++ b/packages/publisher/test/generate-packages.test.ts
@@ -21,7 +21,7 @@ function createRawPackage(license: License): TypingsDataRaw {
   return {
     libraryName: "jquery",
     typingsPackageName: "jquery",
-    dependencies: [{ name: "madeira", version: { major: 1 } }],
+    dependencies: { "madeira": { major: 1 } },
     testDependencies: [],
     pathMappings: [],
     contributors: [{ name: "A", url: "b@c.d", githubUsername: "e" }],


### PR DESCRIPTION
Use the more common object format, which is technically less powerful, but we've never needed the additional power of the array format.