### PR TITLE
feat: allow bee-queue for bull-arena types

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -64,6 +64,7 @@ aws-sdk
 axe-core
 axios
 base-x
+bee-queue
 bignumber.js
 bookshelf
 boxen


### PR DESCRIPTION
For https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46626, which references types from `bee-queue`.

(Disclaimer: I'm the primary maintainer for both packages)