### PR TITLE
Remove elasticsearch from list of allowed package.json dependencies 

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -92,7 +92,6 @@ dnd-core
 domhandler
 dotenv
 egg
-elasticsearch
 electron
 electron-notarize
 electron-osx-sign


### PR DESCRIPTION
Elasticsearch's definitions are actually in `@elastic/elasticsearch`, which is already included.

This reverts https://github.com/microsoft/DefinitelyTyped-tools/pull/123 .  Additional context: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/48112#discussion_r494450938