### PR TITLE
Add msnodesqlv8 to allowed allowed deps

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -410,6 +410,7 @@ moment-timezone
 monaco-editor
 mongoose
 mqtt
+msnodesqlv8
 next
 nock
 normalize-url


### PR DESCRIPTION
Allow msnodesqlv8 package to be added to dependencies as it declares its own types: https://www.npmjs.com/package/msnodesqlv8