### PR TITLE
Add timeout to downloadAndExtractFile

### DIFF
--- a/packages/utils/src/io.ts
+++ b/packages/utils/src/io.ts
@@ -184,9 +184,10 @@ export function downloadAndExtractFile(url: string): Promise<FS> {
       dir.set(baseName, content);
     }
 
-    https.get(url, response => {
+    https.get(url, { timeout: 1_000_000 }, response => {
       const extract = tarStream.extract();
       response.pipe(zlib.createGunzip()).pipe(extract);
+      response.on("error", reject);
       interface Header {
         readonly name: string;
         readonly type: "file" | "directory";

--- a/packages/utils/src/io.ts
+++ b/packages/utils/src/io.ts
@@ -184,37 +184,38 @@ export function downloadAndExtractFile(url: string): Promise<FS> {
       dir.set(baseName, content);
     }
 
-    https.get(url, { timeout: 1_000_000 }, response => {
-      const extract = tarStream.extract();
-      response.pipe(zlib.createGunzip()).pipe(extract);
-      response.on("error", reject);
-      interface Header {
-        readonly name: string;
-        readonly type: "file" | "directory";
-      }
-      extract.on("entry", (header: Header, stream: NodeJS.ReadableStream, next: () => void) => {
-        const name = assertDefined(withoutStart(header.name, "DefinitelyTyped-master/"));
-        switch (header.type) {
-          case "file":
-            stringOfStream(stream, name)
-              .then(s => {
-                insertFile(name, s);
-                next();
-              })
-              .catch(reject);
-            break;
-          case "directory":
-            next();
-            break;
-          default:
-            throw new Error(`Unexpected file system entry kind ${header.type}`);
+    https
+      .get(url, { timeout: 1_000_000 }, response => {
+        const extract = tarStream.extract();
+        response.pipe(zlib.createGunzip()).pipe(extract);
+        interface Header {
+          readonly name: string;
+          readonly type: "file" | "directory";
         }
-      });
-      extract.on("error", reject);
-      extract.on("finish", () => {
-        resolve(new InMemoryFS(root.finish(), ""));
-      });
-    });
+        extract.on("entry", (header: Header, stream: NodeJS.ReadableStream, next: () => void) => {
+          const name = assertDefined(withoutStart(header.name, "DefinitelyTyped-master/"));
+          switch (header.type) {
+            case "file":
+              stringOfStream(stream, name)
+                .then(s => {
+                  insertFile(name, s);
+                  next();
+                })
+                .catch(reject);
+              break;
+            case "directory":
+              next();
+              break;
+            default:
+              throw new Error(`Unexpected file system entry kind ${header.type}`);
+          }
+        });
+        extract.on("error", reject);
+        extract.on("finish", () => {
+          resolve(new InMemoryFS(root.finish(), ""));
+        });
+      })
+      .on("error", reject);
   });
 }
 


### PR DESCRIPTION
It's only used to download the tgz of DT's master.

I set the timeout to 1000 seconds and added an error-handling line? I don't actually know how node's error handling works so I need to go and learn the right way to do it.

Fixes #64