### PR TITLE
More logging of DT io in publisher

### DIFF
--- a/packages/definitions-parser/src/get-definitely-typed.ts
+++ b/packages/definitions-parser/src/get-definitely-typed.ts
@@ -22,7 +22,8 @@ export async function getDefinitelyTyped(options: ParseDefinitionsOptions, log: 
   if (options.definitelyTypedPath === undefined) {
     log.info("Downloading Definitely Typed ...");
     await ensureDir(dataDirPath);
-    return downloadAndExtractFile(definitelyTypedZipUrl);
+    log.info(dataDirPath + " exists.");
+    return downloadAndExtractFile(definitelyTypedZipUrl, log);
   }
   const { error, stderr, stdout } = await exec("git diff --name-only", options.definitelyTypedPath);
   if (error) {


### PR DESCRIPTION
Download timeout is still 1000 seconds -- if node's documentation is trustworthy -- so I don't know what is actually hanging.

(It might be 1,000,000 seconds instead of 1,000,000 milliseconds though.)