### PR TITLE
[perf] Actually fix timeouts when many versions are changed

### DIFF
--- a/packages/perf/src/common/utils.ts
+++ b/packages/perf/src/common/utils.ts
@@ -195,3 +195,28 @@ export function findLast<T>(arr: T[], predicate: (element: T) => boolean): T | u
   }
   return;
 }
+
+export async function forEachWithTimeLimit<T>(
+  limitMs: number,
+  array: readonly T[],
+  inTimeAction: (item: T) => unknown,
+  outOfTimeAction: (item: T) => void
+) {
+  const startTime = Date.now();
+  let complete = true;
+  for (const item of array) {
+    if (Date.now() - startTime > limitMs) {
+      outOfTimeAction(item);
+      complete = false;
+    } else {
+      await inTimeAction(item);
+    }
+  }
+  const duration = Date.now() - startTime;
+  return {
+    startTime,
+    duration,
+    overtime: duration > limitMs,
+    complete
+  };
+}

--- a/packages/perf/src/github/postInitialComparisonResults.ts
+++ b/packages/perf/src/github/postInitialComparisonResults.ts
@@ -19,6 +19,7 @@ export async function postInitialComparisonResults({
   dependentCount,
   dryRun
 }: PostInitialComparisonResultsOptions) {
+  let message;
   if (dryRun) {
     return getFullFirstPostMessage(
       createTablesWithAnalysesMessage(comparisons, parseInt(process.env.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER || "")),
@@ -54,7 +55,7 @@ export async function postInitialComparisonResults({
           return;
         }
 
-        const message = getConciseUpdateMessage(
+        message = getConciseUpdateMessage(
           lastOverallChange,
           currentOverallChange,
           createTablesWithAnalysesMessage(
@@ -72,7 +73,7 @@ export async function postInitialComparisonResults({
           body: createPerfCommentBody(commentData, message)
         });
       } else {
-        const message = getFullFirstPostMessage(createTablesWithAnalysesMessage(comparisons, prNumber), dependentCount);
+        message = getFullFirstPostMessage(createTablesWithAnalysesMessage(comparisons, prNumber), dependentCount);
         await octokit.issues.createComment({
           ...config.github.commonParams,
           issue_number: prNumber,
@@ -85,7 +86,7 @@ export async function postInitialComparisonResults({
       throw err;
     }
   }
-  return;
+  return message;
 }
 
 function getFullFirstPostMessage(mainMessage: string, dependentCount: number): string {


### PR DESCRIPTION
We previously logged “Skipping react because we ran out of time,” but proceeded to benchmark react immediately afterward.