### PR TITLE
Allow `domhandler` in package.json.

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -88,6 +88,7 @@ decimal.js
 del
 dexie
 dnd-core
+domhandler
 dotenv
 egg
 electron


### PR DESCRIPTION
Per https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46560, this PR allows `domhandler` in package.json's.