### PR TITLE
Move empty OTHER_FILES.txt check from dt-mergebot

### DIFF
--- a/packages/definitions-parser/src/lib/definition-parser.ts
+++ b/packages/definitions-parser/src/lib/definition-parser.ts
@@ -270,14 +270,16 @@ function getTypingDataForSingleTypesVersion(
     packageDirectory
   );
   const usedFiles = new Set([...types.keys(), ...tests.keys(), "tsconfig.json", "tslint.json"]);
-  const otherFiles =
-    ls.indexOf(unusedFilesName) > -1
-      ? fs
-          // tslint:disable-next-line:non-literal-fs-path -- Not a reference to the fs package
-          .readFile(unusedFilesName)
-          .split(/\r?\n/g)
-          .filter(Boolean)
-      : [];
+  const otherFiles = ls.includes(unusedFilesName)
+    ? fs
+        // tslint:disable-next-line:non-literal-fs-path -- Not a reference to the fs package
+        .readFile(unusedFilesName)
+        .split(/\r?\n/g)
+        .filter(Boolean)
+    : [];
+  if (ls.includes(unusedFilesName) && !otherFiles.length) {
+    throw new Error(`In ${packageName}: OTHER_FILES.txt is empty.`);
+  }
   for (const file of otherFiles) {
     if (!isRelativePath(file)) {
       throw new Error(`In ${packageName}: A path segment is empty or all dots ${file}`);


### PR DESCRIPTION
Like #127, put [this check](https://github.com/DefinitelyTyped/dt-mergebot/blob/72404d3fb1af96cff27d8e781c03a84092ead1e9/src/pr-info.ts#L397) together with the others.