### PR TITLE
remove(vfile): disallow dependency

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -526,7 +526,6 @@ typescript-tuple
 unified
 utility-types
 vega-typings
-vfile
 vfile-message
 victory
 vite


### PR DESCRIPTION
We are removing DT definition relyng on this rule:
DefinitelyTyped/DefinitelyTyped#56658

This will be no longer need,

Thanks!