### PR TITLE
Add aws-xray-sdk-core

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -301,6 +301,7 @@ ast-types
 async-done
 autoprefixer
 aws-sdk
+aws-xray-sdk-core
 axe-core
 axios
 base-x


### PR DESCRIPTION
Adding aws-xray-sdk-core because it contains type definitions, as advised by DefinitelyTyped CI.