### PR TITLE
Added mongodb to allowedPackageJsonDependencies.txt

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -414,6 +414,7 @@ moment
 moment-range
 moment-timezone
 monaco-editor
+mongodb
 mongoose
 mqtt
 msnodesqlv8


### PR DESCRIPTION
mongodb now ships with its own definitions as of version 4.0.0

PR with failed CI: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54510