### PR TITLE
Add "plugin-error" to allowedPackageJsonDependencies.txt

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -453,6 +453,7 @@ pdfjs-dist
 pg-protocol
 pg-types
 pkcs11js
+plugin-error
 polished
 popper.js
 postcss


### PR DESCRIPTION
This package is needed for `gulp-ttf2woff2` typings ( https://github.com/DefinitelyTyped/DefinitelyTyped/pull/57152 ).