### PR TITLE
Add `@types/formidable` to `allowedPackageJsonDependencies`

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -269,6 +269,7 @@
 @types/expect
 @types/express-serve-static-core
 @types/firebase
+@types/formidable
 @types/got
 @types/helmet
 @types/highcharts


### PR DESCRIPTION
See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56925, so that we can safely upgrade `@types/formidable` without breaking other packages (`restify` specifically)