### PR TITLE
Add @types/mongodb to allowedPackageJsonDependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -265,6 +265,7 @@
 @types/js-data
 @types/leaflet
 @types/mkdirp-promise
+@types/mongodb
 @types/mongoose
 @types/next-redux-wrapper
 @types/node


### PR DESCRIPTION
I forgot to add this in #290 I'm sorry but this PR just adds `@types/mongodb` to the allowed deps list