### PR TITLE
add redis as an allowed dependency

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -488,6 +488,7 @@ react-navigation
 react-popper
 recast
 recharts
+redis
 redux
 redux-logic
 redux-observable


### PR DESCRIPTION
redis 4.x ships its own types, so this is prep for removing it from DT