### PR TITLE
definition-parser: include package name in error

### DIFF
--- a/packages/definitions-parser/src/lib/definition-parser.ts
+++ b/packages/definitions-parser/src/lib/definition-parser.ts
@@ -69,7 +69,7 @@ export function getTypingInfo(packageName: string, fs: FS): TypingsVersionsRaw {
     if (matchesVersion(latestData, directoryVersion, considerLibraryMinorVersion)) {
       const latest = `${latestData.libraryMajorVersion}.${latestData.libraryMinorVersion}`;
       throw new Error(
-        `The latest version is ${latest}, so the subdirectory '${directoryName}' is not allowed` +
+        `The latest version of the '${packageName}' package is ${latest}, so the subdirectory '${directoryName}' is not allowed` +
           (`v${latest}` === directoryName
             ? "."
             : `; since it applies to any ${latestData.libraryMajorVersion}.* version, up to and including ${latest}.`)

--- a/packages/definitions-parser/test/definition-parser.test.ts
+++ b/packages/definitions-parser/test/definition-parser.test.ts
@@ -70,7 +70,7 @@ describe(getTypingInfo, () => {
         expect(() => {
           getTypingInfo("jquery", dt.pkgFS("jquery"));
         }).toThrow(
-          "The latest version is 3.3, so the subdirectory 'v3' is not allowed; " +
+          "The latest version of the 'jquery' package is 3.3, so the subdirectory 'v3' is not allowed; " +
             "since it applies to any 3.* version, up to and including 3.3."
         );
       });
@@ -81,7 +81,7 @@ describe(getTypingInfo, () => {
 
         expect(() => {
           getTypingInfo("jquery", dt.pkgFS("jquery"));
-        }).toThrow("The latest version is 3.3, so the subdirectory 'v3.3' is not allowed.");
+        }).toThrow("The latest version of the 'jquery' package is 3.3, so the subdirectory 'v3.3' is not allowed.");
       });
 
       it("does not throw when a minor version is older than the latest", () => {


### PR DESCRIPTION
Co-authored-by: Piotr Błażejewicz (Peter Blazejewicz) <peterblazejewicz@users.noreply.github.com>

This proposed change is intended to allow developers quickly figure out
the real reason of `getTypingInfo` failing due to version mismatch.
Current error message and related stack trace does not contain a clue
about the package failing and with the context of DT repository and
local development artifacts, this removes the problem with definition
parser failing on the stale data from local repository (non tracked
folders, etc).

Thanks!