### PR TITLE
[perf] Fix versions showing up as "*" all over the place

### DIFF
--- a/packages/definitions-parser/src/lib/definition-parser.ts
+++ b/packages/definitions-parser/src/lib/definition-parser.ts
@@ -154,6 +154,32 @@ export function parseVersionFromDirectoryName(directoryName: string | undefined)
   };
 }
 
+/**
+ * Like `parseVersionFromDirectoryName`, but the leading 'v' is optional,
+ * and falls back to '*' if the input format is not parseable.
+ */
+export function tryParsePackageVersion(versionString: string | undefined): DependencyVersion {
+  const match = /^v?(\d+)(\.(\d+))?$/.exec(versionString!);
+  if (match === null) {
+    return "*";
+  }
+  return {
+    major: Number(match[1]),
+    minor: match[3] !== undefined ? Number(match[3]) : undefined // tslint:disable-line strict-type-predicates (false positive)
+  };
+}
+
+/**
+ * Like `tryParsePackageVersion`, but throws if the input format is not parseable.
+ */
+export function parsePackageVersion(versionString: string): TypingVersion {
+  const version = tryParsePackageVersion(versionString);
+  if (version === "*") {
+    throw new Error(`Version string '${versionString}' is not a valid format.`);
+  }
+  return version;
+}
+
 async function combineDataForAllTypesVersions(
   typingsPackageName: string,
   ls: readonly string[],

--- a/packages/definitions-parser/src/parse-definitions.ts
+++ b/packages/definitions-parser/src/parse-definitions.ts
@@ -4,7 +4,7 @@ import { getTypingInfo } from "./lib/definition-parser";
 import { definitionParserWorkerFilename } from "./lib/definition-parser-worker";
 import { AllPackages, readNotNeededPackages, typesDataFilename, TypingsVersionsRaw } from "./packages";
 
-export { parseVersionFromDirectoryName } from "./lib/definition-parser";
+export { tryParsePackageVersion, parsePackageVersion } from "./lib/definition-parser";
 
 export interface ParallelOptions {
   readonly nProcesses: number;

--- a/packages/perf/src/cli/compare.ts
+++ b/packages/perf/src/cli/compare.ts
@@ -20,12 +20,7 @@ import { printSummary } from "../measure";
 import { getTypeScript } from "../measure/getTypeScript";
 import { postInitialComparisonResults } from "../github/postInitialComparisonResults";
 import { postDependentsComparisonResult } from "../github/postDependentsComparisonResults";
-import {
-  AllPackages,
-  getAffectedPackages,
-  PackageId,
-  parseVersionFromDirectoryName
-} from "@definitelytyped/definitions-parser";
+import { AllPackages, DependencyVersion, getAffectedPackages, PackageId } from "@definitelytyped/definitions-parser";
 import { execAndThrowErrors } from "@definitelytyped/utils";
 const currentSystem = getSystemInfo();
 
@@ -34,7 +29,7 @@ export interface CompareOptions {
   definitelyTypedPath: string;
   typeScriptVersionMajorMinor: string;
   packageName: string;
-  packageVersion: number;
+  packageVersion: DependencyVersion;
   maxRunSeconds?: number;
   upload?: boolean;
 }
@@ -79,7 +74,7 @@ export async function compare({
           definitelyTypedPath,
           typeScriptVersionMajorMinor: tsVersion,
           packageName: affectedPackage.id.name,
-          packageVersion: affectedPackage.major,
+          packageVersion: affectedPackage.id.version,
           maxRunSeconds,
           upload
         })
@@ -117,7 +112,7 @@ export async function compare({
           definitelyTypedPath,
           typeScriptVersionMajorMinor: tsVersion,
           packageName: affectedPackage.id.name,
-          packageVersion: affectedPackage.major,
+          packageVersion: affectedPackage.id.version,
           maxRunSeconds,
           upload
         })
@@ -154,7 +149,7 @@ export async function compareBenchmarks({
   let latestBenchmark: PackageBenchmarkSummary | undefined = latestBenchmarkDocument && latestBenchmarkDocument.body;
   const packageId: PackageId = {
     name: packageName,
-    version: parseVersionFromDirectoryName(packageVersion.toString()) || "*"
+    version: packageVersion
   };
 
   const changedPackagesBetweenLastRunAndMaster =

--- a/packages/perf/src/cli/getPackagesToBenchmark.ts
+++ b/packages/perf/src/cli/getPackagesToBenchmark.ts
@@ -41,7 +41,7 @@ export async function getPackagesToBenchmark({
       container,
       typeScriptVersionMajorMinor: tsVersion,
       packageName: typingsData.id.name,
-      packageVersion: formatDependencyVersion(typingsData.id.version)
+      packageVersion: typingsData.id.version
     });
 
     // No previous run exists; run one

--- a/packages/perf/src/common/utils.ts
+++ b/packages/perf/src/common/utils.ts
@@ -9,8 +9,9 @@ import {
   PackageId,
   gitChanges,
   formatDependencyVersion,
-  parseVersionFromDirectoryName,
-  TypingVersion
+  TypingVersion,
+  tryParsePackageVersion,
+  PackageIdWithDefiniteVersion
 } from "@definitelytyped/definitions-parser";
 
 export const pathExists = promisify(fs.exists);
@@ -130,21 +131,18 @@ export function createDocument<T>(body: T, version: number): Document<T> {
 
 export function parsePackageKey(key: string): PackageId {
   const [name, versionString] = key.split("/");
-  const version = parseVersionFromDirectoryName(versionString);
-  return {
-    name,
-    version: version || ("*" as const)
-  };
+  const version = tryParsePackageVersion(versionString);
+  return { name, version };
 }
 
 export function toPackageKey(name: string, version: string | TypingVersion): string;
-export function toPackageKey(packageId: PackageId): string;
-export function toPackageKey(packageIdOrName: string | PackageId, version?: string | TypingVersion) {
+export function toPackageKey(packageId: PackageIdWithDefiniteVersion): string;
+export function toPackageKey(packageIdOrName: string | PackageIdWithDefiniteVersion, version?: string | TypingVersion) {
   const packageId =
     typeof packageIdOrName === "string"
       ? {
           name: packageIdOrName,
-          version: (typeof version === "string" ? parseVersionFromDirectoryName(version) : version) || ("*" as const)
+          version: (typeof version === "string" ? tryParsePackageVersion(version) : version) || ("*" as const)
         }
       : packageIdOrName;
   return `${packageId.name}/${formatDependencyVersion(packageId.version)}`;

--- a/packages/perf/src/query/index.ts
+++ b/packages/perf/src/query/index.ts
@@ -1,10 +1,11 @@
 import { Container } from "@azure/cosmos";
+import { DependencyVersion, formatDependencyVersion } from "@definitelytyped/definitions-parser";
 import { config, PackageBenchmarkSummary, Document, QueryResult } from "../common";
 
 export interface GetLatestBenchmarkOptions {
   container: Container;
   packageName: string;
-  packageVersion: string | number;
+  packageVersion: DependencyVersion;
   typeScriptVersionMajorMinor: string;
 }
 
@@ -24,7 +25,7 @@ export async function getLatestBenchmark({
         `  ORDER BY b.createdAt DESC`,
       parameters: [
         { name: "@packageName", value: packageName },
-        { name: "@packageVersion", value: packageVersion.toString() },
+        { name: "@packageVersion", value: formatDependencyVersion(packageVersion) },
         { name: "@tsVersion", value: typeScriptVersionMajorMinor }
       ]
     })


### PR DESCRIPTION
I messed up a bunch of string <---> object version conversions in the perf bot code when trying to adapt to @alloy’s changes that allowed minor version typings directories. You can see a symptom of that mistake [here](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/48971#issuecomment-719085291), where both versions of react-dom that are tested are reported as `react-dom/*`. This fix allows `*` to still be used as a version _input_ on the CLI (e.g. `@definitelytyped/perf benchmark react-dom/*`), but should always resolve the `*` to the version number encoded in the header by the time it gets used as outputs (e.g. bot comments or database records).