### PR TITLE
add ember-cli-htmlbars to allowedPackageJsonDependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -101,6 +101,7 @@ electron
 electron-notarize
 electron-osx-sign
 electron-store
+ember-cli-htmlbars
 ethers
 eventemitter2
 eventemitter3


### PR DESCRIPTION
[Updated definitions of `@ember/component`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49325) will depend on [types from `ember-cli-htmlbars`](https://github.com/ember-cli/ember-cli-htmlbars/blob/master/lib/index.d.ts).