### PR TITLE
Allow @maxim_mazurok/gapi.client.sheets in DT

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -114,7 +114,7 @@ final-form
 flatpickr
 form-data
 fs-jetpack
-gapi.client.sheets
+@maxim_mazurok/gapi.client.sheets
 gl-matrix
 glaze
 globby


### PR DESCRIPTION
Allow @maxim_mazurok/gapi.client.sheets in DT instead of gapi.client.sheets
Related to "A file cannot have a reference to itself." error in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49347