### PR TITLE
Use libraryName for deprecation dependency

### DIFF
--- a/packages/definitions-parser/src/packages.ts
+++ b/packages/definitions-parser/src/packages.ts
@@ -288,12 +288,12 @@ export class NotNeededPackage extends PackageBase {
   }
 
   readme(): string {
-    return `This is a stub types definition for ${this.libraryName} (${this.sourceRepoURL}).\n
+    return `This is a stub types definition for ${getFullNpmName(this.name)} (${this.sourceRepoURL}).\n
 ${this.libraryName} provides its own type definitions, so you don't need ${getFullNpmName(this.name)} installed!`;
   }
 
   deprecatedMessage(): string {
-    return `This is a stub types definition. ${this.name} provides its own type definitions, so you do not need this installed.`;
+    return `This is a stub types definition. ${this.libraryName} provides its own type definitions, so you do not need this installed.`;
   }
 }
 

--- a/packages/publisher/src/calculate-versions.ts
+++ b/packages/publisher/src/calculate-versions.ts
@@ -82,8 +82,8 @@ async function computeChangedPackages(
   const changedNotNeededPackages = await mapDefinedAsync(allPackages.allNotNeeded(), async pkg => {
     if (!(await isAlreadyDeprecated(pkg, client, log))) {
       assertDefined(
-        await client.fetchAndCacheNpmInfo(pkg.unescapedName),
-        `To deprecate '@types/${pkg.name}', '${pkg.unescapedName}' must exist on npm.`
+        await client.fetchAndCacheNpmInfo(pkg.libraryName),
+        `To deprecate '@types/${pkg.name}', '${pkg.libraryName}' must exist on npm.`
       );
       log.info(`To be deprecated: ${pkg.name}`);
       return pkg;

--- a/packages/publisher/src/generate-packages.ts
+++ b/packages/publisher/src/generate-packages.ts
@@ -230,7 +230,7 @@ function dependencySemver(dependency: DependencyVersion): string {
 }
 
 export function createNotNeededPackageJSON(
-  { libraryName, license, unescapedName, fullNpmName, sourceRepoURL, version }: NotNeededPackage,
+  { libraryName, license, fullNpmName, sourceRepoURL, version }: NotNeededPackage,
   registry: Registry
 ): string {
   const out = {
@@ -245,7 +245,7 @@ export function createNotNeededPackageJSON(
     license,
     // No `typings`, that's provided by the dependency.
     dependencies: {
-      [unescapedName]: "*"
+      [libraryName]: "*"
     }
   };
   if (registry === Registry.Github) {

--- a/packages/publisher/test/generate-packages.test.ts
+++ b/packages/publisher/test/generate-packages.test.ts
@@ -50,7 +50,7 @@ function createTypesData(): TypesDataFile {
 }
 function createUnneededPackage() {
   return new NotNeededPackage({
-    libraryName: "absalom",
+    libraryName: "alternate",
     typingsPackageName: "absalom",
     asOfVersion: "1.1.1",
     sourceRepoURL: "https://github.com/aardwulf/absalom"
@@ -134,20 +134,20 @@ testo({
     "name": "@types/absalom",
     "version": "1.1.1",
     "typings": null,
-    "description": "Stub TypeScript definitions entry for absalom, which provides its own types definitions",
+    "description": "Stub TypeScript definitions entry for alternate, which provides its own types definitions",
     "main": "",
     "scripts": {},
     "author": "",
     "repository": "https://github.com/aardwulf/absalom",
     "license": "MIT",
     "dependencies": {
-        "absalom": "*"
+        "alternate": "*"
     }
 }`);
   },
   scopedNotNeededPackageJson() {
     const scopedUnneeded = new NotNeededPackage({
-      libraryName: "@google-cloud/pubsub",
+      libraryName: "@google-cloud/chubdub",
       typingsPackageName: "google-cloud__pubsub",
       asOfVersion: "0.26.0",
       sourceRepoURL: "https://github.com/googleapis/nodejs-storage"
@@ -157,14 +157,14 @@ testo({
     "name": "@types/google-cloud__pubsub",
     "version": "0.26.0",
     "typings": null,
-    "description": "Stub TypeScript definitions entry for @google-cloud/pubsub, which provides its own types definitions",
+    "description": "Stub TypeScript definitions entry for @google-cloud/chubdub, which provides its own types definitions",
     "main": "",
     "scripts": {},
     "author": "",
     "repository": "https://github.com/googleapis/nodejs-storage",
     "license": "MIT",
     "dependencies": {
-        "@google-cloud/pubsub": "*"
+        "@google-cloud/chubdub": "*"
     }
 }`);
   },


### PR DESCRIPTION
Previously, the code incorrectly re-used the `@types` package name for the deprecation dependency, which is also noted in the readme as the correct package to install in the future.

This is correct 90%+ percent of the time because `@types/X` usually provides types for package `X`. Sometimes, however, there is no matching `X`, so that `@types/X` should tell users to install some other package `Y` when it's deprecated.

For example, `@types/xumm-api` was for a non-npm package that eventually got published to npm as `xumm-sdk` and at the same time started shipping types. So the deprecation entry looked like this:

```json
{
  "libraryName": "xumm-sdk",
  "typingsPackageName": "xumm-api",
  "sourceRepoURL": "https://github.com/XRPL-Labs/XUMM-SDK",
  "asOfVersion": "0.1.4"
}
```

There IS no `xumm-api`, only an `xumm-sdk`, so it doesn't make sense to point people to `xumm-api` when `@types/xumm-api` is deprecated.