### PR TITLE
Generalize #92 to deep imports from older versions

### DIFF
--- a/packages/definitions-parser/test/definition-parser.test.ts
+++ b/packages/definitions-parser/test/definition-parser.test.ts
@@ -102,6 +102,19 @@ describe(getTypingInfo, () => {
           'jquery: Older version 1 must have a "paths" entry of "jquery/*": ["jquery/v1/*"]'
         );
       });
+
+      it("checks that other deep imports from older versions have wildcard path mappings", () => {
+        const dt = createMockDT();
+        const hasOlderTestDependency = dt.pkgDir("has-older-test-dependency");
+        hasOlderTestDependency.set(
+          "has-older-test-dependency-tests.ts",
+          `import "jquery/component";
+`
+        );
+        return expect(
+          getTypingInfo("has-older-test-dependency", dt.pkgFS("has-older-test-dependency"))
+        ).rejects.toThrow('has-older-test-dependency: Must have a "paths" entry of "jquery/*": ["jquery/v1/*"]');
+      });
     });
   });
 });


### PR DESCRIPTION
Checks that wildcard path mappings are present when necessary. E.g. if you have a `"react-dom": ["react-dom/v15"]` path mapping and import `react-dom/server`, this checks that a wildcard `react-dom/*` path mapping is also present.