### PR TITLE
Add @types/ssh2-streams to allowedPackageJsonDependencies.txt

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -274,6 +274,7 @@
 @types/rsmq
 @types/socket.io
 @types/socket.io-client
+@types/ssh2-streams
 @types/three
 @types/vue
 @types/webdriverio


### PR DESCRIPTION
Adds `@types/ssh2-streams` to `allowedPackageJsonDependencies.txt`.

Required for Required for [DefinitelyTyped/DefinitelyTyped#55050](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/55050).