### PR TITLE
Add @types/highlight.js to allowedPackageJsonDependencies.txt

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -32,6 +32,7 @@
 @types/firebase
 @types/helmet
 @types/highcharts
+@types/highlight.js
 @types/hoist-non-react-statics
 @types/mkdirp-promise
 @types/next-redux-wrapper


### PR DESCRIPTION
Continuing with #151, the old version of `@types/highlight.js` is still in use by some dependencies and must be installed for their tests to pass.

This is required by this pull request: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49293