### PR TITLE
Read allowedPackageJsonDependencies from GitHub

### DIFF
--- a/packages/definitions-parser/src/lib/definition-parser-worker.ts
+++ b/packages/definitions-parser/src/lib/definition-parser-worker.ts
@@ -14,7 +14,10 @@ if (!module.parent) {
     // tslint:disable-next-line no-async-without-await
     logUncaughtErrors(async () => {
       for (const packageName of message as readonly string[]) {
-        const data = getTypingInfo(packageName, getLocallyInstalledDefinitelyTyped(typesPath).subDir(packageName));
+        const data = await getTypingInfo(
+          packageName,
+          getLocallyInstalledDefinitelyTyped(typesPath).subDir(packageName)
+        );
         process.send!({ data, packageName });
       }
     });

--- a/packages/definitions-parser/src/lib/settings.ts
+++ b/packages/definitions-parser/src/lib/settings.ts
@@ -21,7 +21,7 @@ export async function getAllowedPackageJsonDependencies(): Promise<ReadonlySet<s
   if (allowedPackageJsonDependencies) {
     if (allowedPackageJsonDependenciesDownloadFailed) {
       console.error(
-        "Getting the latest allowedPackageJsonDependenices.txt from GitHub failed. Falling back to local copy."
+        "Getting the latest allowedPackageJsonDependencies.txt from GitHub failed. Falling back to local copy."
       );
     }
     return allowedPackageJsonDependencies;

--- a/packages/definitions-parser/src/lib/utils.ts
+++ b/packages/definitions-parser/src/lib/utils.ts
@@ -1,0 +1,15 @@
+import * as http from "http";
+
+export function getUrlContentsAsString(url: string): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    http
+      .get(url, res => {
+        let data = "";
+        res.on("data", d => (data += d));
+        res.on("end", () => {
+          resolve(data);
+        });
+      })
+      .on("error", reject);
+  });
+}

--- a/packages/definitions-parser/src/parse-definitions.ts
+++ b/packages/definitions-parser/src/parse-definitions.ts
@@ -40,7 +40,7 @@ export async function parseDefinitions(
   } else {
     log.info("Parsing in main process...");
     for (const packageName of packageNames) {
-      typings[packageName] = getTypingInfo(packageName, typesFS.subDir(packageName));
+      typings[packageName] = await getTypingInfo(packageName, typesFS.subDir(packageName));
     }
   }
   log.info("Parsing took " + (Date.now() - start) / 1000 + " s");

