### PR TITLE
fix: add sonic-boom to allowed package dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -470,6 +470,7 @@ simple-markdown
 smooth-scrollbar
 socket.io
 socket.io-client
+sonic-boom
 source-map
 ssim.js
 styled-components


### PR DESCRIPTION
The `sonic-boom` package publishes its own types as of version 2.0.0.  This is a companion PR to https://github.com/DefinitelyTyped/DefinitelyTyped/pull/53559. 