### PR TITLE
Add redux-logic as an allowed dependency

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -409,6 +409,7 @@ react-native-svg
 react-navigation
 recast
 redux
+redux-logic
 redux-observable
 redux-persist
 redux-saga


### PR DESCRIPTION
This is to enable `redux-logic-test` types to be added in this PR https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51057