### PR TITLE
Add itty-router to allowedPackageJsonDependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -384,6 +384,7 @@ immer
 immutable
 indefinite-observable
 inversify
+itty-router
 jest-cucumber
 jest-diff
 jest-environment-jsdom


### PR DESCRIPTION
`itty-router` ships with its own types. `ThrowableRouter` in DefinitelyTyped/DefinitelyTyped#54960 is a wrapper around `Router` provided by `itty-router`, and thus depends on it.