### PR TITLE
Fix path mapping not created for older scoped packages

### DIFF
--- a/packages/definitions-parser/src/lib/definition-parser.ts
+++ b/packages/definitions-parser/src/lib/definition-parser.ts
@@ -24,7 +24,9 @@ import {
   flatMap,
   unique,
   unmangleScopedPackage,
-  removeVersionFromPackageName
+  removeVersionFromPackageName,
+  hasVersionNumberInMapping,
+  mangleScopedPackage
 } from "@definitelytyped/utils";
 import { TypeScriptVersion } from "@definitelytyped/typescript-versions";
 
@@ -473,7 +475,9 @@ function calculateDependencies(
       if (dependencyName !== scopedPackageName) {
         throw new Error(`Expected directory ${pathMapping} to be the path mapping for ${dependencyName}`);
       }
-      continue;
+      if (!hasVersionNumberInMapping(pathMapping)) {
+        continue;
+      }
     }
 
     // Might have a path mapping for "foo/*" to support subdirectories
@@ -568,7 +572,7 @@ function parseDependencyVersionFromPath(
   dependencyName: string,
   dependencyPath: string
 ): TypingVersion {
-  const versionString = withoutStart(dependencyPath, `${dependencyName}/`);
+  const versionString = withoutStart(dependencyPath, `${mangleScopedPackage(dependencyName)}/`);
   const version = versionString === undefined ? undefined : parseVersionFromDirectoryName(versionString);
   if (version === undefined) {
     throw new Error(`In ${packageName}, unexpected path mapping for ${dependencyName}: '${dependencyPath}'`);

--- a/packages/definitions-parser/test/definition-parser.test.ts
+++ b/packages/definitions-parser/test/definition-parser.test.ts
@@ -113,6 +113,43 @@ export function myFunction(arg:string): string;
       });
     });
 
+    it("records a path mapping to the scoped version directory", async () => {
+		const dt = createMockDT();
+		const pkg = dt.pkgDir("ckeditor__ckeditor5-utils");
+		pkg.set(
+			"tsconfig.json",
+			JSON.stringify({
+				files: ["index.d.ts"],
+				compilerOptions: {
+					paths: {
+					}
+				}
+			})
+		);
+		pkg.set(
+			"index.d.ts",
+			`// Type definitions for @ckeditor/ckeditor-utils 25.0
+// Project: https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-engine
+// Definitions by: Federico <https://github.com/fedemp>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+`);
+
+		dt.addOldVersionOfPackage("@ckeditor/ckeditor5-utils", "10");
+
+    const info = await getTypingInfo("@ckeditor/ckeditor5-utils", dt.pkgFS("ckeditor__ckeditor5-utils"));
+      expect(info).toEqual({
+        "10.0": expect.objectContaining({
+          pathMappings: {
+            "@ckeditor/ckeditor5-utils": { major: 10 }
+          }
+        }),
+        "25.0": expect.objectContaining({
+          // The latest version does not have path mappings of its own
+          pathMappings: {}
+        })
+      });
+    });
+
     describe("validation thereof", () => {
       it("throws if a directory exists for the latest major version", () => {
         const dt = createMockDT();

--- a/packages/utils/src/miscellany.ts
+++ b/packages/utils/src/miscellany.ts
@@ -43,6 +43,10 @@ export function removeVersionFromPackageName(packageName: string | undefined): s
   return packageName?.replace(/\/v(\d){1,}$/i, "");
 }
 
+export function hasVersionNumberInMapping(packageName: string): boolean {
+  return /\/v\d+$/.test(packageName);
+}
+
 export async function sleep(seconds: number): Promise<void> {
   return new Promise<void>(resolve => setTimeout(resolve, seconds * 1000));
 }


### PR DESCRIPTION
Suppose we have a package called `@ckeditor/ckeditor5-utils` that has an older version `v10`.

The `tsconfig.json` file for the older version must include a path mapping to itself.''

```json
// tsconfig in v10
"paths": {
    "@ckeditor/ckeditor5-utils": ["ckeditor__ckeditor5-utils/v10"]
},
```

Currently `definition-parser` ignores any scoped package and does not try to create a path mapping for those.

