### PR TITLE
Add ng-cordova to expectedFailures.txt

### DIFF
--- a/packages/dtslint-runner/expectedFailures.txt
+++ b/packages/dtslint-runner/expectedFailures.txt
@@ -1,5 +1,6 @@
 electron-clipboard-extended
 electron-notifications
 electron-notify
+ng-cordova
 redux-orm
 vscode-webview


### PR DESCRIPTION
@types/ng-cordova depends on cordova-plugin-file, which conflicts with the DOM types in TS 4.4. cordova-plugin-file hasn't published a new version in 2 years, so is unlikely to be updated.