### PR TITLE
Add @rdfjs/types

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -243,6 +243,7 @@
 @maxim_mazurok/gapi.client.youtubeanalytics
 @maxim_mazurok/gapi.client.youtubereporting
 @popperjs/core
+@rdfjs/types
 @react-navigation/native
 @react-navigation/stack
 @sentry/browser


### PR DESCRIPTION
The package `rdf-js` which already is on this list is just a [backwards-compatibility proxy which installs](https://github.com/rdfjs/rdf-js/blob/master/package.json#L14) `@rdfjs/types`.

We'd want both allowed here