### PR TITLE
Include `downshift` in allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -91,6 +91,7 @@ dexie
 dnd-core
 domhandler
 dotenv
+downshift
 egg
 electron
 electron-notarize


### PR DESCRIPTION
`downshift` includes its own typings: https://github.com/downshift-js/downshift/blob/master/typings/index.d.ts

This is required by this DT PR: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/48446