### PR TITLE
Add @types/event-kit to allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -268,6 +268,7 @@
 @types/base-x
 @types/expect
 @types/express-serve-static-core
+@types/event-kit
 @types/firebase
 @types/got
 @types/helmet


### PR DESCRIPTION
Hello, I would like to allow the new dependency for DefinitelyTyped/DefinitelyTyped#56580.

The type def for @atom/watcher package depends on Disposable from @types/event-kit, 