### PR TITLE
Fix: Allow /* in scoped versioned mappings.

### DIFF
--- a/packages/definitions-parser/src/lib/definition-parser.ts
+++ b/packages/definitions-parser/src/lib/definition-parser.ts
@@ -336,12 +336,13 @@ function getTypingDataForSingleTypesVersion(
   );
 
   const { paths } = tsconfig.compilerOptions;
-  if (directoryVersion && hasNonRelativeImports && !(paths && `${packageName}/*` in paths)) {
+  const hydratedPackageName = unmangleScopedPackage(packageName) ?? packageName;
+  if (directoryVersion && hasNonRelativeImports && !(paths && `${hydratedPackageName}/*` in paths)) {
     const mapping = JSON.stringify([`${packageName}/v${formatTypingVersion(directoryVersion)}/*`]);
     throw new Error(
-      `${packageName}: Older version ${formatTypingVersion(
+      `${hydratedPackageName}: Older version ${formatTypingVersion(
         directoryVersion
-      )} must have a "paths" entry of "${packageName}/*": ${mapping}`
+      )} must have a "paths" entry of "${hydratedPackageName}/*": ${mapping}`
     );
   }
 

--- a/packages/definitions-parser/test/definition-parser.test.ts
+++ b/packages/definitions-parser/test/definition-parser.test.ts
@@ -24,7 +24,7 @@ describe(getTypingInfo, () => {
       "index.d.ts",
       `// Type definitions for @ckeditor/ckeditor-engine 25.0
 // Project: https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-engine
-// Definitions by: Federico <https://github.com/fedemp>
+// Definitions by: My Self <https://github.com/ñ>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as utils from '@ckeditor/ckeditor5-utils';`
@@ -47,7 +47,7 @@ import * as utils from '@ckeditor/ckeditor5-utils';`
       "index.d.ts",
       `// Type definitions for @ckeditor/ckeditor5-utils 25.0
 // Project: https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-utils
-// Definitions by: Federico <https://github.com/fedemp>
+// Definitions by: My Self <https://github.com/ñ>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 export function myFunction(arg:string): string;
  `
@@ -201,7 +201,7 @@ const a = new webpack.AutomaticPrefetchPlugin();
         "index.d.ts",
         `// Type definitions for @ckeditor/ckeditor-utils 25.0
 // Project: https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-engine
-// Definitions by: Federico <https://github.com/fedemp>
+// Definitions by: My Self <https://github.com/ñ>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 `
       );
@@ -260,6 +260,37 @@ const a = new webpack.AutomaticPrefetchPlugin();
         dt.addOldVersionOfPackage("jquery", "1");
         return expect(getTypingInfo("jquery", dt.pkgFS("jquery"))).rejects.toThrow(
           'jquery: Older version 1 must have a "paths" entry of "jquery/*": ["jquery/v1/*"]'
+        );
+      });
+
+      it("checks that scoped older versions with non-relative imports have wildcard path mappings", () => {
+        const dt = createMockDT();
+        const pkg = dt.pkgDir("ckeditor__ckeditor5-utils");
+        pkg.set(
+          "index.d.ts",
+          `// Type definitions for @ckeditor/ckeditor5-utils 25.0
+// Project: https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-utils
+// Definitions by: My Self <https://github.com/ñ>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+import first from "@ckeditor/ckeditor5-utils/src/first";
+ `
+        );
+        pkg.set(
+          "tsconfig.json",
+          JSON.stringify({
+            files: ["index.d.ts"],
+            compilerOptions: {
+              paths: {}
+            }
+          })
+        );
+
+        dt.addOldVersionOfPackage("@ckeditor/ckeditor5-utils", "10");
+
+        return expect(
+          getTypingInfo("ckeditor__ckeditor5-utils", dt.pkgFS("ckeditor__ckeditor5-utils"))
+        ).rejects.toThrow(
+          '@ckeditor/ckeditor5-utils: Older version 10 must have a "paths" entry of "@ckeditor/ckeditor5-utils/*": ["ckeditor__ckeditor5-utils/v10/*"]'
         );
       });
     });

--- a/packages/utils/src/miscellany.ts
+++ b/packages/utils/src/miscellany.ts
@@ -40,11 +40,11 @@ export function mangleScopedPackage(packageName: string): string {
 }
 
 export function removeVersionFromPackageName(packageName: string | undefined): string | undefined {
-  return packageName?.replace(/\/v(\d){1,}$/i, "");
+  return packageName?.replace(/\/v\d+(\/\*)?$/, "$1");
 }
 
 export function hasVersionNumberInMapping(packageName: string): boolean {
-  return /\/v\d+$/.test(packageName);
+  return /\/v\d+(\/\*)?$/.test(packageName);
 }
 
 export async function sleep(seconds: number): Promise<void> {

--- a/packages/utils/test/miscellany.test.ts
+++ b/packages/utils/test/miscellany.test.ts
@@ -17,12 +17,24 @@ describe("miscellany", () => {
     it("for non versioned package returns package", () => {
       expect(removeVersionFromPackageName("@ckeditor/ckeditor5-utils")).toBe("@ckeditor/ckeditor5-utils");
       expect(removeVersionFromPackageName("@foo/bar")).toBe("@foo/bar");
+      expect(removeVersionFromPackageName("foov10")).toBe("foov10");
+      expect(removeVersionFromPackageName("foo/V10")).toBe("foo/V10");
     });
 
     it("for versioned package returns package name only", () => {
       expect(removeVersionFromPackageName("@ckeditor/ckeditor5-utils/v10")).toBe("@ckeditor/ckeditor5-utils");
       expect(removeVersionFromPackageName("@foo/bar/v0")).toBe("@foo/bar");
-      expect(removeVersionFromPackageName("@foo/bar/V999")).toBe("@foo/bar");
+      expect(removeVersionFromPackageName("@foo/bar/V999")).toBe("@foo/bar/V999");
+    });
+
+    it("keeps wildcard path mappings for scoped versioned packages", () => {
+      expect(removeVersionFromPackageName("@ckeditor/ckeditor5-utils/*")).toBe("@ckeditor/ckeditor5-utils/*");
+      expect(removeVersionFromPackageName("@ckeditor/ckeditor5-utils/v10/*")).toBe("@ckeditor/ckeditor5-utils/*");
+    });
+
+    it("keeps wildcard path mappings for versioned packages", () => {
+      expect(removeVersionFromPackageName("foobar/*")).toBe("foobar/*");
+      expect(removeVersionFromPackageName("foobar/v10/*")).toBe("foobar/*");
     });
   });
 });


### PR DESCRIPTION
* definition-parser: Use scoped names when testing mappings for relative
imports.
* miscellany/utils: When removing version number, keeps wildcard at the
end of mapping.
* miscellany/utils: When checking the existence of a version number,
catch those packages that include a wildcard path mapping.