### PR TITLE
chore(node): readable-stream compat

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -259,6 +259,7 @@
 @types/leaflet
 @types/mkdirp-promise
 @types/next-redux-wrapper
+@types/node
 @types/react-native-tab-view
 @types/react-navigation
 @types/rsmq


### PR DESCRIPTION
We need to de-couple `readable-stream` from current head of @types/node since readable-stream strictly states it's a [copy of the v10 stream API](https://www.npmjs.com/package/readable-stream).

See corresponding DT PR: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/52732/files#diff-af7da952bbd3d5c94b761da7f4ce4b7b5dac398dd34b890bde3c77719d5191d6R4