### PR TITLE
add(express-handlerbars): new whitelited entry

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -267,6 +267,7 @@
 @types/autoprefixer
 @types/base-x
 @types/expect
+@types/express-handlebars
 @types/express-serve-static-core
 @types/firebase
 @types/got


### PR DESCRIPTION
Required for removal of `express-handlebars` on DT for 3rd party DT
package tests:

DefinitelyTyped/DefinitelyTyped#57137

Thanks!