### PR TITLE
Fix: remove minor version number from package name

### DIFF
--- a/packages/utils/src/miscellany.ts
+++ b/packages/utils/src/miscellany.ts
@@ -61,11 +61,11 @@ export function mangleScopedPackage(packageName: string): string {
 }
 
 export function removeVersionFromPackageName(packageName: string | undefined): string | undefined {
-  return packageName?.replace(/\/v\d+(\/\*)?$/, "$1");
+  return packageName?.replace(/\/v\d+(\.\d+)?(\/\*)?$/, "$2");
 }
 
 export function hasVersionNumberInMapping(packageName: string): boolean {
-  return /\/v\d+(\/\*)?$/.test(packageName);
+  return /\/v\d+(\.\d+)?(\/\*)?$/.test(packageName);
 }
 
 export async function sleep(seconds: number): Promise<void> {

--- a/packages/utils/test/miscellany.test.ts
+++ b/packages/utils/test/miscellany.test.ts
@@ -23,6 +23,7 @@ describe("miscellany", () => {
 
     it("for versioned package returns package name only", () => {
       expect(removeVersionFromPackageName("@ckeditor/ckeditor5-utils/v10")).toBe("@ckeditor/ckeditor5-utils");
+      expect(removeVersionFromPackageName("@foo/bar/v999.888")).toBe("@foo/bar");
       expect(removeVersionFromPackageName("@foo/bar/v0")).toBe("@foo/bar");
       expect(removeVersionFromPackageName("@foo/bar/V999")).toBe("@foo/bar/V999");
     });
@@ -30,11 +31,13 @@ describe("miscellany", () => {
     it("keeps wildcard path mappings for scoped versioned packages", () => {
       expect(removeVersionFromPackageName("@ckeditor/ckeditor5-utils/*")).toBe("@ckeditor/ckeditor5-utils/*");
       expect(removeVersionFromPackageName("@ckeditor/ckeditor5-utils/v10/*")).toBe("@ckeditor/ckeditor5-utils/*");
+      expect(removeVersionFromPackageName("@ckeditor/ckeditor5-utils/v10.11/*")).toBe("@ckeditor/ckeditor5-utils/*");
     });
 
     it("keeps wildcard path mappings for versioned packages", () => {
       expect(removeVersionFromPackageName("foobar/*")).toBe("foobar/*");
       expect(removeVersionFromPackageName("foobar/v10/*")).toBe("foobar/*");
+      expect(removeVersionFromPackageName("foobar/v10.110/*")).toBe("foobar/*");
     });
   });
 });


### PR DESCRIPTION
Add support for minor versions when removing the version suffix from a
package name. E.g. @foo/bar@v27.1 should be @foo/bar, but currently the
regexp does not match the dot character.