### PR TITLE
Remove the audit CLI output

### DIFF
--- a/packages/utils/src/io.ts
+++ b/packages/utils/src/io.ts
@@ -176,7 +176,7 @@ export async function isDirectory(path: string): Promise<boolean> {
   return (await stat(path)).isDirectory();
 }
 
-export const npmInstallFlags = "--ignore-scripts --no-shrinkwrap --no-package-lock --no-bin-links --no-save";
+export const npmInstallFlags = "--ignore-scripts --no-shrinkwrap --no-package-lock --no-bin-links --no-save  --no-audit";
 const downloadTimeout = 1_000_000; // ms
 const connectionTimeout = 800_000; // ms
 


### PR DESCRIPTION
Lots of the CI output in when you use `dtslint-runner` is [noise](https://github.com/microsoft/TypeScript-DOM-lib-generator/runs/3174306610?check_suite_focus=true) - this should reduce that