### PR TITLE
Improve error message when other package has a path mapping to a version you’re deleting

### DIFF
--- a/packages/definitions-parser/src/packages.ts
+++ b/packages/definitions-parser/src/packages.ts
@@ -122,7 +122,12 @@ export class AllPackages {
     for (const [name, version] of Object.entries(pkg.dependencies)) {
       const versions = this.data.get(getMangledNameForScopedPackage(name));
       if (versions) {
-        yield versions.get(version);
+        yield versions.get(
+          version,
+          pkg.pathMappings[name]
+            ? `${pkg.name} references this version of ${name} in its path mappings in tsconfig.json. If you are deleting this version, update ${pkg.name}’s path mappings accordingly.\n`
+            : undefined
+        );
       }
     }
 
@@ -487,8 +492,8 @@ export class TypingsVersions {
     return this.map.values();
   }
 
-  get(version: DependencyVersion): TypingsData {
-    return version === "*" ? this.getLatest() : this.getLatestMatch(version);
+  get(version: DependencyVersion, errorMessage?: string): TypingsData {
+    return version === "*" ? this.getLatest() : this.getLatestMatch(version, errorMessage);
   }
 
   tryGet(version: DependencyVersion): TypingsData | undefined {
@@ -499,10 +504,10 @@ export class TypingsVersions {
     return this.map.get(this.versions[0])!;
   }
 
-  private getLatestMatch(version: TypingVersion): TypingsData {
+  private getLatestMatch(version: TypingVersion, errorMessage?: string): TypingsData {
     const data = this.tryGetLatestMatch(version);
     if (!data) {
-      throw new Error(`Could not find version ${version.major}.${version.minor ?? "*"}`);
+      throw new Error(`Could not find version ${version.major}.${version.minor ?? "*"}. ${errorMessage || ""}`);
     }
     return data;
   }

--- a/packages/dtslint-runner/package.json
+++ b/packages/dtslint-runner/package.json
@@ -14,7 +14,8 @@
     "url": "git+https://github.com/microsoft/DefinitelyTyped-tools.git"
   },
   "scripts": {
-    "test": "echo \"Error: run tests from root\" && exit 1"
+    "test": "echo \"Error: run tests from root\" && exit 1",
+    "build": "tsc -b ."
   },
   "bugs": {
     "url": "https://github.com/microsoft/DefinitelyTyped-tools/issues"


### PR DESCRIPTION
Most of the changes here improves debugability of `runWithChildProcesses`, but the meaningful change is a follow up to #118 / #147.