### PR TITLE
Check for .d.mts and .d.cts files everywhere we check for .d.ts files

### DIFF
--- a/packages/definitions-parser/src/lib/definition-parser.ts
+++ b/packages/definitions-parser/src/lib/definition-parser.ts
@@ -330,7 +330,7 @@ function getTypingDataForSingleTypesVersion(
     }
   }
   checkAllFilesUsed(ls, usedFiles, otherFiles, packageName, fs);
-  for (const untestedTypeFile of filter(otherFiles, name => name.endsWith(".d.ts"))) {
+  for (const untestedTypeFile of filter(otherFiles, name => name.endsWith(".d.ts") || name.endsWith(".d.mts") || name.endsWith(".d.cts"))) {
     // add d.ts files from OTHER_FILES.txt in order get their dependencies
     // tslint:disable-next-line:non-literal-fs-path -- Not a reference to the fs package
     types.set(untestedTypeFile, createSourceFile(untestedTypeFile, fs.readFile(untestedTypeFile)));

--- a/packages/definitions-parser/src/lib/module-info.ts
+++ b/packages/definitions-parser/src/lib/module-info.ts
@@ -166,7 +166,7 @@ export function allReferencedFiles(
     // tslint:disable-next-line:non-literal-fs-path -- Not a reference to the fs package
     if (fs.exists(resolvedFilename)) {
       const src = createSourceFile(resolvedFilename, readFileAndThrowOnBOM(resolvedFilename, fs));
-      if (resolvedFilename.endsWith(".d.ts")) {
+      if (resolvedFilename.endsWith(".d.ts") || resolvedFilename.endsWith(".d.mts") || resolvedFilename.endsWith(".d.cts")) {
         types.set(resolvedFilename, src);
       } else {
         tests.set(resolvedFilename, src);

--- a/packages/definitions-parser/src/packages.ts
+++ b/packages/definitions-parser/src/packages.ts
@@ -595,7 +595,7 @@ export class TypingsData extends PackageBase {
     return this.data.files;
   }
   get dtsFiles(): readonly string[] {
-    return this.data.files.filter(f => f.endsWith(".d.ts"));
+    return this.data.files.filter(f => f.endsWith(".d.ts") || f.endsWith(".d.mts") || f.endsWith(".d.cts"));
   }
   get license(): License {
     return this.data.license;


### PR DESCRIPTION
This should allow referring to them in `OTHER_FILES.txt`.