### PR TITLE
Make path mappings an object

### DIFF
--- a/packages/definitions-parser/src/check-parse-results.ts
+++ b/packages/definitions-parser/src/check-parse-results.ts
@@ -1,5 +1,5 @@
 import { ParseDefinitionsOptions } from "./get-definitely-typed";
-import { TypingsData, AllPackages, TypingVersion, formatTypingVersion } from "./packages";
+import { TypingsData, AllPackages, formatTypingVersion } from "./packages";
 import {
   assertDefined,
   best,
@@ -81,16 +81,12 @@ function checkTypeScriptVersions(allPackages: AllPackages): void {
 
 function checkPathMappings(allPackages: AllPackages): void {
   for (const pkg of allPackages.allTypings()) {
-    const pathMappings = new Map<string, TypingVersion>(pkg.pathMappings.map(p => [p.packageName, p.version]));
-    const unusedPathMappings = new Set(pathMappings.keys());
+    const unusedPathMappings = new Set(Object.keys(pkg.pathMappings));
 
     // If A depends on B, and B has path mappings, A must have the same mappings.
     for (const dependency of allPackages.allDependencyTypings(pkg)) {
-      for (const {
-        packageName: transitiveDependencyName,
-        version: transitiveDependencyVersion
-      } of dependency.pathMappings) {
-        const pathMappingVersion = pathMappings.get(transitiveDependencyName);
+      for (const [transitiveDependencyName, transitiveDependencyVersion] of Object.entries(dependency.pathMappings)) {
+        const pathMappingVersion = pkg.pathMappings[transitiveDependencyName];
         if (
           pathMappingVersion &&
           (pathMappingVersion.major !== transitiveDependencyVersion.major ||

--- a/packages/definitions-parser/src/packages.ts
+++ b/packages/definitions-parser/src/packages.ts
@@ -347,7 +347,7 @@ export interface TypingsDataRaw extends BaseRaw {
    * Not all path mappings are direct dependencies, they may be necessary for transitive dependencies. However, where `dependencies` and
    * `pathMappings` share a key, they *must* share the same value.
    */
-  readonly pathMappings: readonly PathMapping[];
+  readonly pathMappings: { readonly [packageName: string]: TypingVersion };
 
   /**
    * List of people that have contributed to the definitions in this package.
@@ -423,14 +423,6 @@ export interface TypingsDataRaw extends BaseRaw {
    * External modules declared by this package. Includes the containing folder name when applicable (e.g. proper module).
    */
   readonly declaredModules: readonly string[];
-}
-
-/**
- * @see {TypingsDataRaw.pathMappings}
- */
-export interface PathMapping {
-  readonly packageName: string;
-  readonly version: TypingVersion;
 }
 
 // Note that BSD is not supported -- for that, we'd have to choose a *particular* BSD license from the list at https://spdx.org/licenses/
@@ -568,7 +560,7 @@ export class TypingsData extends PackageBase {
   get globals(): readonly string[] {
     return this.data.globals;
   }
-  get pathMappings(): readonly PathMapping[] {
+  get pathMappings(): { readonly [packageName: string]: TypingVersion } {
     return this.data.pathMappings;
   }
 

--- a/packages/definitions-parser/test/definition-parser.test.ts
+++ b/packages/definitions-parser/test/definition-parser.test.ts
@@ -46,24 +46,18 @@ describe(getTypingInfo, () => {
 
       expect(info).toEqual({
         "1.5": expect.objectContaining({
-          pathMappings: [
-            {
-              packageName: "jquery",
-              version: { major: 1, minor: 5 }
-            }
-          ]
+          pathMappings: {
+            jquery: { major: 1, minor: 5 }
+          }
         }),
         "2.0": expect.objectContaining({
-          pathMappings: [
-            {
-              packageName: "jquery",
-              version: { major: 2, minor: undefined }
-            }
-          ]
+          pathMappings: {
+            jquery: { major: 2, minor: undefined }
+          }
         }),
         "3.3": expect.objectContaining({
           // The latest version does not have path mappings of its own
-          pathMappings: []
+          pathMappings: {}
         })
       });
     });


### PR DESCRIPTION
Same rationale as #57:
- It's written as if it's unique but isn't, because `getAllUniqueValues()` only does shallow (`===`) equality: https://github.com/microsoft/DefinitelyTyped-tools/blob/d885fe030b7ba7157b89887df403b8538646849f/packages/definitions-parser/src/lib/definition-parser.ts#L223
- I'm not aware of any advantages of the array format. The path mappings are used to refine dependencies and npm allows at most one semver per dependency, so you can't represent anything legal in the array that you can't with an object.
- We end up using the array for object lookup anyway:
  - https://github.com/microsoft/DefinitelyTyped-tools/blob/d885fe030b7ba7157b89887df403b8538646849f/packages/definitions-parser/src/check-parse-results.ts#L84
  - https://github.com/microsoft/DefinitelyTyped-tools/pull/87/files#diff-2943710c23a3f82fe40e2a34fa51c393R132