### PR TITLE
Allow @types/ltx for DTS package.json deps

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -278,6 +278,7 @@
 @types/ink
 @types/js-data
 @types/leaflet
+@types/ltx
 @types/mkdirp-promise
 @types/mongodb
 @types/mongoose


### PR DESCRIPTION
Allow @types/ltx to be able to reference older versions of typings. See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/57240.