### PR TITLE
Actually log crashes to STDERR, replace trackEvent with trackException

### DIFF
--- a/packages/publisher/src/main.ts
+++ b/packages/publisher/src/main.ts
@@ -52,14 +52,12 @@ async function withFileLock(lockFilePath: string, cb: () => Promise<void>): Prom
     cb().then(
       () => remove(lockFilePath),
       async error => {
-        await removeLock();
-        applicationinsights.defaultClient.trackEvent({
-          name: "crash",
-          properties: {
-            error: String(error)
-          }
+        console.error(error?.message || error);
+        applicationinsights.defaultClient.trackException({
+          exception: error,
         });
 
+        await removeLock();
         process.exit(1);
       }
     );


### PR DESCRIPTION
`console.error` will allow error messages to show up in App Insights `traces`. I couldn’t find where this `trackEvent` shows up. I’m hoping and assuming that `trackException` will show up in `exceptions`, but the most important thing is having it in logs.