### PR TITLE
feat: allow bullmq for bull-arena types

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -70,6 +70,7 @@ bookshelf
 boxen
 broadcast-channel
 bson
+bullmq
 cac
 cash-dom
 cassandra-driver


### PR DESCRIPTION
For [DefinitelyTyped/pull/48886](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/48886), which references types from bullmq.