### PR TITLE
Add immer to the dependencies whitelist

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -121,6 +121,7 @@ hoist-non-react-statics
 hot-shots
 htmlparser2
 i18next
+immer
 immutable
 indefinite-observable
 inversify


### PR DESCRIPTION
[use-global-hook](https://www.npmjs.com/package/use-global-hook) now takes an immer as an argument.
please see https://github.com/andregardi/use-global-hook/pull/51.

This PR adds immer to the whitelist for [this PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46964).