### PR TITLE
Include `unified` in allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -216,6 +216,7 @@ tweetnacl
 typeorm
 typescript
 typescript-tuple
+unified
 utility-types
 vega-typings
 vfile


### PR DESCRIPTION
I'd like to add some types for Remark plugins, but doing so without including these types seems flaky.