### PR TITLE
Add `iconv-lite` to `allowedPackageJsonDependencies`

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -397,6 +397,7 @@ html-webpack-plugin
 htmlparser2
 http-proxy-middleware
 i18next
+iconv-lite
 immer
 immutable
 indefinite-observable


### PR DESCRIPTION
`mailparser` requires this package. See [56983](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56983).
