### PR TITLE
Fix dtslint build again

### DIFF
--- a/packages/definitions-parser/src/lib/settings.ts
+++ b/packages/definitions-parser/src/lib/settings.ts
@@ -26,7 +26,7 @@ export const getAllowedPackageJsonDependencies = withCache(60 * 60 * 1000, () =>
       } catch (err) {
         console.error(
           "Getting the latest allowedPackageJsonDependencies.txt from GitHub failed. Falling back to local copy.\n" +
-            err.message
+            (err as Error).message
         );
       }
     }

--- a/packages/dts-critic/develop.ts
+++ b/packages/dts-critic/develop.ts
@@ -169,7 +169,7 @@ function doCheck(args: {
     const errors = dtsCritic(dtsPath, /* sourcePath */ undefined, opts, args.debug);
     return { package: args.package, output: errors };
   } catch (e) {
-    return { package: args.package, output: e.toString() };
+    return { package: args.package, output: (e as Error).toString() };
   }
 }
 

--- a/packages/dts-critic/index.test.ts
+++ b/packages/dts-critic/index.test.ts
@@ -1,3 +1,4 @@
+/// <reference types="jest" />
 import {
   findDtsName,
   getNpmInfo,

--- a/packages/dts-critic/index.ts
+++ b/packages/dts-critic/index.ts
@@ -309,9 +309,6 @@ export function findDtsName(dtsPath: string) {
   return path.basename(path.dirname(resolved));
 }
 
-/** Default path to store packages downloaded from npm. */
-const sourceDir = path.resolve(path.join(__dirname, "..", "sources"));
-
 /** Returns path of downloaded npm package. */
 function downloadNpmPackage(name: string, version: string, outDir: string): string {
   const npmName = dtToNpmName(name);

--- a/packages/dts-critic/package.json
+++ b/packages/dts-critic/package.json
@@ -33,7 +33,7 @@
     "types": "dist/index.d.ts",
     "scripts": {
         "test": "npm run build && jest",
-        "build": "tsc",
+        "build": "tsc -b .",
         "dt": "node dist/dt.js",
         "prepublishOnly": "npm run build && npm run test"
     },

--- a/packages/dts-critic/tsconfig.json
+++ b/packages/dts-critic/tsconfig.json
@@ -6,6 +6,7 @@
     "resolveJsonModule": true,
     "outDir": "dist",
     "declaration": true,
+    "types": ["jest"]
   },
   "exclude": [
     "dist/*",

--- a/packages/dtslint/package.json
+++ b/packages/dtslint/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "watch": "tsc --watch",
-    "build": "tsc",
+    "build": "tsc -b .",
     "lint": "eslint --ext ts src",
     "test": "npm run build && node test/test.js",
     "prepublishOnly": "npm run build && npm run test && npm run lint"

--- a/packages/dtslint/src/rules/noUnnecessaryGenericsRule.ts
+++ b/packages/dtslint/src/rules/noUnnecessaryGenericsRule.ts
@@ -89,7 +89,7 @@ function getSoleUse(sig: ts.SignatureDeclaration, typeParameterSymbol: ts.Symbol
 
   return soleUse ? { type: "sole", soleUse } : { type: "never" };
 
-  function recur(node: ts.TypeNode): void {
+  function recur(node: ts.Node): void {
     if (ts.isIdentifier(node)) {
       if (checker.getSymbolAtLocation(node) === typeParameterSymbol) {
         if (soleUse === undefined) {

--- a/packages/dtslint/src/suggestions.ts
+++ b/packages/dtslint/src/suggestions.ts
@@ -47,7 +47,7 @@ export function addSuggestion<T>(ctx: WalkContext<T>, message: string, start?: n
       { flag, encoding: "utf8" }
     );
   } catch (e) {
-    console.log(`Could not write suggestions for package ${packageName}. ${e.message || ""}`);
+    console.log(`Could not write suggestions for package ${packageName}. ${(e as Error).message || ""}`);
   }
 }
 

--- a/packages/publisher/src/publish-packages.ts
+++ b/packages/publisher/src/publish-packages.ts
@@ -43,7 +43,7 @@ if (!module.parent) {
         );
       } catch (e) {
         // log and continue
-        log("publishing to github failed: " + e.toString());
+        log("publishing to github failed: " + (e as Error).toString());
       }
       await deprecateNotNeededPackage(
         await NpmPublishClient.create(await getSecret(Secret.NPM_TOKEN), undefined, Registry.NPM),
@@ -89,7 +89,7 @@ export default async function publishPackages(
       await publishTypingsPackage(ghClient, cp, dry, log, Registry.Github);
     } catch (e) {
       // log and continue
-      log("publishing to github failed: " + e.toString());
+      log("publishing to github failed: " + (e as Error).toString());
     }
     await publishTypingsPackage(client, cp, dry, log, Registry.NPM);
 
@@ -179,7 +179,7 @@ export default async function publishPackages(
           await publishNotNeededPackage(ghClient, target, dry, log, Registry.Github);
         } catch (e) {
           // log and continue
-          log("publishing to github failed: " + e.toString());
+          log("publishing to github failed: " + (e as Error).toString());
         }
         await publishNotNeededPackage(client, target, dry, log, Registry.NPM);
       }

--- a/packages/publisher/src/publish-registry.ts
+++ b/packages/publisher/src/publish-registry.ts
@@ -83,7 +83,7 @@ export default async function publishRegistry(
     await publishToRegistry(RegistryName.Github);
   } catch (e) {
     // log and continue
-    log("publishing to github failed: " + e.toString());
+    log("publishing to github failed: " + (e as Error).toString());
   }
   await publishToRegistry(RegistryName.NPM);
   await writeLog("publish-registry.md", logResult());

--- a/packages/utils/src/process.ts
+++ b/packages/utils/src/process.ts
@@ -161,7 +161,7 @@ export function runWithListeningChildProcesses<In extends Serializable>({
             }
           }
         } catch (e) {
-          onError(e);
+          onError(e as Error);
         }
       };
 
@@ -218,7 +218,7 @@ export function runWithListeningChildProcesses<In extends Serializable>({
               assert.fail(`${processIndex}> Unexpected crashRecoveryState: ${crashRecoveryState}`);
           }
         } catch (e) {
-          onError(e);
+          onError(e as Error);
         }
       };
 
@@ -233,7 +233,7 @@ export function runWithListeningChildProcesses<In extends Serializable>({
           child = fork(workerFile, commandLineArgs, { cwd, execArgv: await getChildProcessExecArgv(i, execArgv) });
           runningChildren.add(child);
         } catch (e) {
-          fail(e);
+          fail(e as Error);
           return;
         }
 
@@ -262,7 +262,7 @@ export function runWithListeningChildProcesses<In extends Serializable>({
           child.on("error", onError);
           taskAction();
         } catch (e) {
-          onError(e);
+          onError(e as Error);
         }
       };
 
@@ -279,7 +279,7 @@ export function runWithListeningChildProcesses<In extends Serializable>({
           child.removeAllListeners();
           child.kill();
         } catch (e) {
-          onError(e);
+          onError(e as Error);
         }
       };
 
@@ -290,7 +290,7 @@ export function runWithListeningChildProcesses<In extends Serializable>({
           stopChild(/*done*/ false);
           await startChild(taskAction, execArgv);
         } catch (e) {
-          onError(e);
+          onError(e as Error);
         }
       };
 
@@ -299,7 +299,7 @@ export function runWithListeningChildProcesses<In extends Serializable>({
           assert(runningChildren.has(child), `${processIndex}> Child not running`);
           child.send(currentInput);
         } catch (e) {
-          onError(e);
+          onError(e as Error);
         }
       };
 
@@ -313,7 +313,7 @@ export function runWithListeningChildProcesses<In extends Serializable>({
           }
           child.send(currentInput);
         } catch (e) {
-          onError(e);
+          onError(e as Error);
         }
       };
 


### PR DESCRIPTION
1. Use Error casts instead of type annotations to any.
2. Somehow stricter settings didn't apply to dtslint before.
3. Use tsc -b . in dtslint and dts-critic's `build` script.
4. Manually triple-slash reference jest in dts-critic's tests.