### PR TITLE
Add highlight.js to allowedPackageJsonDependencies.txt

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -123,6 +123,7 @@ graphql-tools
 grpc
 handlebars
 helmet
+highlight.js
 hoist-non-react-statics
 hot-shots
 html-webpack-plugin


### PR DESCRIPTION
`highlight.js` has its own typings: https://github.com/highlightjs/highlight.js/blob/master/types/index.d.ts

This is required by this pull request: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49293

I'm participating in Hacktoberfest, so if you accept these changes please also label the PR as `hacktoberfest-accepted`! Thanks!