### PR TITLE
Add `html-webpack-plugin`

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -120,6 +120,7 @@ handlebars
 helmet
 hoist-non-react-statics
 hot-shots
+html-webpack-plugin
 htmlparser2
 i18next
 immer


### PR DESCRIPTION
There are couple of definitions that depends on `html-webpack-plugin`
and using old definition type, instead of using inline version shipped
with v4.0.0 of plugin itself.

https://github.com/jantimon/html-webpack-plugin/blob/master/typings.d.ts

Thanks!