### PR TITLE
Add manual timeout to downloadAndExtractFile

### DIFF
--- a/packages/utils/src/io.ts
+++ b/packages/utils/src/io.ts
@@ -177,6 +177,10 @@ const connectionTimeout = 800_000; // ms
 export function downloadAndExtractFile(url: string, log: LoggerWithErrors): Promise<FS> {
   return new Promise<FS>((resolve, reject) => {
     const timeout = setTimeout(reject, downloadTimeout);
+    function rejectAndClearTimeout(reason?: any) {
+      clearTimeout(timeout);
+      return reject(reason);
+    };
     const root = new Dir(undefined);
     function insertFile(path: string, content: string): void {
       const components = path.split("/");
@@ -192,8 +196,7 @@ export function downloadAndExtractFile(url: string, log: LoggerWithErrors): Prom
     https
       .get(url, { timeout: connectionTimeout }, response => {
         if (response.statusCode !== 200) {
-          clearTimeout(timeout);
-          return reject(new Error(`DefinitelyTyped download failed with status code ${response.statusCode}`));
+          return rejectAndClearTimeout(new Error(`DefinitelyTyped download failed with status code ${response.statusCode}`));
         }
 
         log.info("Getting " + url);
@@ -211,7 +214,7 @@ export function downloadAndExtractFile(url: string, log: LoggerWithErrors): Prom
                   insertFile(name, s);
                   next();
                 })
-                .catch(reject);
+                .catch(rejectAndClearTimeout);
               break;
             case "directory":
               next();
@@ -220,7 +223,7 @@ export function downloadAndExtractFile(url: string, log: LoggerWithErrors): Prom
               throw new Error(`Unexpected file system entry kind ${header.type}`);
           }
         });
-        extract.on("error", reject);
+        extract.on("error", rejectAndClearTimeout);
         extract.on("finish", () => {
           log.info("Done receiving " + url);
           clearTimeout(timeout);
@@ -229,7 +232,7 @@ export function downloadAndExtractFile(url: string, log: LoggerWithErrors): Prom
 
         response.pipe(zlib.createGunzip()).pipe(extract);
       })
-      .on("error", reject);
+      .on("error", rejectAndClearTimeout);
   });
 }
 


### PR DESCRIPTION
Open question:
I'm not sure whether to add a clearTimeout call to `on("error", reject)` -- right now I only put them in things that resemble normal returns.