### PR TITLE
definition-parser: Show path of empty dir

### DIFF
--- a/packages/definitions-parser/src/lib/definition-parser.ts
+++ b/packages/definitions-parser/src/lib/definition-parser.ts
@@ -658,7 +658,7 @@ function checkAllUsedRecur(ls: Iterable<string>, usedFiles: Set<string>, unusedF
       const lssubdir = subdir.readdir();
       if (lssubdir.length === 0) {
         // tslint:disable-next-line strict-string-expressions
-        throw new Error(`Empty directory ${subdir} (${join(usedFiles)})`);
+        throw new Error(`Empty directory ${subdir.debugPath()} (${join(usedFiles)})`);
       }
 
       function takeSubdirectoryOutOfSet(originalSet: Set<string>): Set<string> {


### PR DESCRIPTION
When checkAllUsedRecur fails because of an empty directory, show the
full path to it. Currently "[Object object]" is printed to the terminal.

debugPath does not show path relative to current position, but relative
to root of project.