### PR TITLE
Fix unused path mapping detection for scoped packages

### DIFF
--- a/packages/definitions-parser/src/check-parse-results.ts
+++ b/packages/definitions-parser/src/check-parse-results.ts
@@ -107,7 +107,7 @@ function checkPathMappings(allPackages: AllPackages): void {
     }
 
     for (const unusedPathMapping of unusedPathMappings) {
-      if (pkg.name !== unusedPathMapping) {
+      if (pkg.name !== unusedPathMapping && pkg.unescapedName !== unusedPathMapping) {
         throw new Error(`${pkg.desc} has unused path mapping for ${unusedPathMapping}`);
       }
     }


### PR DESCRIPTION
This should have a test, but writing tests for this is so hard. We should really invest in a system like dt-mergebot has where we can easily generate fixtures for an actual GitHub PR and generate baselines for them.