### PR TITLE
Automatically patch a package.json entry onto all object export maps

### DIFF
--- a/packages/definitions-parser/src/lib/definition-parser.ts
+++ b/packages/definitions-parser/src/lib/definition-parser.ts
@@ -270,7 +270,7 @@ async function combineDataForAllTypesVersions(
     globals: getAllUniqueValues<"globals", string>(allTypesVersions, "globals"),
     declaredModules: getAllUniqueValues<"declaredModules", string>(allTypesVersions, "declaredModules"),
     imports: checkPackageJsonImports(packageJson.imports, packageJsonName),
-    exports: checkPackageJsonExports(packageJson.exports, packageJsonName),
+    exports: checkPackageJsonExportsAndAddPJsonEntry(packageJson.exports, packageJsonName),
     type: checkPackageJsonType(packageJson.type, packageJsonName)
   };
 }
@@ -377,7 +377,7 @@ function getTypingDataForSingleTypesVersion(
   };
 }
 
-function checkPackageJsonExports(exports: unknown, path: string) {
+function checkPackageJsonExportsAndAddPJsonEntry(exports: unknown, path: string) {
   if (exports === undefined) return exports;
   if (typeof exports === "string") {
     return exports;
@@ -387,6 +387,9 @@ function checkPackageJsonExports(exports: unknown, path: string) {
   }
   if (exports === null) {
     throw new Error(`Package exports at path ${path} should not be null.`);
+  }
+  if (!(exports as Record<string, unknown>)["./package.json"]) {
+    (exports as Record<string, unknown>)["./package.json"] = "./package.json";
   }
   return exports;
 }


### PR DESCRIPTION
Some ecosystem packages unconditionally `require` a package's `package.json`, which throws if it's not exported in an export map. While a bundler has no good reason to be inspecting an `@types` package, so we really shouldn't need to be providing a `package.json` entrypoint, including the mapping should fix issues like [this one](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/57235#issuecomment-979829788).