### PR TITLE
Flip typesVersions order to oldest-first

### DIFF
--- a/packages/header-parser/src/index.ts
+++ b/packages/header-parser/src/index.ts
@@ -41,11 +41,11 @@ export function makeTypesVersionsForPackageJson(typesVersions: readonly TypeScri
     return undefined;
   }
 
-  const newestFirst = typesVersions.slice();
-  newestFirst.sort((v1, v2) => (v1 < v2 ? 1 : v1 > v2 ? -1 : 0));
+  const oldestFirst = typesVersions.slice();
+  oldestFirst.sort((v1, v2) => (v1 > v2 ? 1 : v1 < v2 ? -1 : 0));
   const out: { [key: string]: { readonly "*": readonly string[] } } = {};
-  for (const version of newestFirst) {
-    out[`>=${version}.0-0`] = { "*": [`ts${version}/*`] };
+  for (const version of oldestFirst) {
+    out[`<=${version}`] = { "*": [`ts${version}/*`] };
   }
   return out;
 }

--- a/packages/header-parser/test/index.test.ts
+++ b/packages/header-parser/test/index.test.ts
@@ -206,45 +206,45 @@ describe("makeTypesVersionsForPackageJson", () => {
   });
   it("works for one version", () => {
     expect(makeTypesVersionsForPackageJson(["3.3"])).toEqual({
-      ">=3.3.0-0": {
+      "<=3.3": {
         "*": ["ts3.3/*"]
       }
     });
   });
-  it("orders versions new to old with old-to-new input", () => {
+  it("orders versions old to new  with old-to-new input", () => {
     expect(JSON.stringify(makeTypesVersionsForPackageJson(["3.2", "3.5", "3.6"]), undefined, 4)).toEqual(`{
-    ">=3.6.0-0": {
+    "<=3.2": {
         "*": [
-            "ts3.6/*"
+            "ts3.2/*"
         ]
     },
-    ">=3.5.0-0": {
+    "<=3.5": {
         "*": [
             "ts3.5/*"
         ]
     },
-    ">=3.2.0-0": {
+    "<=3.6": {
         "*": [
-            "ts3.2/*"
+            "ts3.6/*"
         ]
     }
 }`);
   });
-  it("orders versions new to old with new-to-old input", () => {
+  it("orders versions old to new  with new-to-old input", () => {
     expect(JSON.stringify(makeTypesVersionsForPackageJson(["3.6", "3.5", "3.2"]), undefined, 4)).toEqual(`{
-    ">=3.6.0-0": {
+    "<=3.2": {
         "*": [
-            "ts3.6/*"
+            "ts3.2/*"
         ]
     },
-    ">=3.5.0-0": {
+    "<=3.5": {
         "*": [
             "ts3.5/*"
         ]
     },
-    ">=3.2.0-0": {
+    "<=3.6": {
         "*": [
-            "ts3.2/*"
+            "ts3.6/*"
         ]
     }
 }`);


### PR DESCRIPTION
typesVersions subfolders are now expected to cover *older* versions with the root having the newest version, and the entry in package.json should be ordered oldest-first now:

For example, a package with 3.2,3.5,3.6 covers these ranges:
3.1-3.2, 3.3-3.5, 3.6, 3.7-4.1

And has the following typesVersions keys:

<=3.2, <=3.5, <=3.6

Publishing this change will block changes to the 18 DT packages that still have typesVersions entries, so I will fix them locally using the prerelease package once this PR is merged.

Edit: Before this change, a package with 3.2,3.5,3.6 covers different ranges and has different typesVersions keys:

3.1, 3.2-3.4, 3.5, 3.6-4.1

with keys:

>=3.6, >=3.5, >=3.2