### PR TITLE
Remove dependency from deprecated packages

### DIFF
--- a/packages/publisher/src/generate-packages.ts
+++ b/packages/publisher/src/generate-packages.ts
@@ -242,7 +242,7 @@ export function createNotNeededPackageJSON(
     scripts: {},
     author: "",
     repository: registry === Registry.NPM ? sourceRepoURL : "https://github.com/types/_definitelytypedmirror.git",
-    license,
+    license
   };
   if (registry === Registry.Github) {
     (out as any).publishConfig = { registry: "https://npm.pkg.github.com/" };

--- a/packages/publisher/src/generate-packages.ts
+++ b/packages/publisher/src/generate-packages.ts
@@ -243,10 +243,6 @@ export function createNotNeededPackageJSON(
     author: "",
     repository: registry === Registry.NPM ? sourceRepoURL : "https://github.com/types/_definitelytypedmirror.git",
     license,
-    // No `typings`, that's provided by the dependency.
-    dependencies: {
-      [libraryName]: "*"
-    }
   };
   if (registry === Registry.Github) {
     (out as any).publishConfig = { registry: "https://npm.pkg.github.com/" };

--- a/packages/publisher/test/generate-packages.test.ts
+++ b/packages/publisher/test/generate-packages.test.ts
@@ -139,10 +139,7 @@ testo({
     "scripts": {},
     "author": "",
     "repository": "https://github.com/aardwulf/absalom",
-    "license": "MIT",
-    "dependencies": {
-        "alternate": "*"
-    }
+    "license": "MIT"
 }`);
   },
   scopedNotNeededPackageJson() {
@@ -162,10 +159,7 @@ testo({
     "scripts": {},
     "author": "",
     "repository": "https://github.com/googleapis/nodejs-storage",
-    "license": "MIT",
-    "dependencies": {
-        "@google-cloud/chubdub": "*"
-    }
+    "license": "MIT"
 }`);
   },
   githubNotNeededPackageJson() {


### PR DESCRIPTION
1. This is only useful if you install `@types/X` but forget to install `X`, which is unlikely.
2. If you already have `X`, it does nothing.
3. A `"*"` dependency in `@types/X` apparently prevents unpublishing `X`.