### PR TITLE
add @types/socket.io and @types/socket.io-client to allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -262,6 +262,8 @@
 @types/react-native-tab-view
 @types/react-navigation
 @types/rsmq
+@types/socket.io
+@types/socket.io-client
 @types/three
 @types/vue
 @types/webdriverio


### PR DESCRIPTION
add @types/socket.io and @types/socket.io-client to allowed dependencies

as discussed with @sandersn @peterblazejewicz in
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/52719#issuecomment-840721803