### PR TITLE
Adds `serialize-query-params` to allowed package.json dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -482,3 +482,4 @@ xmlbuilder
 xpath
 zipkin
 zipkin-transport-http
+serialize-query-params


### PR DESCRIPTION
Adds `serialize-query-params` to the dependencies list.

Required for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/52695/files