### PR TITLE
Add @jest/test-result to allowedPackageJsonDependencies.txt

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -19,6 +19,7 @@
 @jest/fake-timers
 @jest/globals
 @jest/reporters
+@jest/test-result
 @jest/transform
 @jest/types
 @loadable/component


### PR DESCRIPTION
Adds `@jest/reporters` to the dependencies list.

Required for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51600.