### PR TITLE
Allow to use gapi.client.sheets as a dependency

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -114,6 +114,7 @@ final-form
 flatpickr
 form-data
 fs-jetpack
+gapi.client.sheets
 gl-matrix
 glaze
 globby


### PR DESCRIPTION
Requried for @types/gapi.client.sheets
See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49347 and https://github.com/DefinitelyTyped/DefinitelyTyped/issues/49235