### PR TITLE
Don't show the difference in mean CV

### DIFF
--- a/packages/perf/src/analysis/metrics.ts
+++ b/packages/perf/src/analysis/metrics.ts
@@ -251,7 +251,7 @@ export const metrics: { [K in MetricName]: Metric } = {
     sentenceName: "mean coefficient of variation of samples measured for quick info time",
     getValue: x => x.body.quickInfo.meanCoefficientOfVariation,
     getSignificance: getInsignificant,
-    formatOptions: { percentage: true }
+    formatOptions: { percentage: true, noDiff: true }
   },
   quickInfoWorstMean: {
     columnName: "Worst duration (ms)",


### PR DESCRIPTION
Add `noDiff` to `quickInfoAvgCV`, like `completionsAvgCV`.

Fixes #166