### PR TITLE
Add `helmet` to `allowedPackageJsonDependencies.txt`

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -29,6 +29,7 @@
 @types/base-x
 @types/expect
 @types/firebase
+@types/helmet
 @types/highcharts
 @types/hoist-non-react-statics
 @types/mkdirp-promise


### PR DESCRIPTION
`helmet` now bundles its types as of 4.0.0, but other package types rely on pre-4.0.0 versions of `helmet`, so `@types/helmet` needs to be added to this list.