### PR TITLE
Remove @types/formidable

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -269,7 +269,6 @@
 @types/expect
 @types/express-serve-static-core
 @types/firebase
-@types/formidable
 @types/got
 @types/helmet
 @types/highcharts


### PR DESCRIPTION
It was incorrectly assumed that it would allow installation of v1 types for Restify, while having v2 types in the DefinitelyTyped repository. Apologies!