### PR TITLE
Allow tests to path-reference other tests

### DIFF
--- a/packages/definitions-parser/src/lib/module-info.ts
+++ b/packages/definitions-parser/src/lib/module-info.ts
@@ -387,7 +387,9 @@ export function getTestDependencies(
     let referencesSelf = false;
 
     for (const { fileName: ref } of referencedFiles) {
-      throw new Error(`Test files should not use '<reference path="" />'. '${filePath()}' references '${ref}'.`);
+      if (ref.endsWith(".d.ts")) {
+        throw new Error(`Test files should not use '<reference path="" />'. '${filePath()}' references '${ref}'.`);
+      }
     }
     for (const { fileName: referencedPackage } of typeReferenceDirectives) {
       if (dependencies.has(referencedPackage)) {


### PR DESCRIPTION
Allows tests to use `/// <reference path="ts1.0/mock-tests.ts" />` to reference older-`typesVersions` tests, while still forbidding them to path-reference published files.

`if (ref.endswith(".d.ts"))` comes from :point_down: where it already distinguishes files that will be published (types) from others (tests)
https://github.com/microsoft/DefinitelyTyped-tools/blob/1a1420912ee1ede0c9f4e191ed4ffdc4ea0fb1a7/packages/definitions-parser/src/lib/module-info.ts#L169-L173