### PR TITLE
Require lowercase package names in notNeededPackages.json

### DIFF
--- a/packages/definitions-parser/src/mocks.ts
+++ b/packages/definitions-parser/src/mocks.ts
@@ -12,7 +12,7 @@ class DTMock {
       JSON.stringify({
         packages: {
           angular: {
-            libraryName: "angular 2",
+            libraryName: "angular",
             asOfVersion: "1.2.3"
           }
         }

--- a/packages/definitions-parser/src/mocks.ts
+++ b/packages/definitions-parser/src/mocks.ts
@@ -12,7 +12,7 @@ class DTMock {
       JSON.stringify({
         packages: {
           angular: {
-            libraryName: "Angular 2",
+            libraryName: "angular 2",
             asOfVersion: "1.2.3"
           }
         }

--- a/packages/definitions-parser/src/packages.ts
+++ b/packages/definitions-parser/src/packages.ts
@@ -268,10 +268,16 @@ export class NotNeededPackage extends PackageBase {
   }
 
   static fromRaw(name: string, raw: NotNeededPackageRaw) {
+    if (name !== name.toLowerCase()) {
+      throw new Error(`not-needed package '${name}' must use all lower-case letters.`)
+    }
     for (const key of Object.keys(raw)) {
       if (!["libraryName", "sourceRepoURL", "asOfVersion"].includes(key)) {
         throw new Error(`Unexpected key in not-needed package: ${key}`);
       }
+    }
+    if (raw.libraryName !== raw.libraryName.toLowerCase()) {
+      throw new Error(`not-needed package '${name}' must use a libraryName that is all lower-case letters.`)
     }
 
     return new NotNeededPackage(name, raw.libraryName, raw.asOfVersion);

--- a/packages/definitions-parser/test/packages.test.ts
+++ b/packages/definitions-parser/test/packages.test.ts
@@ -234,6 +234,17 @@ describe(NotNeededPackage, () => {
       "This is a stub types definition. real-package provides its own type definitions, so you do not need this installed."
     );
   });
+
+  describe("fromRaw", () => {
+    it("throws on uppercase package name", () => {
+      expect(() => NotNeededPackage.fromRaw("noUISlider", { libraryName: "nouislider", asOfVersion: "16.0.0" }))
+        .toThrow("not-needed package 'noUISlider' must use all lower-case letters.")
+    })
+    it("throws on uppercase library name", () => {
+      expect(() => NotNeededPackage.fromRaw("nouislider", { libraryName: "noUISlider", asOfVersion: "16.0.0" }))
+        .toThrow("not-needed package 'nouislider' must use a libraryName that is all lower-case letters.")
+    })
+  })
 });
 
 describe(getLicenseFromPackageJson, () => {


### PR DESCRIPTION
This means we can't deprecate packages with uppercase letters, but I don't think there are many on npm -- possibly none.