### PR TITLE
Add sketchapp to expected failures

### DIFF
--- a/packages/dtslint-runner/expectedFailures.txt
+++ b/packages/dtslint-runner/expectedFailures.txt
@@ -4,4 +4,5 @@ electron-notify
 jest-environment-puppeteer
 ng-cordova
 redux-orm
+sketchapp
 vscode-webview


### PR DESCRIPTION
A learner mistakenly made a sketchapp package that *uses* sketchapp. `@types/sketchapp` is still for a non-npm package. I don't think it's worthwhile to rename a rarely used `@types` package to avoid an even more rarely used mistake package.