### PR TITLE
Added react-popper to allowedPackageJsonDependencies.txt

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -455,6 +455,7 @@ react-native-svg
 react-native-svg
 react-native-tab-view
 react-navigation
+react-popper
 recast
 redux
 redux-logic


### PR DESCRIPTION
The `react-popper` package ships with its own typings

PR with failed pipeline: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/53588