### PR TITLE
Add dayjs to allowedPackageJsonDependencies.txt

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -296,6 +296,7 @@ cropperjs
 csstype
 cypress
 date-fns
+dayjs
 decimal.js
 del
 dexie


### PR DESCRIPTION
Adds dayjs to the dependencies list.

Required for DefinitelyTyped/DefinitelyTyped#51728.