### PR TITLE
Allow node/buffer path mapping

### DIFF
--- a/packages/definitions-parser/src/lib/definition-parser.ts
+++ b/packages/definitions-parser/src/lib/definition-parser.ts
@@ -504,7 +504,8 @@ function calculateDependencies(
       continue;
     }
 
-    // buffer -> node/buffer may be required because of the VERY REAL and NOT NODE buffer package on npm
+    // buffer -> node/buffer may be required because of the non-node 'buffer' package on npm
+    // which DT infrastructure depends on, and which resolves before node's ambient module 'buffer'
     if (dependencyName === "buffer" && pathMapping === "node/buffer") {
       dependencies["node"] = "*";
       continue;

--- a/packages/definitions-parser/src/lib/definition-parser.ts
+++ b/packages/definitions-parser/src/lib/definition-parser.ts
@@ -507,7 +507,7 @@ function calculateDependencies(
     // buffer -> node/buffer may be required because of the non-node 'buffer' package on npm
     // which DT infrastructure depends on, and which resolves before node's ambient module 'buffer'
     if (dependencyName === "buffer" && pathMapping === "node/buffer") {
-      dependencies["node"] = "*";
+      dependencies.node = "*";
       continue;
     }
 

--- a/packages/definitions-parser/src/lib/definition-parser.ts
+++ b/packages/definitions-parser/src/lib/definition-parser.ts
@@ -504,6 +504,12 @@ function calculateDependencies(
       continue;
     }
 
+    // buffer -> node/buffer may be required because of the VERY REAL and NOT NODE buffer package on npm
+    if (dependencyName === "buffer" && pathMapping === "node/buffer") {
+      dependencies["node"] = "*";
+      continue;
+    }
+
     const pathMappingVersion = parseDependencyVersionFromPath(dependencyName, dependencyName, pathMapping);
     if (dependencyName === packageName) {
       if (directoryVersion === undefined) {

--- a/packages/definitions-parser/test/definition-parser.test.ts
+++ b/packages/definitions-parser/test/definition-parser.test.ts
@@ -75,6 +75,58 @@ export function myFunction(arg:string): string;
     dt.addOldVersionOfPackage("jquery", "2");
     // now add a dependency that maps to jquery/1.42
   });
+  it("allows path mapping to node/buffer", async () => {
+    // Actually, the default seup already has 'has-older-test-dependency', so probably doesn't need an explicit test
+    const dt = createMockDT();
+    const safer = dt.pkgDir("safer");
+    safer.set(
+      "index.d.ts",
+      `// Type definitions for safer 1.0
+// Project: https://github.com/safer/safer
+// Definitions by: Noone <https://github.com/noone>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+export * from 'buffer';
+`
+    );
+    safer.set("safer-tests.ts", "");
+    safer.set(
+      "tsconfig.json",
+      `{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "paths": {
+            "buffer": [
+                "node/buffer"
+            ]
+        },
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "safer-tests.ts"
+    ]
+} `
+    );
+
+    const info = await getTypingInfo("safer", dt.pkgFS("safer"));
+    expect(info).toBeDefined();
+    expect(info["1.0"].dependencies).toEqual({ node: "*" });
+  });
   it("errors on arbitrary path mapping", () => {});
   it("supports node_modules passthrough path mapping", async () => {
     const dt = createMockDT();


### PR DESCRIPTION
This will allow https://github.com/DefinitelyTyped/DefinitelyTyped/pull/53441 to pass.