### PR TITLE
docs: updated repository links

### DIFF
--- a/packages/definitions-parser/package.json
+++ b/packages/definitions-parser/package.json
@@ -2,13 +2,13 @@
   "name": "@definitelytyped/definitions-parser",
   "version": "0.0.40",
   "description": "Reads the DefinitelyTyped repository and provides an API for querying its metadata",
-  "homepage": "https://github.com/DefinitelyTyped/tools#readme",
+  "homepage": "https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/definitions-parser#readme",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/DefinitelyTyped/tools.git",
+    "url": "git+https://github.com/microsoft/DefinitelyTyped-tools.git",
     "directory": "packages/definitions-parser"
   },
   "scripts": {
@@ -16,7 +16,7 @@
     "test": "../../node_modules/.bin/jest --config ../../jest.config.js packages/definitions-parser"
   },
   "bugs": {
-    "url": "https://github.com/DefinitelyTyped/tools/issues"
+    "url": "https://github.com/microsoft/DefinitelyTyped-tools/issues"
   },
   "dependencies": {
     "@definitelytyped/header-parser": "^0.0.40",

--- a/packages/header-parser/package.json
+++ b/packages/header-parser/package.json
@@ -3,13 +3,13 @@
   "version": "0.0.40",
   "description": "",
   "author": "Nathan Shively-Sanders <nathansa@microsoft.com>",
-  "homepage": "https://github.com/DefinitelyTyped/tools#readme",
+  "homepage": "https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/header-parser#readme",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/DefinitelyTyped/tools.git",
+    "url": "git+https://github.com/microsoft/DefinitelyTyped-tools.git",
     "directory": "packages/header-parser"
   },
   "scripts": {
@@ -17,7 +17,7 @@
     "test": "../../node_modules/.bin/jest --config ../../jest.config.js packages/header-parser"
   },
   "bugs": {
-    "url": "https://github.com/DefinitelyTyped/tools/issues"
+    "url": "https://github.com/microsoft/DefinitelyTyped-tools/issues"
   },
   "dependencies": {
     "@definitelytyped/typescript-versions": "^0.0.40",

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -53,16 +53,16 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/DefinitelyTyped/tools.git",
+    "url": "git+https://github.com/microsoft/DefinitelyTyped-tools.git",
     "directory": "packages/publisher"
   },
   "author": "Microsoft",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/DefinitelyTyped/tools/issues"
+    "url": "https://github.com/microsoft/DefinitelyTyped-tools/issues"
   },
   "engines": {
     "node": ">=6.10.0"
   },
-  "homepage": "https://github.com/DefinitelyTyped/tools#readme"
+  "homepage": "https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/publisher#readme"
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -2,13 +2,13 @@
   "name": "@definitelytyped/utils",
   "version": "0.0.40",
   "description": "Shared utilities for DefinitelyTyped tools",
-  "homepage": "https://github.com/DefinitelyTyped/tools#readme",
+  "homepage": "https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/utils#readme",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/DefinitelyTyped/tools.git",
+    "url": "git+https://github.com/microsoft/DefinitelyTyped-tools.git",
     "directory": "packages/utils"
   },
   "scripts": {
@@ -16,7 +16,7 @@
     "test": "../../node_modules/.bin/jest --config ../../jest.config.js packages/utils"
   },
   "bugs": {
-    "url": "https://github.com/DefinitelyTyped/tools/issues"
+    "url": "https://github.com/microsoft/DefinitelyTyped-tools/issues"
   },
   "dependencies": {
     "@definitelytyped/typescript-versions": "^0.0.40",


### PR DESCRIPTION
Otherwise it's not obvious where the source lives for the corresponding npm packages.

Aside: Why is it owned by microsoft and not in the DT org? Will this be moved later and the links already anticipated this move or are the links outdated in which case: why did it move?