### PR TITLE
Add pg-types to list of allowed package dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -375,6 +375,7 @@ opentracing
 parchment
 parse5
 path-to-regexp
+pg-types
 pkcs11js
 popper.js
 postcss


### PR DESCRIPTION
`pg-types` has had bundled TypeScript type definitions for a while now: https://github.com/brianc/node-pg-types/pull/83

I have a PR up to remove `@types/pg-types` up here: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49567
`pg` uses `pg-types` and therefore obviously needs its type definitions.