### PR TITLE
Add @types/express-serve-static-core to allowed

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -226,6 +226,7 @@
 @tweenjs/tween.js
 @types/base-x
 @types/expect
+@types/express-serve-static-core
 @types/firebase
 @types/helmet
 @types/highcharts


### PR DESCRIPTION
Adds `@types/express-serve-static-core` to `allowedPackageJsonDependencies.txt`.

Required for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/50554.

`@types/express@4.17.10` requires `@types/express-serve-static-core@^4.17.18`.
All versions before `4.17.18` break typing.