### PR TITLE
Add support for copying package imports/exports/type to resulting package files

### DIFF
--- a/packages/definitions-parser/src/packages.ts
+++ b/packages/definitions-parser/src/packages.ts
@@ -363,6 +363,21 @@ export interface TypingsDataRaw extends BaseRaw {
   readonly dependencies: { readonly [name: string]: DependencyVersion };
 
   /**
+   * Package `imports`, as read in the `package.json` file
+   */
+  readonly imports?: object;
+
+  /**
+   * Package `exports`, as read in the `package.json` file
+   */
+  readonly exports?: object | string;
+
+  /**
+   * Package `type`, as read in the `package.json` file
+   */
+  readonly type?: string;
+
+  /**
    * Other definitions, that exist in the same typings repo, that the tests, but not the types, of this package depend on.
    *
    * These are always the latest version and will not include anything already in `dependencies`.
@@ -606,6 +621,18 @@ export class TypingsData extends PackageBase {
 
   get dependencies(): { readonly [name: string]: DependencyVersion } {
     return this.data.dependencies;
+  }
+
+  get type() {
+    return this.data.type;
+  }
+
+  get imports() {
+    return this.data.imports;
+  }
+
+  get exports() {
+    return this.data.exports;
   }
 
   get versionDirectoryName() {

--- a/packages/publisher/src/generate-packages.ts
+++ b/packages/publisher/src/generate-packages.ts
@@ -200,6 +200,18 @@ export function createPackageJSON(
   if (registry === Registry.Github) {
     (out as any).publishConfig = { registry: "https://npm.pkg.github.com/" };
   }
+  const exports = typing.exports;
+  if (exports) {
+    (out as any).exports = exports;
+  }
+  const imports = typing.imports;
+  if (imports) {
+    (out as any).imports = imports;
+  }
+  const type = typing.type;
+  if (type) {
+    (out as any).type = type;
+  }
 
   return JSON.stringify(out, undefined, 4);
 }


### PR DESCRIPTION
This way packages on DT can specify imports, exports, and `type`, as may be required to support various modern node specifier resolutions.