### PR TITLE
Fix allowedPackageJsonDependencies download

### DIFF
--- a/packages/definitions-parser/src/lib/settings.ts
+++ b/packages/definitions-parser/src/lib/settings.ts
@@ -16,29 +16,22 @@ export const scopeName = "types";
 const allowedPackageJsonDependenciesUrl =
   "https://raw.githubusercontent.com/microsoft/DefinitelyTyped-tools/master/packages/definitions-parser/allowedPackageJsonDependencies.txt";
 let allowedPackageJsonDependencies: Promise<ReadonlySet<string>>;
-let allowedPackageJsonDependenciesDownloadFailed = false;
 export async function getAllowedPackageJsonDependencies(): Promise<ReadonlySet<string>> {
-  if (allowedPackageJsonDependencies) {
-    const deps = await allowedPackageJsonDependencies;
-    if (allowedPackageJsonDependenciesDownloadFailed) {
-      console.error(
-        "Getting the latest allowedPackageJsonDependencies.txt from GitHub failed. Falling back to local copy."
-      );
-    }
-    return deps;
-  }
-
-  allowedPackageJsonDependencies = new Promise<ReadonlySet<string>>(async resolve => {
-    let raw = readFileSync(joinPaths(root, "allowedPackageJsonDependencies.txt"));
-    if (process.env.NODE_ENV !== "test") {
-      try {
-        raw = await getUrlContentsAsString(allowedPackageJsonDependenciesUrl);
-      } catch (err) {
-        allowedPackageJsonDependenciesDownloadFailed = true;
+  return (
+    allowedPackageJsonDependencies ||
+    (allowedPackageJsonDependencies = new Promise<ReadonlySet<string>>(async resolve => {
+      let raw = readFileSync(joinPaths(root, "allowedPackageJsonDependencies.txt"));
+      if (process.env.NODE_ENV !== "test") {
+        try {
+          raw = await getUrlContentsAsString(allowedPackageJsonDependenciesUrl);
+        } catch (err) {
+          console.error(
+            "Getting the latest allowedPackageJsonDependencies.txt from GitHub failed. Falling back to local copy.\n" +
+              err.message
+          );
+        }
       }
-    }
-    resolve(new Set(raw.split(/\r?\n/)));
-  });
-
-  return getAllowedPackageJsonDependencies();
+      resolve(new Set(raw.split(/\r?\n/)));
+    }))
+  );
 }

--- a/packages/definitions-parser/src/lib/utils.ts
+++ b/packages/definitions-parser/src/lib/utils.ts
@@ -1,8 +1,8 @@
-import * as http from "http";
+import * as https from "https";
 
 export function getUrlContentsAsString(url: string): Promise<string> {
   return new Promise<string>((resolve, reject) => {
-    http
+    https
       .get(url, res => {
         let data = "";
         res.on("data", d => (data += d));

--- a/packages/definitions-parser/src/mocks.ts
+++ b/packages/definitions-parser/src/mocks.ts
@@ -198,6 +198,22 @@ var z = y;
 `
   );
   globby.set("tsconfig.json", tsconfig(["globby-tests.ts", "test/other-tests.ts"]));
+
+  const hasDependency = dt.pkgDir("has-dependency");
+  hasDependency.set(
+    "index.d.ts",
+    `// Type definitions for has-dependency 3.3
+// Project: https://www.microsoft.com
+// Definitions by: Andrew Branch <https://github.com/andrewbranch>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.1
+    
+export * from "moment"`
+  );
+  hasDependency.set("has-dependency-tests.ts", "");
+  hasDependency.set("tsconfig.json", tsconfig(["has-dependency-tests.ts"]));
+  hasDependency.set("package.json", `{ "private": true, "dependencies": { "moment": "*" } }`);
+
   const jquery = dt.pkgDir("jquery");
   jquery.set(
     "JQuery.d.ts",
@@ -225,21 +241,6 @@ console.log(jQuery);
 `
   );
   jquery.set("tsconfig.json", tsconfig(["jquery-tests.ts"]));
-
-  const hasDependency = dt.pkgDir("has-dependency");
-  hasDependency.set(
-    "index.d.ts",
-    `// Type definitions for has-dependency 3.3
-// Project: https://www.microsoft.com
-// Definitions by: Andrew Branch <https://github.com/andrewbranch>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.1
-    
-export * from "moment"`
-  );
-  hasDependency.set("has-dependency-tests.ts", "");
-  hasDependency.set("tsconfig.json", tsconfig(["has-dependency-tests.ts"]));
-  hasDependency.set("package.json", `{ "private": true, "dependencies": { "moment": "*" } }`);
 
   return dt;
 }

--- a/packages/definitions-parser/src/mocks.ts
+++ b/packages/definitions-parser/src/mocks.ts
@@ -156,34 +156,7 @@ import { inane } from "boring/v1";
 untested.d.ts
 `
   );
-  boring.set(
-    "tsconfig.json",
-    `{
-    "compilerOptions": {
-        "module": "commonjs",
-        "lib": [
-            "es6",
-            "dom"
-        ],
-        "target": "es6",
-        "noImplicitAny": true,
-        "noImplicitThis": true,
-        "strictNullChecks": true,
-        "strictFunctionTypes": true,
-        "baseUrl": "../",
-        "typeRoots": [
-            "../"
-        ],
-        "types": [],
-        "noEmit": true,
-        "forceConsistentCasingInFileNames": true
-    },
-    "files": [
-        "index.d.ts",
-        "boring-tests.ts"
-    ]
-}`
-  );
+  boring.set("tsconfig.json", tsconfig(["boring-tests.ts"]));
 
   const globby = dt.pkgDir("globby");
   globby.set(
@@ -224,35 +197,7 @@ var z = x;
 var z = y;
 `
   );
-  globby.set(
-    "tsconfig.json",
-    `{
-    "compilerOptions": {
-        "module": "commonjs",
-        "lib": [
-            "es6",
-            "dom"
-        ],
-        "target": "es6",
-        "noImplicitAny": true,
-        "noImplicitThis": true,
-        "strictNullChecks": true,
-        "strictFunctionTypes": true,
-        "baseUrl": "../",
-        "typeRoots": [
-            "../"
-        ],
-        "types": [],
-        "noEmit": true,
-        "forceConsistentCasingInFileNames": true
-    },
-    "files": [
-        "index.d.ts",
-        "globby-tests.ts",
-        "test/other-tests.ts"
-    ]
-}`
-  );
+  globby.set("tsconfig.json", tsconfig(["globby-tests.ts", "test/other-tests.ts"]));
   const jquery = dt.pkgDir("jquery");
   jquery.set(
     "JQuery.d.ts",
@@ -279,9 +224,28 @@ export = jQuery;
 console.log(jQuery);
 `
   );
-  jquery.set(
-    "tsconfig.json",
-    `{
+  jquery.set("tsconfig.json", tsconfig(["jquery-tests.ts"]));
+
+  const hasDependency = dt.pkgDir("has-dependency");
+  hasDependency.set(
+    "index.d.ts",
+    `// Type definitions for has-dependency 3.3
+// Project: https://www.microsoft.com
+// Definitions by: Andrew Branch <https://github.com/andrewbranch>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.1
+    
+export * from "moment"`
+  );
+  hasDependency.set("has-dependency-tests.ts", "");
+  hasDependency.set("tsconfig.json", tsconfig(["has-dependency-tests.ts"]));
+  hasDependency.set("package.json", `{ "private": true, "dependencies": { "moment": "*" } }`);
+
+  return dt;
+}
+
+function tsconfig(testNames: string[]) {
+  return `{
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
@@ -303,12 +267,7 @@ console.log(jQuery);
     },
     "files": [
         "index.d.ts",
-        "jquery-tests.ts"
+${testNames.map(s => "        " + JSON.stringify(s)).join(",\n")}
     ]
-}
-
-`
-  );
-
-  return dt;
+}`;
 }

--- a/packages/definitions-parser/test/definition-parser.test.ts
+++ b/packages/definitions-parser/test/definition-parser.test.ts
@@ -11,6 +11,12 @@ describe(getTypingInfo, () => {
     expect(Object.keys(info).sort()).toEqual(["1.42", "2.0", "3.3"]);
   });
 
+  it("works for a package with dependencies", async () => {
+    const dt = createMockDT();
+    const info = await getTypingInfo("has-dependency", dt.pkgFS("has-dependency"));
+    expect(info).toBeDefined();
+  });
+
   describe("concerning multiple versions", () => {
     it("records what the version directory looks like on disk", async () => {
       const dt = createMockDT();

--- a/packages/definitions-parser/test/parse-definitions.test.ts
+++ b/packages/definitions-parser/test/parse-definitions.test.ts
@@ -20,7 +20,7 @@ testo({
     const log = quietLoggerWithErrors()[0];
     const defs = await parseDefinitions(createMockDT().fs, undefined, log);
     expect(defs.allNotNeeded().length).toBe(1);
-    expect(defs.allTypings().length).toBe(3);
+    expect(defs.allTypings().length).toBe(4);
     const j = defs.tryGetLatestVersion("jquery");
     expect(j).toBeDefined();
     expect(j!.fullNpmName).toContain("types");


### PR DESCRIPTION
- Turns out there were no tests that would trigger an `allowedPackageJsonDependencies.txt` download/read (the download is disabled in test runs, but I commented out the env check locally to ensure it works), and a silly `http` vs. `https` module mistake prevented it from working.
- The getter function was previously more complicated because I thought I wanted to log a botched download every time we ask for the list to make sure it’s visible in the long-running types-publisher logs, but changed my mind, since a download issue will be easy to catch in CI.