### PR TITLE
Add arweave to allowed package.json dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -263,6 +263,7 @@ aphrodite
 apollo-client
 apollo-link
 apollo-link-http-common
+arweave
 ast-types
 async-done
 autoprefixer


### PR DESCRIPTION
The `arweave` package's type definitions are needed in `@types` packages, at [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)

Primarly requesting for [#51035](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51035) in [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)