### PR TITLE
Fix old and same newer pkg require different TS

### DIFF
--- a/packages/definitions-parser/src/check-parse-results.ts
+++ b/packages/definitions-parser/src/check-parse-results.ts
@@ -72,7 +72,7 @@ export async function checkParseResults(
 function checkTypeScriptVersions(allPackages: AllPackages): void {
   for (const pkg of allPackages.allTypings()) {
     for (const dep of allPackages.allDependencyTypings(pkg)) {
-      if (dep.minTypeScriptVersion > pkg.minTypeScriptVersion) {
+      if (dep.minTypeScriptVersion > pkg.minTypeScriptVersion && dep.name !== pkg.name) {
         throw new Error(`${pkg.desc} depends on ${dep.desc} but has a lower required TypeScript version.`);
       }
     }


### PR DESCRIPTION
The `checkTypeScriptVersions` fails on an older package that depends on
a lower TS version than its latest version.

e.g. `@ckeditor/ckeditor-engine` depends on TS 3.6 and
`@ckeditor/ckeditor-engine/v11` depends on TS 2.3.

Without this fix, parser complains that v11 depends on a package that
has a more recent TS version as dependency.

One could argue that we could just drop the `// TypeScript Version` from
the older package, but it may occur that the older version requires
`LTS+1` and latest requires `LTS+2`.