### PR TITLE
Add tarn to allowed allowedPackageJsonDependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -473,6 +473,7 @@ styled-components
 sw-toolbox
 swagger-parser
 tapable
+tarn
 tasker-types
 terser
 three


### PR DESCRIPTION
Allow tarn package to be added to dependencies as it declares its own types: https://www.npmjs.com/package/tarn