### PR TITLE
Add+Ship 4.6, deprecate 3.7

### DIFF
--- a/packages/header-parser/test/index.test.ts
+++ b/packages/header-parser/test/index.test.ts
@@ -40,7 +40,7 @@ describe("parse", () => {
       libraryName: "foo",
       libraryMajorVersion: 1,
       libraryMinorVersion: 2,
-      typeScriptVersion: "3.7",
+      typeScriptVersion: "3.8",
       nonNpm: false,
       projects: ["https://github.com/foo/foo", "https://foo.com"],
       contributors: [
@@ -65,7 +65,7 @@ describe("parse", () => {
       libraryName: "foo",
       libraryMajorVersion: 1,
       libraryMinorVersion: 2,
-      typeScriptVersion: "3.7",
+      typeScriptVersion: "3.8",
       nonNpm: false,
       projects: ["https://github.com/foo/foo", "https://foo.com"],
       contributors: [
@@ -147,11 +147,11 @@ describe("isSupported", () => {
   it("works", () => {
     expect(TypeScriptVersion.isSupported("4.1")).toBeTruthy();
   });
-  it("supports 3.7", () => {
-    expect(TypeScriptVersion.isSupported("3.7")).toBeTruthy();
+  it("supports 3.8", () => {
+    expect(TypeScriptVersion.isSupported("3.8")).toBeTruthy();
   });
-  it("does not support 3.6", () => {
-    expect(!TypeScriptVersion.isSupported("3.6")).toBeTruthy();
+  it("does not support 3.7", () => {
+    expect(!TypeScriptVersion.isSupported("3.7")).toBeTruthy();
   });
 });
 
@@ -169,10 +169,10 @@ describe("isTypeScriptVersion", () => {
 
 describe("range", () => {
   it("works", () => {
-    expect(TypeScriptVersion.range("4.0")).toEqual(["4.0", "4.1", "4.2", "4.3", "4.4", "4.5"]);
+    expect(TypeScriptVersion.range("4.0")).toEqual(["4.0", "4.1", "4.2", "4.3", "4.4", "4.5", "4.6"]);
   });
-  it("includes 3.7 onwards", () => {
-    expect(TypeScriptVersion.range("3.7")).toEqual(TypeScriptVersion.supported);
+  it("includes 3.8 onwards", () => {
+    expect(TypeScriptVersion.range("3.8")).toEqual(TypeScriptVersion.supported);
   });
 });
 
@@ -186,11 +186,12 @@ describe("tagsToUpdate", () => {
       "ts4.3",
       "ts4.4",
       "ts4.5",
+      "ts4.6",
       "latest"
     ]);
   });
-  it("allows 3.7 onwards", () => {
-    expect(TypeScriptVersion.tagsToUpdate("3.7")).toEqual(
+  it("allows 3.8 onwards", () => {
+    expect(TypeScriptVersion.tagsToUpdate("3.8")).toEqual(
       TypeScriptVersion.supported.map(s => "ts" + s).concat("latest")
     );
   });

--- a/packages/publisher/test/generate-packages.test.ts
+++ b/packages/publisher/test/generate-packages.test.ts
@@ -133,7 +133,7 @@ testo({
         "balzac": "~3"
     },
     "typesPublisherContentHash": "11",
-    "typeScriptVersion": "3.7"
+    "typeScriptVersion": "3.8"
 }`);
   },
   githubPackageJsonName() {

--- a/packages/typescript-versions/src/index.ts
+++ b/packages/typescript-versions/src/index.ts
@@ -43,20 +43,21 @@ export type UnsupportedTypeScriptVersion =
   | "3.3"
   | "3.4"
   | "3.5"
-  | "3.6";
+  | "3.6"
+  | "3.7";
 /**
  * Parseable and supported TypeScript versions.
  * Only add to this list if we will support this version on DefinitelyTyped.
  */
-export type TypeScriptVersion = "3.7" | "3.8" | "3.9" | "4.0" | "4.1" | "4.2" | "4.3" | "4.4" | "4.5";
+export type TypeScriptVersion = "3.8" | "3.9" | "4.0" | "4.1" | "4.2" | "4.3" | "4.4" | "4.5" | "4.6";
 
 export type AllTypeScriptVersion = UnsupportedTypeScriptVersion | TypeScriptVersion;
 
 export namespace TypeScriptVersion {
   /** Add to this list when a version actually ships.  */
-  export const shipped: readonly TypeScriptVersion[] = ["3.7", "3.8", "3.9", "4.0", "4.1", "4.2", "4.3", "4.4"];
+    export const shipped: readonly TypeScriptVersion[] = ["3.8", "3.9", "4.0", "4.1", "4.2", "4.3", "4.4", "4.5"];
   /** Add to this list when a version is available as typescript@next */
-  export const supported: readonly TypeScriptVersion[] = [...shipped, "4.5"];
+  export const supported: readonly TypeScriptVersion[] = [...shipped, "4.6"];
   /** Add to this list when it will no longer be supported on Definitely Typed */
   export const unsupported: readonly UnsupportedTypeScriptVersion[] = [
     "2.0",
@@ -75,7 +76,8 @@ export namespace TypeScriptVersion {
     "3.3",
     "3.4",
     "3.5",
-    "3.6"
+    "3.6",
+    "3.7"
   ];
   export const all: readonly AllTypeScriptVersion[] = [...unsupported, ...supported];
   export const lowest = supported[0];


### PR DESCRIPTION
I missed adding 4.6 at the beginning of the RC, so this adds it and ships it in the same commit.