### PR TITLE
Allow ./node_modules passthrough in paths

### DIFF
--- a/packages/definitions-parser/src/lib/definition-parser.ts
+++ b/packages/definitions-parser/src/lib/definition-parser.ts
@@ -469,7 +469,7 @@ function calculateDependencies(
       throw new Error(`In ${packageName}: Path mapping for ${dependencyName} may only have 1 entry.`);
     }
     const pathMapping = pathMappingList[0];
-    if (dependencyName == scopedPackageName && pathMapping === "./node_modules/" + scopedPackageName) {
+    if (dependencyName === scopedPackageName && pathMapping === "./node_modules/" + scopedPackageName) {
       continue;
     }
 

--- a/packages/definitions-parser/src/lib/definition-parser.ts
+++ b/packages/definitions-parser/src/lib/definition-parser.ts
@@ -462,17 +462,21 @@ function calculateDependencies(
   const dependencies: { [name: string]: DependencyVersion } = {};
   const pathMappings: { [packageName: string]: TypingVersion } = {};
 
+  const scopedPackageName = unmangleScopedPackage(packageName) ?? packageName;
   for (const dependencyName of Object.keys(paths)) {
     const pathMappingList = paths[dependencyName];
     if (pathMappingList.length !== 1) {
       throw new Error(`In ${packageName}: Path mapping for ${dependencyName} may only have 1 entry.`);
     }
     const pathMapping = pathMappingList[0];
+    if (dependencyName == scopedPackageName && pathMapping === "./node_modules/" + scopedPackageName) {
+      continue;
+    }
 
     // Path mapping may be for "@foo/*" -> "foo__*".
-    const scopedPackageName = removeVersionFromPackageName(unmangleScopedPackage(pathMapping));
-    if (scopedPackageName !== undefined) {
-      if (dependencyName !== scopedPackageName) {
+    const unversionedScopedPackageName = removeVersionFromPackageName(unmangleScopedPackage(pathMapping));
+    if (unversionedScopedPackageName !== undefined) {
+      if (dependencyName !== unversionedScopedPackageName) {
         throw new Error(`Expected directory ${pathMapping} to be the path mapping for ${dependencyName}`);
       }
       if (!hasVersionNumberInMapping(pathMapping)) {
@@ -509,7 +513,6 @@ function calculateDependencies(
     pathMappings[dependencyName] = pathMappingVersion;
   }
 
-  const scopedPackageName = unmangleScopedPackage(packageName) ?? packageName;
   if (directoryVersion !== undefined && !(paths && scopedPackageName in paths)) {
     const mapping = JSON.stringify([`${packageName}/v${formatTypingVersion(directoryVersion)}`]);
     throw new Error(

--- a/packages/definitions-parser/test/definition-parser.test.ts
+++ b/packages/definitions-parser/test/definition-parser.test.ts
@@ -68,6 +68,75 @@ export function myFunction(arg:string): string;
     expect(info).toBeDefined();
   });
 
+  it("allows path mapping to older versions", () => {
+    // Actually, the default seup already has 'has-older-test-dependency', so probably doesn't need an explicit test
+    const dt = createMockDT();
+    dt.addOldVersionOfPackage("jquery", "1.42");
+    dt.addOldVersionOfPackage("jquery", "2");
+    // now add a dependency that maps to jquery/1.42
+  });
+  it("errors on arbitrary path mapping", () => {});
+  it("supports node_modules passthrough path mapping", async () => {
+    const dt = createMockDT();
+    const webpack = dt.pkgDir("webpack");
+    webpack.set(
+      "index.d.ts",
+      `// Type definitions for webpack 5.2
+// Project: https://github.com/webpack/webpack
+// Definitions by: Qubo <https://github.com/tkqubo>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+/* tslint:disable-next-line:no-self-import */
+import webpack = require('webpack');
+export = webpack;
+`
+    );
+    webpack.set(
+      "webpack-tests.ts",
+      `
+import webpack = require('webpack');
+const a = new webpack.AutomaticPrefetchPlugin();
+`
+    );
+    webpack.set(
+      "tsconfig.json",
+      `{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "target": "es6",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "paths": {
+            "webpack": [
+                "./node_modules/webpack"
+            ]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "webpack-tests.ts"
+    ]
+}`
+    );
+
+    const info = await getTypingInfo("webpack", dt.pkgFS("webpack"));
+    expect(info).toBeDefined();
+  });
+
   describe("concerning multiple versions", () => {
     it("records what the version directory looks like on disk", async () => {
       const dt = createMockDT();


### PR DESCRIPTION
I introduced a node_modules passthrough in webpack in DefinitelyTyped/DefinitelyTyped#51712: the entire index.d.ts is

```ts
import webpack = require('./node_modules/webpack')
export = webpack
```

This allows @types/webpack@5 to delegate its entire type definition to webpack@5, while still allowing @types/webpack@4 to be maintained on DT.

However, the correct module specifier is actually just 'webpack', since there's no guarantee of the exact location where webpack will be installed. This can be made to compile on DT with a path mapping:

```json
"paths": {
    "webpack": [
        "./node_modules/webpack"
    ]
}
```

Previously, path mappings like this were not allowed. This PR allows them, of the form `packageName: ["./node_modules/" + packageName]`.