### PR TITLE
[@definitelytyped/perf] Use yargs for CLI parsing

### DIFF
--- a/packages/perf/package.json
+++ b/packages/perf/package.json
@@ -22,9 +22,13 @@
     "@octokit/rest": "^16.33.0",
     "@types/node": "^12.12.29",
     "markdown-table": "^1.1.3",
-    "typescript": "^3.8.3"
+    "typescript": "^3.8.3",
+    "yargs": "^15.4.1"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "devDependencies": {
+    "@types/yargs": "^15.0.5"
   }
 }

--- a/packages/perf/src/cli/index.ts
+++ b/packages/perf/src/cli/index.ts
@@ -1,30 +1,176 @@
-import { deserializeArgs } from "../common";
+import os from "os";
+import path from "path";
+import process from "process";
+import yargs from "yargs";
 import { benchmark } from "./benchmark";
 import { getPackagesToBenchmark } from "./getPackagesToBenchmark";
 import { compare } from "./compare";
 import { compareTypeScriptCLI } from "./compareTypeScript";
+import { parsePackageKey } from "../common";
 
-const entry = process.argv[2];
-const args = deserializeArgs(process.argv.slice(3));
-(async () => {
-  try {
-    switch (entry) {
-      case "benchmark":
-        return benchmark(args);
-      case "getPackagesToBenchmark":
-        return getPackagesToBenchmark(args);
-      case "compare":
-        return compare(args);
-      case "compareTypeScript":
-        return compareTypeScriptCLI(args);
-      default:
-        console.error(`Unrecognized entry '${entry}'`);
-    }
-  } catch (err) {
-    console.error(err);
-    process.exit(1);
-  }
-})();
+const maxRunSeconds = {
+  type: "number",
+  requiresArg: true,
+  description: "limits the total run time of the benchmark"
+} as const;
+
+const upload = {
+  type: "boolean",
+  description: "uploads benchmark results to a database",
+  default: true
+} as const;
+
+const file = {
+  type: "string",
+  requiresArg: true,
+  description: "a path to a JSON file specifying run options"
+} as const;
+
+const definitelyTypedPath = {
+  type: "string",
+  requiresArg: true,
+  description: "the directory of the DefinitelyTyped repository",
+  default: process.cwd()
+} as const;
+
+const localTypeScriptPath = {
+  type: "string",
+  description: "path to a locally built TypeScript installation",
+  default: path.resolve("built/local")
+} as const;
+
+const tsVersion = {
+  type: "string",
+  description: "the TypeScript major/minor version to use for the measurements",
+  default: "next"
+} as const;
+
+void yargs
+  .command(
+    "benchmark",
+    "benchmark a single package",
+    {
+      file,
+      upload,
+      tsVersion,
+      progress: {
+        type: "boolean",
+        description: "logs progress updates during benchmarking",
+        default: false
+      },
+      iterations: {
+        type: "number",
+        requiresArg: true,
+        description: "the number of times to measure the package",
+        default: 5
+      },
+      nProcesses: {
+        type: "number",
+        requiresArg: true,
+        description: "splits the measurment iterations across multiple child processes",
+        default: os.cpus().length
+      },
+      maxRunSeconds,
+      printSummary: {
+        type: "boolean",
+        description: "logs a benchmark summary before exiting",
+        default: true
+      },
+      definitelyTypedPath,
+      failOnErrors: {
+        type: "boolean",
+        description: "exits with a non-zero code if a measurement process crashes",
+        default: true
+      },
+      installTypeScript: {
+        type: "boolean",
+        description: "installs TypeScript before running measurements",
+        default: true
+      },
+      localTypeScriptPath
+    },
+    benchmark
+  )
+  .command(
+    "getPackagesToBenchmark",
+    "generates a benchmark manifest file to be run by multiple agents",
+    {
+      definitelyTypedPath: {
+        ...definitelyTypedPath,
+        coerce: (dtPath: string) => (path.isAbsolute(dtPath) ? dtPath : path.resolve(process.cwd(), dtPath))
+      },
+      agentCount: {
+        type: "number",
+        requiresArg: true,
+        description: "the number of agents that will run the benchmarks",
+        demandOption: true
+      },
+      tsVersion: {
+        ...tsVersion,
+        demandOption: true
+      },
+      outFile: {
+        type: "string",
+        requiresArg: true,
+        description: "the path to the manifest file to be written",
+        demandOption: true
+      }
+    },
+    getPackagesToBenchmark
+  )
+  .command(
+    "compare",
+    "compare packages modified in a PR to those packages in the main branch",
+    {
+      definitelyTypedPath,
+      tsVersion: {
+        ...tsVersion,
+        demandOption: true
+      },
+      maxRunSeconds,
+      upload,
+      comment: {
+        type: "boolean",
+        description: "leave a typescript-bot comment on the associated DefinitelyTyped PR"
+      },
+      runDependents: {
+        description: "also compare packages dependent upon the modified packages",
+        coerce: (r: any) => {
+          if (typeof r !== "boolean" && typeof r !== "number") {
+            throw new Error("'runDependents' must be a boolean or the maximum number of dependent packages to run");
+          }
+          if (r === true) return 2;
+          if (r === false) return false;
+          return r;
+        }
+      }
+    },
+    compare
+  )
+  .command(
+    "compareTypeScript",
+    "compare packages’ performance between different TypeScript versions",
+    {
+      file,
+      compareAgainstVersion: {
+        type: "string",
+        requiresArg: true,
+        description: "the TypeScript major/minor version to compare against",
+        demandOption: true
+      },
+      packages: {
+        type: ("array" as unknown) as undefined, // yargs seems to have a problem with "array" + `coerce`
+        description: "list of packages to benchmark",
+        requiresArg: true,
+        coerce: (packages: string[]) => packages.map(parsePackageKey)
+      },
+      maxRunSeconds,
+      definitelyTypedPath,
+      localTypeScriptPath
+    },
+    compareTypeScriptCLI
+  )
+  .help().argv;
 
 process.on("unhandledRejection", err => {
   console.error(err);

--- a/packages/perf/src/common/utils.ts
+++ b/packages/perf/src/common/utils.ts
@@ -26,35 +26,6 @@ export function ensureExists(...pathNames: string[]): string {
   throw new Error(`File or directory does not exist: ${pathNamesPrint}`);
 }
 
-export interface Args {
-  [key: string]: string | boolean | number;
-}
-
-export function deserializeArgs(args: string[]): Args {
-  const obj: Args = {};
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    if (arg.startsWith("--")) {
-      const nextArg = args[i + 1];
-      if (!nextArg || nextArg.startsWith("--")) {
-        obj[arg.slice(2)] = true;
-      } else {
-        const numberArg = parseFloat(nextArg);
-        const boolArg = nextArg === "true" ? true : nextArg === "false" ? false : undefined;
-        obj[arg.slice(2)] = typeof boolArg === "boolean" ? boolArg : isNaN(numberArg) ? nextArg : numberArg;
-        i++;
-      }
-    }
-  }
-  return obj;
-}
-
-export function serializeArgs(args: Args): string {
-  return Object.keys(args)
-    .map(arg => `--${arg}` + (args[arg] === true ? "" : args[arg].toString()))
-    .join(" ");
-}
-
 export function compact<T>(arr: (T | null | undefined)[]): T[] {
   return arr.filter((elem): elem is T => elem !== null && elem !== undefined);
 }
@@ -71,17 +42,6 @@ export function assertNumber(input: any, name?: string): number {
     throw new Error(`Expected a number for input${name ? ` '${name}'` : ""} but received ${typeof input}`);
   }
   return input;
-}
-
-export function assertBoolean(input: any, name?: string): boolean {
-  if (typeof input !== "boolean") {
-    throw new Error(`Expected a boolean for input${name ? ` '${name}'` : ""} but received ${typeof input}`);
-  }
-  return input;
-}
-
-export function withDefault<T>(input: T, defaultValue: T): T {
-  return input === undefined ? defaultValue : input;
 }
 
 export function getSystemInfo(): SystemInfo {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3039,7 +3039,7 @@ debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -4470,7 +4470,7 @@ import-local@^3.0.2:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -5802,11 +5802,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -5815,32 +5810,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -5871,11 +5844,6 @@ lodash.memoize@4.x:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -6631,7 +6599,6 @@ npm@^6.13.4:
     cmd-shim "^3.0.3"
     columnify "~1.5.4"
     config-chain "^1.1.12"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -6646,7 +6613,6 @@ npm@^6.13.4:
     has-unicode "~2.0.1"
     hosted-git-info "^2.8.8"
     iferr "^1.0.2"
-    imurmurhash "*"
     infer-owner "^1.0.4"
     inflight "~1.0.6"
     inherits "^2.0.4"
@@ -6665,14 +6631,8 @@ npm@^6.13.4:
     libnpx "^10.2.2"
     lock-verify "^2.1.0"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"
@@ -9422,7 +9382,7 @@ yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
-yargs-parser@18.x, yargs-parser@^18.1.1:
+yargs-parser@18.x, yargs-parser@^18.1.1, yargs-parser@^18.1.2:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
   integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
@@ -9510,6 +9470,23 @@ yargs@^14.2.2:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^15.0.1"
+
+yargs@^15.4.1:
+  version "15.4.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
+  integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^18.1.2"
 
 yargs@^8.0.2:
   version "8.0.2"


### PR DESCRIPTION
Fixes a bug where `--tsVersion 4.0` is inferred as a number, causing it to stringify as `4`, causing us to look in the wrong directory for the TypeScript installation. Has the added bonus of documenting all CLI options and autogenerating help menus.

I manually sanity-checked by running some commands locally, but plan to test DT’s CI with it by manually triggering runs against `@definitelytyped/perf@next`, which will be published when this is merged to master, prior to publishing a `latest` npm release.