### PR TITLE
Add @wordpress/api-fetch to allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -253,6 +253,7 @@
 @types/wonder-frp
 @uirouter/angularjs
 @vue/test-utils
+@wordpress/api-fetch
 @wordpress/element
 abort-controller
 actions-on-google


### PR DESCRIPTION
`api-fetch` is required by `data-controls` and publishes its own types since 3.21.2. This PR blocks https://github.com/DefinitelyTyped/DefinitelyTyped/pull/52388