### PR TITLE
Allow moment-timezone as package.json dependency

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -145,6 +145,7 @@ magic-string
 mali
 meteor-typings
 moment
+moment-timezone
 monaco-editor
 moment-range
 mqtt


### PR DESCRIPTION
moment-timezone now serves its own typings. Add it here so the DT typings can be deleted.

See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46421