### PR TITLE
Allow depending on got in `package.json` on DT

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -351,6 +351,7 @@ glaze
 globby
 google-auth-library
 google-gax
+got
 graphql
 graphql-tools
 grpc


### PR DESCRIPTION
[`got`](https://github.com/sindresorhus/got/commits/main/source/index.ts) was reimplemented in TypeScript since [v10](https://github.com/sindresorhus/got/commit/5dac30dff88d1e0821fd143382e39ad74c11b522#diff-fcd423a0b6ae0654240ee2c1cb0b023707df57b7d1c7a3834c5bfbef7d901da5). This MR adds `got` to allowed dependencies in `package.json` files for type definitions on DT.