### PR TITLE
[definitions-parser] Fix deleting old versions of packages

### DIFF
--- a/packages/definitions-parser/src/packages.ts
+++ b/packages/definitions-parser/src/packages.ts
@@ -63,7 +63,7 @@ export class AllPackages {
 
   tryResolve(dep: PackageId): PackageId {
     const versions = this.data.get(getMangledNameForScopedPackage(dep.name));
-    return versions ? versions.get(dep.version).id : dep;
+    return (versions && versions.tryGet(dep.version)?.id) || dep;
   }
 
   /** Gets the latest version of a package. E.g. getLatest(node v6) was node v10 (before node v11 came out). */

--- a/packages/definitions-parser/test/get-affected-packages.test.ts
+++ b/packages/definitions-parser/test/get-affected-packages.test.ts
@@ -42,6 +42,10 @@ testo({
     expect(changedPackages.map(({ id }) => id)).toEqual([]);
     expect(dependentPackages.map(({ id }) => id)).toEqual([{ name: "unknown-test", version: { major: 1, minor: 0 } }]);
   },
+  deletedVersion() {
+    const { changedPackages } = getAffectedPackages(allPackages, [{ name: "jquery", version: { major: 0 } }]);
+    expect(changedPackages).toEqual([]);
+  },
   olderVersion() {
     const { changedPackages, dependentPackages } = getAffectedPackages(allPackages, [
       { name: "jquery", version: { major: 1 } }


### PR DESCRIPTION
Honestly, this `tryResolve` method seems extremely suspicious both before and after this change. It returns its input when resolution fails? I’m not sure I see the point. But, it seems to fix the bug, so the enigmatic `AllPackages` will live unscathed for another day, I suppose.

Fixes #118.