### PR TITLE
Revert "Added @types/eslint & co to allowedPackageJsonDependencies.txt"

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -253,9 +253,6 @@
 @types/anymatch
 @types/autoprefixer
 @types/base-x
-@types/eslint
-@types/eslint-visitor-keys
-@types/estree
 @types/expect
 @types/express-serve-static-core
 @types/firebase


### PR DESCRIPTION
Reverts microsoft/DefinitelyTyped-tools#276 per @sandersn's indication that it's not necessary.