### PR TITLE
Fix '--clone' vs '--path' conflict due to defaults

### DIFF
--- a/packages/dtslint-runner/src/index.ts
+++ b/packages/dtslint-runner/src/index.ts
@@ -20,8 +20,7 @@ if (!module.parent) {
         group: "DefinitelyTyped acquisition",
         description: "Path to local DefinitelyTyped clone.",
         conflicts: "clone",
-        type: "string",
-        default: "../DefinitelyTyped"
+        type: "string"
       },
       selection: {
         group: "Package selection",
@@ -85,7 +84,7 @@ if (!module.parent) {
         }
       : {
           kind: "local",
-          path: args.path
+          path: args.path || "../DefinitelyTyped"
         },
     onlyRunAffectedPackages: args.selection === "affected",
     nProcesses: args.nProcesses,


### PR DESCRIPTION
If `--path` has a default, then it will always conflict with `--clone`, which is causing problems with the On-Demand DT tests for TypeScript