### PR TITLE
Add jest-environment-puppeteer to expectedFailures

### DIFF
--- a/packages/dtslint-runner/expectedFailures.txt
+++ b/packages/dtslint-runner/expectedFailures.txt
@@ -1,6 +1,7 @@
 electron-clipboard-extended
 electron-notifications
 electron-notify
+jest-environment-puppeteer
 ng-cordova
 redux-orm
 vscode-webview


### PR DESCRIPTION
Jest needs to upgrade to @types/node@16. I expect this will happen pretty soon, but I tried myself and it wasn't trivial. Now I'm tired of looking at the error -- as soon as it's fixed, the test will fail again and I will remove this entry.