### PR TITLE
Added vite to allowedPackageJsonDependencies.txt

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -499,6 +499,7 @@ utility-types
 vega-typings
 vfile
 vfile-message
+vite
 vue
 vue-router
 vuex


### PR DESCRIPTION
The `vite` package ships with its own type definitions.

PR with failed CI: [DefinitelyTyped/DefinitelyTyped#54276](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54276)