### PR TITLE
Try to get minTypeScriptVersion-compatible dependencies

### DIFF
--- a/packages/dtslint-runner/src/prepareAffectedPackages.ts
+++ b/packages/dtslint-runner/src/prepareAffectedPackages.ts
@@ -59,7 +59,7 @@ export async function installDependencies(packages: Iterable<TypingsData>, types
 
     // Scripts may try to compile native code.
     // This doesn't work reliably on travis, and we're just installing for the types, so ignore.
-    const cmd = `npm install ${npmInstallFlags}`;
+    const cmd = `npm install ${npmInstallFlags} --tag ts${pkg.minTypeScriptVersion}`;
     console.log(`  ${cwd}: ${cmd}`);
     const stdout = await execAndThrowErrors(cmd, cwd);
     if (stdout) {

--- a/packages/dtslint-runner/src/prepareAffectedPackages.ts
+++ b/packages/dtslint-runner/src/prepareAffectedPackages.ts
@@ -5,7 +5,6 @@ import {
   checkParseResults,
   getAffectedPackagesFromDiff,
   allDependencies,
-  AllPackages,
   TypingsData
 } from "@definitelytyped/definitions-parser";
 import { execAndThrowErrors, joinPaths, loggerWithErrors, npmInstallFlags } from "@definitelytyped/utils";
@@ -39,7 +38,7 @@ export async function prepareAffectedPackages({
   );
 
   if (!noInstall) {
-    await installDependencies(allPackages, [...changedPackages, ...dependentPackages], typesPath);
+    await installDependencies(allDependencies(allPackages, [...changedPackages, ...dependentPackages]), typesPath);
   }
 
   return {
@@ -48,15 +47,11 @@ export async function prepareAffectedPackages({
   };
 }
 
-async function installDependencies(
-  allPackages: AllPackages,
-  packages: Iterable<TypingsData>,
-  typesPath: string
-): Promise<void> {
+export async function installDependencies(packages: Iterable<TypingsData>, typesPath: string): Promise<void> {
   console.log("Installing NPM dependencies...");
 
   // We need to run `npm install` for all dependencies, too, so that we have dependencies' dependencies installed.
-  for (const pkg of allDependencies(allPackages, packages)) {
+  for (const pkg of packages) {
     const cwd = joinPaths(typesPath, pkg.subDirectoryPath);
     if (!(await pathExists(joinPaths(cwd, "package.json")))) {
       continue;


### PR DESCRIPTION
We'll be testing the types with `minTypeScriptVersion` (modulo `onlyTestTsNext`) so make an effort to get compatible external dependencies by adding the `--tag ts${minTypeScriptVersion}` option to `npm install`. If a dependency provides such a tag then we'll get that compatible version. If not, well, we'll continue to get the current behavior.

This adds the `--tag` option to `prepareAffectedPackages()` (trivial) and `prepareAllPackages()`, which previously used separate logic to crawl the types directory and bypassed `@definitelytyped/definitions-parser`. Adding the `--tag` option means reading the `minTypeScriptVersion`, so I made `prepareAffectedPackages()` and `prepareAllPackages()` share the same logic. I think this is desirable: You should get the same per-package behavior regardless of `onlyRunAffectedPackages`?