### PR TITLE
Allow deleted files outside notNeededPackages entries

### DIFF
--- a/packages/definitions-parser/src/git.ts
+++ b/packages/definitions-parser/src/git.ts
@@ -13,6 +13,7 @@ import {
   execAndThrowErrors,
   flatMapIterable,
   mapIterable,
+  mapDefined,
   FS,
   consoleLogger,
   assertDefined,
@@ -162,11 +163,10 @@ it is supposed to replace, ${latestTypings.versionString} of ${unneeded.fullNpmN
 }
 
 /**
- * 1. find all the deleted files and group by toplevel
- * 2. Make sure that there are no packages left with deleted entries
- * 3. make sure that each toplevel deleted has a matching entry in notNeededPackages
- */
-export function getNotNeededPackages(allPackages: AllPackages, diffs: GitDiff[]): Iterable<NotNeededPackage> {
+ * 1. Find all the deleted files and group by package (error on deleted files outside a package).
+ * 2. Make sure that all deleted packages in notNeededPackages have no files left.
+  */
+export function getNotNeededPackages(allPackages: AllPackages, diffs: GitDiff[]) {
   const deletedPackages = new Set(
     diffs
       .filter(d => d.status === "D")
@@ -179,10 +179,17 @@ When removing packages, you should only delete files that are a part of removed 
           ).name
       )
   );
-  return mapIterable(deletedPackages, p => {
-    if (allPackages.hasTypingFor({ name: p, version: "*" })) {
-      throw new Error(`Please delete all files in ${p} when adding it to notNeededPackages.json.`);
+  return mapDefined(deletedPackages, p => {
+    const hasTyping = allPackages.hasTypingFor({ name: p, version: "*" })
+    const notNeeded = allPackages.getNotNeededPackage(p)
+    if (hasTyping) {
+      if (notNeeded) {
+        throw new Error(`Please delete all files in ${p} when adding it to notNeededPackages.json.`);
+      }
+      return undefined
     }
-    return assertDefined(allPackages.getNotNeededPackage(p), `Deleted package ${p} is not in notNeededPackages.json.`);
+    else {
+        return notNeeded;
+    }
   });
 }

--- a/packages/definitions-parser/src/git.ts
+++ b/packages/definitions-parser/src/git.ts
@@ -165,7 +165,7 @@ it is supposed to replace, ${latestTypings.versionString} of ${unneeded.fullNpmN
 /**
  * 1. Find all the deleted files and group by package (error on deleted files outside a package).
  * 2. Make sure that all deleted packages in notNeededPackages have no files left.
-  */
+ */
 export function getNotNeededPackages(allPackages: AllPackages, diffs: GitDiff[]) {
   const deletedPackages = new Set(
     diffs

--- a/packages/definitions-parser/test/git.test.ts
+++ b/packages/definitions-parser/test/git.test.ts
@@ -23,47 +23,41 @@ const deleteJestDiffs: GitDiff[] = [
 
 testo({
   ok() {
-    expect(Array.from(getNotNeededPackages(allPackages, deleteJestDiffs))).toEqual(jestNotNeeded);
+    expect(getNotNeededPackages(allPackages, deleteJestDiffs)).toEqual(jestNotNeeded);
   },
   forgotToDeleteFiles() {
     expect(() =>
-      Array.from(
-        getNotNeededPackages(
-          AllPackages.from({ jest: createTypingsVersionRaw("jest", {}, [], {}) }, jestNotNeeded),
-          deleteJestDiffs
-        )
+      getNotNeededPackages(
+        AllPackages.from({ jest: createTypingsVersionRaw("jest", {}, [], {}) }, jestNotNeeded),
+        deleteJestDiffs
       )
     ).toThrow("Please delete all files in jest");
   },
   tooManyDeletes() {
-    expect(() => Array.from(getNotNeededPackages(allPackages, [{ status: "D", file: "oops.txt" }]))).toThrow(
+    expect(() => getNotNeededPackages(allPackages, [{ status: "D", file: "oops.txt" }])).toThrow(
       "Unexpected file deleted: oops.txt"
     );
   },
+  deleteInOtherPackage() {
+    expect(getNotNeededPackages(allPackages, [...deleteJestDiffs, { status: "D", file: "types/most-recent/extra-tests.ts" }])).toEqual(jestNotNeeded);
+  },
   extraneousFile() {
-    Array.from(
+    expect(
       getNotNeededPackages(allPackages, [
         { status: "A", file: "oooooooooooops.txt" },
         { status: "M", file: "notNeededPackages.json" },
         { status: "D", file: "types/jest/index.d.ts" },
         { status: "D", file: "types/jest/jest-tests.d.ts" }
       ])
-    );
-  },
-  forgotToUpdateNotNeededJson() {
-    expect(() =>
-      Array.from(
-        getNotNeededPackages(AllPackages.from(typesData, []), [{ status: "D", file: "types/jest/index.d.ts" }])
-      )
-    ).toThrow("Deleted package jest is not in notNeededPackages.json.");
+    ).toEqual(jestNotNeeded)
   },
   scoped() {
-    Array.from(
+    expect(
       getNotNeededPackages(
         AllPackages.from(typesData, [new NotNeededPackage("ember__object", "@ember/object", "1.0.0")]),
         [{ status: "D", file: "types/ember__object/index.d.ts" }]
       )
-    );
+    ).toEqual([new NotNeededPackage("ember__object", "@ember/object", "1.0.0")])
   }
   // TODO: Test npm info (and with scoped names)
   // TODO: Test with dependents, etc etc


### PR DESCRIPTION
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/52719 needs to deprecate @types/socket.io@2 and in doing so modify its dependents. One of its dependents needs to delete a file in its own package (its socket.io test is no longer needed), but this isn't allowed currently.

This changes it to be allowed. I'm not sure I've covered all the interesting cases, so check whether the new code is now too permissive.