### PR TITLE
Deprecate Typescript 3.1

### DIFF
--- a/packages/header-parser/src/index.ts
+++ b/packages/header-parser/src/index.ts
@@ -230,7 +230,7 @@ const typeScriptVersionLineParser: pm.Parser<AllTypeScriptVersion> = pm
 const typeScriptVersionParser: pm.Parser<AllTypeScriptVersion> = pm
   .regexp(/\r?\n/)
   .then(typeScriptVersionLineParser)
-  .fallback<TypeScriptVersion>("3.2");
+  .fallback<TypeScriptVersion>(TypeScriptVersion.shipped[0]);
 
 export function parseTypeScriptVersionLine(line: string): AllTypeScriptVersion {
   const result = typeScriptVersionLineParser.parse(line);

--- a/packages/header-parser/src/index.ts
+++ b/packages/header-parser/src/index.ts
@@ -230,7 +230,7 @@ const typeScriptVersionLineParser: pm.Parser<AllTypeScriptVersion> = pm
 const typeScriptVersionParser: pm.Parser<AllTypeScriptVersion> = pm
   .regexp(/\r?\n/)
   .then(typeScriptVersionLineParser)
-  .fallback<TypeScriptVersion>("3.1");
+  .fallback<TypeScriptVersion>("3.2");
 
 export function parseTypeScriptVersionLine(line: string): AllTypeScriptVersion {
   const result = typeScriptVersionLineParser.parse(line);

--- a/packages/header-parser/test/index.test.ts
+++ b/packages/header-parser/test/index.test.ts
@@ -40,7 +40,7 @@ describe("parse", () => {
       libraryName: "foo",
       libraryMajorVersion: 1,
       libraryMinorVersion: 2,
-      typeScriptVersion: "3.1",
+      typeScriptVersion: "3.2",
       nonNpm: false,
       projects: ["https://github.com/foo/foo", "https://foo.com"],
       contributors: [
@@ -65,7 +65,7 @@ describe("parse", () => {
       libraryName: "foo",
       libraryMajorVersion: 1,
       libraryMinorVersion: 2,
-      typeScriptVersion: "3.1",
+      typeScriptVersion: "3.2",
       nonNpm: false,
       projects: ["https://github.com/foo/foo", "https://foo.com"],
       contributors: [
@@ -147,11 +147,11 @@ describe("isSupported", () => {
   it("works", () => {
     expect(TypeScriptVersion.isSupported("3.7")).toBeTruthy();
   });
-  it("supports 3.1", () => {
-    expect(TypeScriptVersion.isSupported("3.1")).toBeTruthy();
+  it("supports 3.2", () => {
+    expect(TypeScriptVersion.isSupported("3.2")).toBeTruthy();
   });
-  it("does not support 3.0", () => {
-    expect(!TypeScriptVersion.isSupported("3.0")).toBeTruthy();
+  it("does not support 3.1", () => {
+    expect(!TypeScriptVersion.isSupported("3.1")).toBeTruthy();
   });
 });
 
@@ -178,8 +178,7 @@ describe("range", () => {
 
 describe("tagsToUpdate", () => {
   it("works", () => {
-    expect(TypeScriptVersion.tagsToUpdate("3.1")).toEqual([
-      "ts3.1",
+    expect(TypeScriptVersion.tagsToUpdate("3.2")).toEqual([
       "ts3.2",
       "ts3.3",
       "ts3.4",
@@ -193,8 +192,8 @@ describe("tagsToUpdate", () => {
       "latest"
     ]);
   });
-  it("allows 3.1 onwards", () => {
-    expect(TypeScriptVersion.tagsToUpdate("3.1")).toEqual(
+  it("allows 3.2 onwards", () => {
+    expect(TypeScriptVersion.tagsToUpdate("3.2")).toEqual(
       TypeScriptVersion.supported.map(s => "ts" + s).concat("latest")
     );
   });

--- a/packages/publisher/test/generate-packages.test.ts
+++ b/packages/publisher/test/generate-packages.test.ts
@@ -27,7 +27,7 @@ function createRawPackage(license: License): TypingsDataRaw {
     contributors: [{ name: "A", url: "b@c.d", githubUsername: "e" }],
     libraryMajorVersion: 1,
     libraryMinorVersion: 0,
-    minTsVersion: "3.1",
+    minTsVersion: "3.2",
     typesVersions: [],
     files: ["index.d.ts", "jquery.test.ts"],
     license,
@@ -111,7 +111,7 @@ testo({
         "balzac": "~3"
     },
     "typesPublisherContentHash": "11",
-    "typeScriptVersion": "3.1"
+    "typeScriptVersion": "3.2"
 }`);
   },
   githubPackageJsonName() {

--- a/packages/typescript-versions/src/index.ts
+++ b/packages/typescript-versions/src/index.ts
@@ -38,19 +38,19 @@ export type UnsupportedTypeScriptVersion =
   | "2.7"
   | "2.8"
   | "2.9"
-  | "3.0";
+  | "3.0"
+  | "3.1";
 /**
  * Parseable and supported TypeScript versions.
  * Only add to this list if we will support this version on DefinitelyTyped.
  */
-export type TypeScriptVersion = "3.1" | "3.2" | "3.3" | "3.4" | "3.5" | "3.6" | "3.7" | "3.8" | "3.9" | "4.0" | "4.1";
+export type TypeScriptVersion = "3.2" | "3.3" | "3.4" | "3.5" | "3.6" | "3.7" | "3.8" | "3.9" | "4.0" | "4.1";
 
 export type AllTypeScriptVersion = UnsupportedTypeScriptVersion | TypeScriptVersion;
 
 export namespace TypeScriptVersion {
   /** Add to this list when a version actual ships.  */
   export const shipped: readonly TypeScriptVersion[] = [
-    "3.1",
     "3.2",
     "3.3",
     "3.4",
@@ -75,7 +75,8 @@ export namespace TypeScriptVersion {
     "2.7",
     "2.8",
     "2.9",
-    "3.0"
+    "3.0",
+    "3.1",
   ];
   export const all: readonly AllTypeScriptVersion[] = [...unsupported, ...supported];
   export const lowest = supported[0];

--- a/packages/typescript-versions/src/index.ts
+++ b/packages/typescript-versions/src/index.ts
@@ -50,17 +50,7 @@ export type AllTypeScriptVersion = UnsupportedTypeScriptVersion | TypeScriptVers
 
 export namespace TypeScriptVersion {
   /** Add to this list when a version actual ships.  */
-  export const shipped: readonly TypeScriptVersion[] = [
-    "3.2",
-    "3.3",
-    "3.4",
-    "3.5",
-    "3.6",
-    "3.7",
-    "3.8",
-    "3.9",
-    "4.0"
-  ];
+  export const shipped: readonly TypeScriptVersion[] = ["3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0"];
   /** Add to this list when a version is available as typescript@next */
   export const supported: readonly TypeScriptVersion[] = [...shipped, "4.1"];
   /** Add to this list when it will no longer be supported on Definitely Typed */
@@ -76,7 +66,7 @@ export namespace TypeScriptVersion {
     "2.8",
     "2.9",
     "3.0",
-    "3.1",
+    "3.1"
   ];
   export const all: readonly AllTypeScriptVersion[] = [...unsupported, ...supported];
   export const lowest = supported[0];


### PR DESCRIPTION
[According to the schedule](https://github.com/DefinitelyTyped/DefinitelyTyped#older-versions-of-typescript-30-and-earlier), it's time to deprecate 3.1. It seems like not much time since I delayed the 3.0 deprecation to match the 4.0 release.

Removing 3.1 support was complicated. This should be much easier. The follow-up tasks are:

1. Update dtslint and dts-critic.
2. Remove ts3.1/ directories from web-animations-js, openpgp, jest, es-to-primitive.
3. Remove ts3./1 directories from all versions of node. (This is big enough that it deserves its own task; the default implementations will have to move up to the next TS version directory since node's types build up from the oldest versions.)
4. Update "lowest version number" in DT's README.