### PR TITLE
Add node-fetch to allowedPackageJsonDependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -270,6 +270,7 @@
 @types/mongoose
 @types/next-redux-wrapper
 @types/node
+@types/node-fetch
 @types/react-native-tab-view
 @types/react-navigation
 @types/rsmq
@@ -423,6 +424,7 @@ mqtt
 msnodesqlv8
 next
 nock
+node-fetch
 normalize-url
 objection
 opentracing


### PR DESCRIPTION
This PR adds `@types/node-fetch` and `node-fetch` to the allowedPackageJsonDependencies since this package recently updated to support its own built-in typings and others will now need to be updated.