### PR TITLE
Add timeout to https.request.

### DIFF
--- a/packages/utils/src/io.ts
+++ b/packages/utils/src/io.ts
@@ -100,6 +100,7 @@ export interface FetchOptions {
   readonly path: string;
   readonly retries?: boolean | number;
   readonly body?: string;
+  readonly timeout?: number;
   readonly method?: "GET" | "PATCH" | "POST";
   readonly headers?: {};
 }
@@ -146,7 +147,8 @@ function doRequest(options: FetchOptions, makeRequest: typeof request, agent?: A
         path: `/${options.path}`,
         agent,
         method: options.method || "GET",
-        headers: options.headers
+        headers: options.headers,
+        timeout: options.timeout ?? downloadTimeout
       },
       res => {
         let text = "";

--- a/packages/utils/src/io.ts
+++ b/packages/utils/src/io.ts
@@ -94,15 +94,9 @@ export function streamDone(stream: NodeJS.WritableStream): Promise<void> {
   });
 }
 
-export interface FetchOptions {
-  readonly hostname: string;
-  readonly port?: number;
-  readonly path: string;
+type FetchOptions = https.RequestOptions & {
   readonly retries?: boolean | number;
   readonly body?: string;
-  readonly timeout?: number;
-  readonly method?: "GET" | "PATCH" | "POST";
-  readonly headers?: {};
 }
 export class Fetcher {
   private readonly agent = new Agent({ keepAlive: true });


### PR DESCRIPTION
I haven't looked at the source, but Stack Overflow claims there is no timeout by default.