### PR TITLE
Add joi to allowed

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -345,6 +345,7 @@ jest-environment-jsdom
 jest-mock
 jest-snapshot
 jimp
+joi
 jointjs
 jose
 jsonata


### PR DESCRIPTION
Need it to remove `joi` from DefinitelyTyped without breaking the packages that depend on it

[**`joi/lib/index.d.ts`**](https://github.com/sideway/joi/blob/master/lib/index.d.ts)