### PR TITLE
add @types/redis to whitelist for backwards compatibility

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -288,6 +288,7 @@
 @types/react-native-tab-view
 @types/react-navigation
 @types/react-select
+@types/redis
 @types/rsmq
 @types/socket.io
 @types/socket.io-client


### PR DESCRIPTION
For DefinitelyTyped/DefinitelyTyped#57611 we need to whitelist this so older packages can remain dependent on the old redis types after we remove them.