### PR TITLE
Add simple-markdown to allowedPackageJsonDependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -465,6 +465,7 @@ scroll-into-view-if-needed
 semantic-ui-react
 serialize-query-params
 should
+simple-markdown
 smooth-scrollbar
 socket.io
 socket.io-client


### PR DESCRIPTION
Add [`simple-markdown`](https://github.com/Khan/simple-markdown) to the list of allowed package.json dependencies. Required for the types for discord-markdown (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/53501).