### PR TITLE
Make new packages public

### DIFF
--- a/packages/dts-critic/package.json
+++ b/packages/dts-critic/package.json
@@ -3,6 +3,9 @@
     "version": "0.0.95-next.0",
     "author": "Nathan Shively-Sanders",
     "description": "Checks a new .d.ts against the Javascript source and tells you what problems it has",
+    "publishConfig": {
+        "access": "public"
+    },
     "dependencies": {
         "@definitelytyped/header-parser": "latest",
         "command-exists": "^1.2.8",

--- a/packages/dtslint/package.json
+++ b/packages/dtslint/package.json
@@ -10,6 +10,9 @@
   ],
   "main": "bin",
   "bin": "./bin/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "contributors": [
     "Nathan Shively-Sanders <nathansa@microsoft.com> (https://github.com/sandersn)",
     "Andy Hanson <andy-ms@microsoft.com> (https://github.com/andy-ms)",


### PR DESCRIPTION
The other packages have publishConfig setting access: "public", and I think this will correct the lerna problem.