### PR TITLE
Add tasker-types to allowedPackageJsonDependencies.txt

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -421,6 +421,7 @@ styled-components
 sw-toolbox
 swagger-parser
 tapable
+tasker-types
 terser
 three
 treat


### PR DESCRIPTION
Hello! I'm new with Typescript and new in defining types for it, so please tell me if I'm doing something wrong.

I'm going to create the definition types for the following Javascript library: https://github.com/amoshydra/tasker-js-runner, but for that I need the types of another library: https://github.com/Rayquaza01/tasker-types. So, it would be really helpful if "tasker-types"'s library is added to the repository. 

Thank you in advance ;)