### PR TITLE
Remove electron-json-storage from expectedFailures.txt

### DIFF
--- a/packages/dtslint-runner/expectedFailures.txt
+++ b/packages/dtslint-runner/expectedFailures.txt
@@ -1,4 +1,3 @@
 electron-clipboard-extended
-electron-json-storage
 electron-notifications
 electron-notify


### PR DESCRIPTION
An update to the package makes it no longer directly depend on electron
(which is still broken on new typescripts).