### PR TITLE
Add @tweenjs/tween.js to allowedPackageJsonDependencies.txt

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -26,6 +26,7 @@
 @storybook/addons
 @storybook/react
 @testing-library/dom
+@tweenjs/tween.js
 @types/base-x
 @types/expect
 @types/firebase


### PR DESCRIPTION
Hi.

`@tween.js/tween.js` now distributes it's own types and I would to like to remove `@types/tween.js`, but `@types/aframe` depends on it https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49024/files#diff-5eda909de686a86eb94de143856c39400ee018575b1dbe36e247b48172696c94R4.

