### PR TITLE
Do not spread processed notneededpackage into raw one

### DIFF
--- a/packages/publisher/src/lib/npm.ts
+++ b/packages/publisher/src/lib/npm.ts
@@ -20,7 +20,7 @@ export function skipBadPublishes(pkg: NotNeededPackage, client: CachedNpmInfoCli
     const plusOne = new Semver(latest.major, latest.minor, latest.patch + 1);
     log(`Deprecation of ${notNeeded.versionString} failed, instead using ${plusOne.versionString}.`);
     return new NotNeededPackage(pkg.name, {
-      ...pkg,
+      libraryName: pkg.libraryName,
       asOfVersion: plusOne.versionString
     });
   }


### PR DESCRIPTION
The compiler is fine with it, but the constructor expects strict compatibility, not subtype compatibility.

The real fix is not to use constructors, not to assert strict compatibility, and not to use classes at all. I'll look at this after the publisher is working again.