### PR TITLE
add: mongoose

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -264,6 +264,7 @@
 @types/js-data
 @types/leaflet
 @types/mkdirp-promise
+@types/mongoose
 @types/next-redux-wrapper
 @types/node
 @types/react-native-tab-view
@@ -407,6 +408,7 @@ moment
 moment-range
 moment-timezone
 monaco-editor
+mongoose
 mqtt
 next
 nock


### PR DESCRIPTION
Mongoose ships its own types starting 5.11
At the same time, there is a dozen or more packages on DT that would
require minor changes to adapt to that change, either by fixing to
already published @types/mongoose or using new native package reference

Ref: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/53417

Thanks!