### PR TITLE
feat: adding elastic-apm-node to allowedPackageJsonDependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -98,6 +98,7 @@ domhandler
 dotenv
 downshift
 egg
+elastic-apm-node
 electron
 electron-notarize
 electron-osx-sign


### PR DESCRIPTION
Adding `elastic-apm-node` to allowedPackageJsonDependencies.txt

it's needed for this PR https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49455