### PR TITLE
Add @types/webpack as an allowed dependency

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -239,6 +239,7 @@
 @types/rsmq
 @types/vue
 @types/webdriverio
+@types/webpack
 @types/winston
 @types/wonder-commonlib
 @types/wonder-frp


### PR DESCRIPTION
https://github.com/DefinitelyTyped/DefinitelyTyped/issues/49757

To help facilitate the removal of @types/webpack for pre-5.0.0 and use the internal typings of webpack 5+