### PR TITLE
allow exactOptionalPropertyTypes in DT tsconfigs

### DIFF
--- a/packages/dtslint/src/checks.ts
+++ b/packages/dtslint/src/checks.ts
@@ -3,8 +3,9 @@ import { TypeScriptVersion } from "@definitelytyped/typescript-versions";
 import assert = require("assert");
 import { pathExists } from "fs-extra";
 import { join as joinPaths } from "path";
+import { CompilerOptions } from "typescript";
 
-import { getCompilerOptions, readJson } from "./util";
+import { readJson } from "./util";
 
 export async function checkPackageJson(dirPath: string, typesVersions: readonly TypeScriptVersion[]): Promise<void> {
   const pkgJsonPath = joinPaths(dirPath, "package.json");
@@ -59,9 +60,7 @@ export interface DefinitelyTypedInfo {
   /** "../" or "../../" or "../../../". This should use '/' even on windows. */
   readonly relativeBaseUrl: string;
 }
-export async function checkTsconfig(dirPath: string, dt: DefinitelyTypedInfo | undefined): Promise<void> {
-  const options = await getCompilerOptions(dirPath);
-
+export function checkTsconfig(options: CompilerOptions, dt: DefinitelyTypedInfo | undefined): void {
   if (dt) {
     const { relativeBaseUrl } = dt;
 
@@ -78,7 +77,7 @@ export async function checkTsconfig(dirPath: string, dt: DefinitelyTypedInfo | u
       const expected = mustHave[key];
       const actual = options[key];
       if (!deepEquals(expected, actual)) {
-        throw new Error(`Expected compilerOptions[${JSON.stringify(key)}] === ${JSON.stringify(expected)}`);
+        throw new Error(`Expected compilerOptions[${JSON.stringify(key)}] === ${JSON.stringify(expected)}, but got ${JSON.stringify(actual)}`);
       }
     }
 
@@ -96,14 +95,15 @@ export async function checkTsconfig(dirPath: string, dt: DefinitelyTypedInfo | u
         case "allowSyntheticDefaultImports":
           // Allow any value
           break;
-        case "target":
         case "paths":
+          // OK. "paths" checked further by types-publisher
+        case "target":
         case "jsx":
         case "jsxFactory":
         case "experimentalDecorators":
         case "noUnusedLocals":
         case "noUnusedParameters":
-          // OK. "paths" checked further by types-publisher
+        case "exactOptionalPropertyTypes":
           break;
         default:
           if (!(key in mustHave)) {
@@ -132,6 +132,11 @@ export async function checkTsconfig(dirPath: string, dt: DefinitelyTypedInfo | u
       if (!(key in options)) {
         throw new Error(`Expected \`"${key}": true\` or \`"${key}": false\`.`);
       }
+    }
+  }
+  if ("exactOptionalPropertyTypes" in options) {
+    if (options.exactOptionalPropertyTypes !== true) {
+      throw new Error('When "exactOptionalPropertyTypes" is present, it must be set to `true`.');
     }
   }
 

--- a/packages/dtslint/src/checks.ts
+++ b/packages/dtslint/src/checks.ts
@@ -82,7 +82,6 @@ export function checkTsconfig(options: CompilerOptions, dt: DefinitelyTypedInfo 
     }
 
     for (const key in options) {
-      // tslint:disable-line forin
       switch (key) {
         case "lib":
         case "noImplicitAny":
@@ -93,10 +92,7 @@ export function checkTsconfig(options: CompilerOptions, dt: DefinitelyTypedInfo 
         case "strictFunctionTypes":
         case "esModuleInterop":
         case "allowSyntheticDefaultImports":
-          // Allow any value
-          break;
         case "paths":
-          // OK. "paths" checked further by types-publisher
         case "target":
         case "jsx":
         case "jsxFactory":

--- a/packages/dtslint/src/index.ts
+++ b/packages/dtslint/src/index.ts
@@ -9,7 +9,7 @@ import { basename, dirname, join as joinPaths, resolve } from "path";
 import { cleanTypeScriptInstalls, installAllTypeScriptVersions, installTypeScriptNext } from "@definitelytyped/utils";
 import { checkPackageJson, checkTsconfig } from "./checks";
 import { checkTslintJson, lint, TsVersion } from "./lint";
-import { mapDefinedAsync, withoutPrefix } from "./util";
+import { getCompilerOptions, mapDefinedAsync, withoutPrefix } from "./util";
 
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
@@ -221,8 +221,8 @@ async function testTypesVersion(
   isLatest: boolean
 ): Promise<void> {
   await checkTslintJson(dirPath, dt);
-  await checkTsconfig(
-    dirPath,
+  checkTsconfig(
+    await getCompilerOptions(dirPath),
     dt ? { relativeBaseUrl: ".." + (isOlderVersion ? "/.." : "") + (isLatest ? "" : "/..") + "/" } : undefined
   );
   const err = await lint(dirPath, lowVersion, hiVersion, isLatest, expectOnly, tsLocal);


### PR DESCRIPTION
Also add unit tests to dtslint for the first time ever.

I'm not sure it makes sense to allow any other flags, and eventually exactOptionalPropertyTypes should be required.

Fixes part of microsoft/dtslint#348