### PR TITLE
Improve process logging + expectedFailures addition

### DIFF
--- a/packages/dtslint-runner/expectedFailures.txt
+++ b/packages/dtslint-runner/expectedFailures.txt
@@ -2,3 +2,5 @@ electron-clipboard-extended
 electron-json-storage
 electron-notifications
 electron-notify
+mithril
+mithril-global

--- a/packages/utils/src/process.ts
+++ b/packages/utils/src/process.ts
@@ -74,7 +74,7 @@ export function runWithChildProcesses<In>({
       });
       child.on("disconnect", () => {
         if (outputsLeft !== 0) {
-            fail(new Error(`disconnect with ${outputsLeft} outputs left`));
+          fail(new Error(`disconnect with ${outputsLeft} outputs left`));
         }
       });
       child.on("close", () => {
@@ -83,7 +83,7 @@ export function runWithChildProcesses<In>({
       child.on("error", fail);
     }
 
-      function fail(e: Error): void {
+    function fail(e: Error): void {
       rejected = true;
       for (const child of allChildren) {
         child.kill();

--- a/packages/utils/src/process.ts
+++ b/packages/utils/src/process.ts
@@ -74,7 +74,7 @@ export function runWithChildProcesses<In>({
       });
       child.on("disconnect", () => {
         if (outputsLeft !== 0) {
-          fail();
+            fail(new Error(`disconnect with ${outputsLeft} outputs left`));
         }
       });
       child.on("close", () => {
@@ -83,12 +83,12 @@ export function runWithChildProcesses<In>({
       child.on("error", fail);
     }
 
-    function fail(): void {
+      function fail(e: Error): void {
       rejected = true;
       for (const child of allChildren) {
         child.kill();
       }
-      reject(new Error("Parsing failed."));
+      reject(e);
     }
   });
 }


### PR DESCRIPTION
1. Improve the error message in runWithChildProcesses to pass through the failure reason.
2. Add mithril and mithril-global to expectedFailures, since I haven't found a satisfactory way to make them pass on 4.3 in my two attempts at DefinitelyTyped/DefinitelyTyped#51482 and DefinitelyTyped/DefinitelyTyped#51765.