### PR TITLE
Add elasticsearch to list of allowed package.json dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -92,6 +92,7 @@ dnd-core
 domhandler
 dotenv
 egg
+elasticsearch
 electron
 electron-notarize
 electron-osx-sign


### PR DESCRIPTION
Elasticsearch provides its own typings as of 6.0 https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/6.x/typescript.html

The package `http-aws-es` has this dependency.

The matching DefinitelyTyped PR: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/48112