### PR TITLE
Add tapable as an allowed dependency

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -414,6 +414,7 @@ source-map
 styled-components
 sw-toolbox
 swagger-parser
+tapable
 terser
 three
 treat


### PR DESCRIPTION
Adding tapable as an allowed package for use inside of `@types/webpack`.

For use in DefinitelyTyped/DefinitelyTyped#49749