### PR TITLE
Add `jsonata` to `allowedPackageJsonDependencies.txt`

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -127,6 +127,7 @@ jest-mock
 jest-snapshot
 jimp
 jointjs
+jsonata
 levelup
 lit-element
 localforage


### PR DESCRIPTION
Working on types for a module. On `npm test` I got the following error:

```
Error: In package.json: Dependency jsonata not in the allowed dependencies list.
If you are depending on another `@types` package, do *not* add it to a `package.json`. Path mapping should make the import work.
For namespaced dependencies you then have to add a `paths` mapping from `@namespace/library` to `namespace__library` in `tsconfig.json`.
If this is an external library that provides typings,  please make a pull request to microsoft/DefinitelyTyped-tools adding it to `packages/definitions-parser/allowedPackageJsonDependencies.txt`.
```

This is an external library that provides typings.
Repo: https://github.com/jsonata-js/jsonata/blob/master/jsonata.d.ts
Required typings: https://github.com/jsonata-js/jsonata/blob/master/jsonata.d.ts
