### PR TITLE
chore: Add bson to allowPackageJsonDependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -69,6 +69,7 @@ bignumber.js
 bookshelf
 boxen
 broadcast-channel
+bson
 cac
 cash-dom
 cassandra-driver


### PR DESCRIPTION
Hello!
The bson library now distributes it's own types as of version v4.2.0 and I'm submitting a deprecation but the mongodb types rely on the definitions so `bson` needs to be a permitted package dep.