### PR TITLE
Allow typesVersions-parent tests in tsconfig.json

### DIFF
--- a/packages/definitions-parser/src/lib/definition-parser.ts
+++ b/packages/definitions-parser/src/lib/definition-parser.ts
@@ -411,7 +411,7 @@ function checkFilesFromTsConfig(packageName: string, tsconfig: TsConfig, directo
     if (file.startsWith("./")) {
       throw new Error(`In ${tsconfigPath}: Unnecessary "./" at the start of ${file}`);
     }
-    if (!isRelativePath(file)) {
+    if (!isRelativePath(file.replace(/^(?:\.\.\/)+/, ""))) {
       throw new Error(`In ${tsconfigPath}: A path segment is empty or all dots ${file}`);
     }
     if (file.endsWith(".d.ts") && file !== "index.d.ts") {
@@ -419,7 +419,7 @@ function checkFilesFromTsConfig(packageName: string, tsconfig: TsConfig, directo
 Other d.ts files must either be referenced through index.d.ts, tests, or added to OTHER_FILES.txt.`);
     }
 
-    if (!file.endsWith(".d.ts") && !file.startsWith("test/")) {
+    if (!file.endsWith(".d.ts") && !file.startsWith("test/") && !file.startsWith("../")) {
       const expectedName = `${packageName}-tests.ts`;
       if (file !== expectedName && file !== `${expectedName}x`) {
         const message =

--- a/packages/definitions-parser/test/definition-parser.test.ts
+++ b/packages/definitions-parser/test/definition-parser.test.ts
@@ -1,3 +1,4 @@
+import { Dir, InMemoryFS } from "@definitelytyped/utils";
 import { createMockDT } from "../src/mocks";
 import { getTypingInfo } from "../src/lib/definition-parser";
 
@@ -108,5 +109,26 @@ describe(getTypingInfo, () => {
   it("allows wildcard scope path mappings", () => {
     const dt = createMockDT();
     return expect(getTypingInfo("wordpress__plugins", dt.pkgFS("wordpress__plugins"))).resolves.toBeDefined();
+  });
+
+  it("allows typesVersions-parent tests in tsconfig.json", () => {
+    const pkg = new Dir(undefined);
+    pkg.set(
+      "index.d.ts",
+      `// Type definitions for mock
+// Project: https://github.com/baz/foo
+// Definitions by: My Self <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+`
+    );
+    pkg.set(
+      "tsconfig.json",
+      JSON.stringify({
+        compilerOptions: {},
+        files: ["index.d.ts", "../mock-tests.ts"]
+      })
+    );
+    const memFS = new InMemoryFS(pkg, "types/ts1.0/mock");
+    return expect(getTypingInfo("mock", memFS)).resolves.toBeDefined();
   });
 });


### PR DESCRIPTION
Allows e.g. listing `../mock-tests.ts` in `types/mock/ts1.0/tsconfig.json`, so you can run the same tests on newer and older `typesVersions`.