### PR TITLE
Add @types/leaflet to allowedPackageJsonDependencies.txt

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -34,6 +34,7 @@
 @types/highcharts
 @types/highlight.js
 @types/hoist-non-react-statics
+@types/leaflet
 @types/mkdirp-promise
 @types/next-redux-wrapper
 @types/ink


### PR DESCRIPTION
@types/iitc requires old @types/leaflet v0.7

to fix https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49423/commits/e4770b38eee3a5a54f5849b6bc72ac604dffdcb4