### PR TITLE
Use libraryName homepage for not-needed stub

### DIFF
--- a/packages/definitions-parser/src/git.ts
+++ b/packages/definitions-parser/src/git.ts
@@ -129,11 +129,8 @@ export async function getAffectedPackagesFromDiff(
 
 /**
  * 1. libraryName must exist on npm (SKIPPED and preferably/optionally have been the libraryName in just-deleted header)
- * (SKIPPED 2.) sourceRepoURL must exist and be the npm homepage
- * 3. asOfVersion must be newer than `@types/name@latest` on npm
- * 4. `name@asOfVersion` must exist on npm
- *
- * I skipped (2) because the cached npm info doesn't include it. I might add it later.
+ * 2. asOfVersion must be newer than `@types/name@latest` on npm
+ * 3. `name@asOfVersion` must exist on npm
  */
 export function checkNotNeededPackage(
   unneeded: NotNeededPackage,

--- a/packages/definitions-parser/src/mocks.ts
+++ b/packages/definitions-parser/src/mocks.ts
@@ -9,14 +9,15 @@ class DTMock {
     this.root = new Dir(undefined);
     this.root.set(
       "notNeededPackages.json",
-      `{
-            "packages": [{
-            "libraryName": "Angular 2",
-            "typingsPackageName": "angular",
-            "asOfVersion": "1.2.3",
-            "sourceRepoURL": "https://github.com/angular/angular2"
-          }]
-        }`
+      JSON.stringify({
+        packages: [
+          {
+            libraryName: "Angular 2",
+            typingsPackageName: "angular",
+            asOfVersion: "1.2.3"
+          }
+        ]
+      })
     );
     this.fs = new InMemoryFS(this.root, "DefinitelyTyped");
   }

--- a/packages/definitions-parser/src/packages.ts
+++ b/packages/definitions-parser/src/packages.ts
@@ -202,7 +202,6 @@ export abstract class PackageBase {
   }
 
   abstract readonly isLatest: boolean;
-  abstract readonly projectName: string;
   abstract readonly declaredModules: readonly string[];
   abstract readonly globals: readonly string[];
   abstract readonly minTypeScriptVersion: TypeScriptVersion;
@@ -236,8 +235,6 @@ interface NotNeededPackageRaw extends BaseRaw {
    */
   // This must be "major.minor.patch"
   readonly asOfVersion: string;
-  /** The package's own url, *not* DefinitelyTyped's. */
-  readonly sourceRepoURL: string;
 }
 
 export class NotNeededPackage extends PackageBase {
@@ -247,18 +244,15 @@ export class NotNeededPackage extends PackageBase {
     return License.MIT;
   }
 
-  readonly sourceRepoURL: string;
-
   constructor(raw: NotNeededPackageRaw) {
     super(raw);
-    this.sourceRepoURL = raw.sourceRepoURL;
 
     for (const key of Object.keys(raw)) {
       if (!["libraryName", "typingsPackageName", "sourceRepoURL", "asOfVersion"].includes(key)) {
         throw new Error(`Unexpected key in not-needed package: ${key}`);
       }
     }
-    assert(raw.libraryName && raw.typingsPackageName && raw.sourceRepoURL && raw.asOfVersion);
+    assert(raw.libraryName && raw.typingsPackageName && raw.asOfVersion);
 
     this.version = Semver.parse(raw.asOfVersion);
   }
@@ -274,9 +268,6 @@ export class NotNeededPackage extends PackageBase {
   get isLatest(): boolean {
     return true;
   }
-  get projectName(): string {
-    return this.sourceRepoURL;
-  }
   get declaredModules(): readonly string[] {
     return [];
   }
@@ -285,11 +276,6 @@ export class NotNeededPackage extends PackageBase {
   }
   get minTypeScriptVersion(): TypeScriptVersion {
     return TypeScriptVersion.lowest;
-  }
-
-  readme(): string {
-    return `This is a stub types definition for ${getFullNpmName(this.name)} (${this.sourceRepoURL}).\n
-${this.libraryName} provides its own type definitions, so you don't need ${getFullNpmName(this.name)} installed!`;
   }
 
   deprecatedMessage(): string {

--- a/packages/definitions-parser/test/get-affected-packages.test.ts
+++ b/packages/definitions-parser/test/get-affected-packages.test.ts
@@ -19,8 +19,7 @@ const notNeeded = [
   new NotNeededPackage({
     typingsPackageName: "jest",
     libraryName: "jest",
-    asOfVersion: "100.0.0",
-    sourceRepoURL: "jest.com"
+    asOfVersion: "100.0.0"
   })
 ];
 const allPackages = AllPackages.from(typesData, notNeeded);

--- a/packages/definitions-parser/test/git.test.ts
+++ b/packages/definitions-parser/test/git.test.ts
@@ -16,8 +16,7 @@ const jestNotNeeded = [
   new NotNeededPackage({
     typingsPackageName: "jest",
     libraryName: "jest",
-    asOfVersion: "100.0.0",
-    sourceRepoURL: "jest.com"
+    asOfVersion: "100.0.0"
   })
 ];
 const allPackages = AllPackages.from(typesData, jestNotNeeded);
@@ -71,8 +70,7 @@ testo({
           new NotNeededPackage({
             typingsPackageName: "ember__object",
             libraryName: "@ember/object",
-            asOfVersion: "1.0.0",
-            sourceRepoURL: "ember.js"
+            asOfVersion: "1.0.0"
           })
         ]),
         [{ status: "D", file: "types/ember__object/index.d.ts" }]

--- a/packages/publisher/src/generate-packages.ts
+++ b/packages/publisher/src/generate-packages.ts
@@ -1,4 +1,5 @@
 import { makeTypesVersionsForPackageJson } from "@definitelytyped/header-parser";
+import assert = require("assert");
 import { emptyDir, mkdir, mkdirp, readFileSync } from "fs-extra";
 import * as path from "path";
 import * as yargs from "yargs";
@@ -124,8 +125,12 @@ async function generateNotNeededPackage(
   log: Logger
 ): Promise<void> {
   pkg = skipBadPublishes(pkg, client, log);
-  await writeCommonOutputs(pkg, createNotNeededPackageJSON(pkg, Registry.NPM), pkg.readme(), Registry.NPM);
-  await writeCommonOutputs(pkg, createNotNeededPackageJSON(pkg, Registry.Github), pkg.readme(), Registry.Github);
+  const info = await client.fetchAndCacheNpmInfo(pkg.libraryName);
+  assert(info);
+  const readme = `This is a stub types definition for ${getFullNpmName(pkg.name)} (${info.homepage}).\n
+${pkg.libraryName} provides its own type definitions, so you don't need ${getFullNpmName(pkg.name)} installed!`;
+  await writeCommonOutputs(pkg, createNotNeededPackageJSON(pkg, Registry.NPM), readme, Registry.NPM);
+  await writeCommonOutputs(pkg, createNotNeededPackageJSON(pkg, Registry.Github), readme, Registry.Github);
 }
 
 async function writeCommonOutputs(
@@ -230,7 +235,7 @@ function dependencySemver(dependency: DependencyVersion): string {
 }
 
 export function createNotNeededPackageJSON(
-  { libraryName, license, fullNpmName, sourceRepoURL, version }: NotNeededPackage,
+  { libraryName, license, fullNpmName, version }: NotNeededPackage,
   registry: Registry
 ): string {
   const out = {
@@ -241,7 +246,6 @@ export function createNotNeededPackageJSON(
     main: "",
     scripts: {},
     author: "",
-    repository: registry === Registry.NPM ? sourceRepoURL : "https://github.com/types/_definitelytypedmirror.git",
     license,
     // No `typings`, that's provided by the dependency.
     dependencies: {

--- a/packages/publisher/src/lib/npm.ts
+++ b/packages/publisher/src/lib/npm.ts
@@ -22,7 +22,6 @@ export function skipBadPublishes(pkg: NotNeededPackage, client: CachedNpmInfoCli
     return new NotNeededPackage({
       asOfVersion: plusOne.versionString,
       libraryName: pkg.libraryName,
-      sourceRepoURL: pkg.sourceRepoURL,
       typingsPackageName: pkg.name
     });
   }

--- a/packages/publisher/test/generate-packages.test.ts
+++ b/packages/publisher/test/generate-packages.test.ts
@@ -52,8 +52,7 @@ function createUnneededPackage() {
   return new NotNeededPackage({
     libraryName: "alternate",
     typingsPackageName: "absalom",
-    asOfVersion: "1.1.1",
-    sourceRepoURL: "https://github.com/aardwulf/absalom"
+    asOfVersion: "1.1.1"
   });
 }
 testo({
@@ -138,7 +137,6 @@ testo({
     "main": "",
     "scripts": {},
     "author": "",
-    "repository": "https://github.com/aardwulf/absalom",
     "license": "MIT",
     "dependencies": {
         "alternate": "*"
@@ -149,8 +147,7 @@ testo({
     const scopedUnneeded = new NotNeededPackage({
       libraryName: "@google-cloud/chubdub",
       typingsPackageName: "google-cloud__pubsub",
-      asOfVersion: "0.26.0",
-      sourceRepoURL: "https://github.com/googleapis/nodejs-storage"
+      asOfVersion: "0.26.0"
     });
     const s = createNotNeededPackageJSON(scopedUnneeded, Registry.NPM);
     expect(s).toEqual(`{
@@ -161,7 +158,6 @@ testo({
     "main": "",
     "scripts": {},
     "author": "",
-    "repository": "https://github.com/googleapis/nodejs-storage",
     "license": "MIT",
     "dependencies": {
         "@google-cloud/chubdub": "*"

--- a/packages/utils/src/npm.ts
+++ b/packages/utils/src/npm.ts
@@ -37,6 +37,7 @@ export interface NpmInfoRaw {
   readonly time: {
     readonly [s: string]: string;
   };
+  readonly homepage: string;
 }
 export interface NpmInfoRawVersions {
   readonly [version: string]: NpmInfoVersion;
@@ -47,6 +48,7 @@ export interface NpmInfo {
   readonly distTags: Map<string, string>;
   readonly versions: Map<string, NpmInfoVersion>;
   readonly time: Map<string, string>;
+  readonly homepage: string;
 }
 export interface NpmInfoVersion {
   readonly typesPublisherContentHash?: string;
@@ -229,6 +231,7 @@ export class NpmPublishClient {
 
 function npmInfoFromJson(n: NpmInfoRaw): NpmInfo {
   return {
+    ...n,
     distTags: recordToMap(n["dist-tags"], identity),
     // Callback ensures we remove any other properties
     versions: recordToMap(n.versions, ({ typesPublisherContentHash, deprecated }) => ({
@@ -241,6 +244,7 @@ function npmInfoFromJson(n: NpmInfoRaw): NpmInfo {
 
 function jsonFromNpmInfo(n: NpmInfo): NpmInfoRaw {
   return {
+    ...n,
     "dist-tags": mapToRecord(n.distTags),
     versions: mapToRecord(n.versions),
     time: mapToRecord(n.time)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1549,9 +1549,9 @@
   integrity sha512-PQKsydPxYxF1DsAFWmunaxd3sOi3iMt6Zmx/tgaagHYmwJ/9cRH91hQkeJZaUGWbvn0K5HlSVEXkn5U/llWPpQ==
 
 "@types/node@^12.12.29":
-  version "12.12.37"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.37.tgz#cb4782d847f801fa58316da5b4801ca3a59ae790"
-  integrity sha512-4mXKoDptrXAwZErQHrLzpe0FN/0Wmf5JRniSVIdwUrtDf9wnmEV1teCNLBo/TwuXhkK/bVegoEn/wmb+x0AuPg==
+  version "12.19.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.19.2.tgz#9565ed5c72ba96038fc3add643edd5e7820598e7"
+  integrity sha512-SRH6QM0IMOBBFmDiJ75vlhcbUEYEquvSuhsVW9ijG20JvdFTfOrB1p6ddZxz5y/JNnbf+9HoHhjhOVSX2hsJyA==
 
 "@types/node@^8.0.47":
   version "8.10.60"


### PR DESCRIPTION
Instead of tracking `sourceRepoURL` in `notNeededPackages.json` get it directly from the replacement npm package.

- Move `NotNeededPackage.readme` -> `generateNotNeededPackage()` unchanged except for the reference to `info.homepage` vs. `sourceRepoURL`
- Add `homepage` to `NpmInfo`
- Remove references to `sourceRepoURL`