--- a/packages/definitions-parser/test/definition-parser.test.ts
+++ b/packages/definitions-parser/test/definition-parser.test.ts
@@ -2,21 +2,21 @@ import { createMockDT } from "../src/mocks";
 import { getTypingInfo } from "../src/lib/definition-parser";
 
 describe(getTypingInfo, () => {
-  it("keys data by major.minor version", () => {
+  it("keys data by major.minor version", async () => {
     const dt = createMockDT();
     dt.addOldVersionOfPackage("jquery", "1.42");
     dt.addOldVersionOfPackage("jquery", "2");
-    const info = getTypingInfo("jquery", dt.pkgFS("jquery"));
+    const info = await getTypingInfo("jquery", dt.pkgFS("jquery"));
 
     expect(Object.keys(info).sort()).toEqual(["1.42", "2.0", "3.3"]);
   });
 
   describe("concerning multiple versions", () => {
-    it("records what the version directory looks like on disk", () => {
+    it("records what the version directory looks like on disk", async () => {
       const dt = createMockDT();
       dt.addOldVersionOfPackage("jquery", "2");
       dt.addOldVersionOfPackage("jquery", "1.5");
-      const info = getTypingInfo("jquery", dt.pkgFS("jquery"));
+      const info = await getTypingInfo("jquery", dt.pkgFS("jquery"));
 
       expect(info).toEqual({
         "1.5": expect.objectContaining({
@@ -32,11 +32,11 @@ describe(getTypingInfo, () => {
       });
     });
 
-    it("records a path mapping to the version directory", () => {
+    it("records a path mapping to the version directory", async () => {
       const dt = createMockDT();
       dt.addOldVersionOfPackage("jquery", "2");
       dt.addOldVersionOfPackage("jquery", "1.5");
-      const info = getTypingInfo("jquery", dt.pkgFS("jquery"));
+      const info = await getTypingInfo("jquery", dt.pkgFS("jquery"));
 
       expect(info).toEqual({
         "1.5": expect.objectContaining({
@@ -67,30 +67,27 @@ describe(getTypingInfo, () => {
         const dt = createMockDT();
         dt.addOldVersionOfPackage("jquery", "3");
 
-        expect(() => {
-          getTypingInfo("jquery", dt.pkgFS("jquery"));
-        }).toThrow(
-          "The latest version of the 'jquery' package is 3.3, so the subdirectory 'v3' is not allowed; " +
+        expect(getTypingInfo("jquery", dt.pkgFS("jquery"))).rejects.toMatchObject({
+          message:
+            "The latest version of the 'jquery' package is 3.3, so the subdirectory 'v3' is not allowed; " +
             "since it applies to any 3.* version, up to and including 3.3."
-        );
+        });
       });
 
       it("throws if a directory exists for the latest minor version", () => {
         const dt = createMockDT();
         dt.addOldVersionOfPackage("jquery", "3.3");
 
-        expect(() => {
-          getTypingInfo("jquery", dt.pkgFS("jquery"));
-        }).toThrow("The latest version of the 'jquery' package is 3.3, so the subdirectory 'v3.3' is not allowed.");
+        expect(getTypingInfo("jquery", dt.pkgFS("jquery"))).rejects.toMatchObject({
+          message: "The latest version of the 'jquery' package is 3.3, so the subdirectory 'v3.3' is not allowed."
+        });
       });
 
       it("does not throw when a minor version is older than the latest", () => {
         const dt = createMockDT();
         dt.addOldVersionOfPackage("jquery", "3.0");
 
-        expect(() => {
-          getTypingInfo("jquery", dt.pkgFS("jquery"));
-        }).not.toThrow();
+        expect(getTypingInfo("jquery", dt.pkgFS("jquery"))).resolves.toBeDefined();
       });
     });
   });

--- a/packages/definitions-parser/test/packages.test.ts
+++ b/packages/definitions-parser/test/packages.test.ts
@@ -5,12 +5,12 @@ import { TypingsVersions } from "../src/packages";
 describe(TypingsVersions, () => {
   let versions: TypingsVersions;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     const dt = createMockDT();
     dt.addOldVersionOfPackage("jquery", "1");
     dt.addOldVersionOfPackage("jquery", "2");
     dt.addOldVersionOfPackage("jquery", "2.5");
-    versions = new TypingsVersions(getTypingInfo("jquery", dt.pkgFS("jquery")));
+    versions = new TypingsVersions(await getTypingInfo("jquery", dt.pkgFS("jquery")));
   });
 
   it("sorts the data from latest to oldest version", () => {

--- a/packages/publisher/src/parse-definitions.ts
+++ b/packages/publisher/src/parse-definitions.ts
@@ -38,7 +38,7 @@ if (!module.parent) {
 }
 
 async function single(singleName: string, dt: FS): Promise<void> {
-  const data = getTypingInfo(singleName, dt.subDir("types").subDir(singleName));
+  const data = await getTypingInfo(singleName, dt.subDir("types").subDir(singleName));
   const typings = { [singleName]: data };
   await writeDataFile(typesDataFilename, typings);
   console.log(JSON.stringify(data, undefined, 4));


### PR DESCRIPTION
Prevents us from needing to republish/redeploy when allowedPackageJsonDependencies.txt is changed.