### PR TITLE
add(anymatch): update allowed deps list with anymatch

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -245,6 +245,7 @@
 @storybook/react
 @testing-library/dom
 @tweenjs/tween.js
+@types/anymatch
 @types/autoprefixer
 @types/base-x
 @types/expect
@@ -284,6 +285,7 @@ ajv
 algoliasearch
 algoliasearch-helper
 anydb-sql
+anymatch
 aphrodite
 apollo-client
 apollo-link


### PR DESCRIPTION
Webpack 4 DT depends on `anymatch` and @types/anymatch was removed.
This shoudl allow
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/53107 to be
merged with fix for failing types.

Thanks!