### PR TITLE
Added @jest/reporters to allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -18,6 +18,7 @@
 @jest/environment
 @jest/fake-timers
 @jest/globals
+@jest/reporters
 @jest/transform
 @jest/types
 @loadable/component


### PR DESCRIPTION
Adds `@jest/reporters` to the dependencies list.

Required for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51600.