### PR TITLE
Allow passthrough anywhere.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@types/jest": "^25.1.3",
-    "@types/node": "^14.14.35",
+    "@types/node": "^14.14.37",
     "@types/yargs": "^15.0.4",
     "@typescript-eslint/eslint-plugin": "^4.8.1",
     "@typescript-eslint/parser": "^4.8.1",

--- a/packages/definitions-parser/src/lib/definition-parser.ts
+++ b/packages/definitions-parser/src/lib/definition-parser.ts
@@ -469,7 +469,9 @@ function calculateDependencies(
       throw new Error(`In ${packageName}: Path mapping for ${dependencyName} may only have 1 entry.`);
     }
     const pathMapping = pathMappingList[0];
-    if (dependencyName === scopedPackageName && pathMapping === "./node_modules/" + scopedPackageName) {
+    if (pathMapping === "./node_modules/" + dependencyName) {
+      // allow passthrough remappings for packages like webpack that have shipped their own types,
+      // but have some dependents on DT that depend on the new types and some that depend on the old types
       continue;
     }
 

--- a/packages/definitions-parser/test/definition-parser.test.ts
+++ b/packages/definitions-parser/test/definition-parser.test.ts
@@ -120,6 +120,9 @@ const a = new webpack.AutomaticPrefetchPlugin();
         "paths": {
             "webpack": [
                 "./node_modules/webpack"
+            ],
+            "tapable": [
+                "./node_modules/tapable"
             ]
         },
         "types": [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1600,6 +1600,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.35.tgz#42c953a4e2b18ab931f72477e7012172f4ffa313"
   integrity sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==
 
+"@types/node@^14.14.37":
+  version "14.14.37"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.37.tgz#a3dd8da4eb84a996c36e331df98d82abd76b516e"
+  integrity sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==
+
 "@types/node@^8.0.47":
   version "8.10.60"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.60.tgz#73eb4d1e1c8aa5dc724363b57db019cf28863ef7"


### PR DESCRIPTION
Turns out that passthroughs need to be allowed anywhere.

Since you can only add passthroughs to `./node_modules`, you can only add passthroughs to things in package.json, which means that that file remains the security bottleneck.