### PR TITLE
If the module is a single dts file, show it in the README

### DIFF
--- a/packages/definitions-parser/src/packages.ts
+++ b/packages/definitions-parser/src/packages.ts
@@ -573,6 +573,9 @@ export class TypingsData extends PackageBase {
   get files(): readonly string[] {
     return this.data.files;
   }
+  get dtsFiles(): readonly string[] {
+    return this.data.files.filter(f => f.endsWith(".d.ts"));
+  }
   get license(): License {
     return this.data.license;
   }

--- a/packages/publisher/src/generate-packages.ts
+++ b/packages/publisher/src/generate-packages.ts
@@ -277,10 +277,11 @@ export function createReadme(typing: TypingsData, packageFS: FS): string {
 
   if (typing.dtsFiles.length === 1 && packageFS.readFile(typing.dtsFiles[0]).length < 2500) {
     const dts = typing.dtsFiles[0]
-    lines.push(`## ${typing.dtsFiles[0]}`)
-    lines.push("```ts")
+    const url = `${definitelyTypedURL}/tree/${sourceBranch}/types/${typing.subDirectoryPath}/${dts}`
+    lines.push(`## [${typing.dtsFiles[0]}](${url})`)
+    lines.push("````ts")
     lines.push(packageFS.readFile(dts))
-    lines.push("```")
+    lines.push("````")
   }
 
   lines.push("");

--- a/packages/publisher/src/generate-packages.ts
+++ b/packages/publisher/src/generate-packages.ts
@@ -98,13 +98,13 @@ async function generateTypingPackage(
   await writeCommonOutputs(
     typing,
     createPackageJSON(typing, version, packages, Registry.NPM),
-    createReadme(typing),
+    createReadme(typing, packageFS),
     Registry.NPM
   );
   await writeCommonOutputs(
     typing,
     createPackageJSON(typing, version, packages, Registry.Github),
-    createReadme(typing),
+    createReadme(typing, packageFS),
     Registry.Github
   );
   await Promise.all(
@@ -258,7 +258,7 @@ export function createNotNeededPackageJSON(
   return JSON.stringify(out, undefined, 4);
 }
 
-export function createReadme(typing: TypingsData): string {
+export function createReadme(typing: TypingsData, packageFS: FS): string {
   const lines: string[] = [];
   lines.push("# Installation");
   lines.push(`> \`npm install --save ${typing.fullNpmName}\``);
@@ -274,6 +274,14 @@ export function createReadme(typing: TypingsData): string {
 
   lines.push("# Details");
   lines.push(`Files were exported from ${definitelyTypedURL}/tree/${sourceBranch}/types/${typing.subDirectoryPath}.`);
+
+  if (typing.dtsFiles.length === 1) {
+    const dts = typing.dtsFiles[0]
+    lines.push("## " + path.basename(dts))
+    lines.push("```ts")
+    lines.push(packageFS.readFile(dts))
+    lines.push("```")
+  }
 
   lines.push("");
   lines.push("### Additional Details");

--- a/packages/publisher/src/generate-packages.ts
+++ b/packages/publisher/src/generate-packages.ts
@@ -275,9 +275,9 @@ export function createReadme(typing: TypingsData, packageFS: FS): string {
   lines.push("# Details");
   lines.push(`Files were exported from ${definitelyTypedURL}/tree/${sourceBranch}/types/${typing.subDirectoryPath}.`);
 
-  if (typing.dtsFiles.length === 1) {
+  if (typing.dtsFiles.length === 1 && packageFS.readFile(typing.dtsFiles[0]).length < 2500) {
     const dts = typing.dtsFiles[0]
-    lines.push("## " + path.basename(dts))
+    lines.push(`## ${typing.dtsFiles[0]}`)
     lines.push("```ts")
     lines.push(packageFS.readFile(dts))
     lines.push("```")


### PR DESCRIPTION
The idea being that you won't need to pop to GitHub to read the types if it's a small dep. 