### PR TITLE
Whitelist `@types/webpack-dev-middleware`

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -296,6 +296,7 @@
 @types/vue
 @types/webdriverio
 @types/webpack
+@types/webpack-dev-middleware
 @types/winston
 @types/wonder-commonlib
 @types/wonder-frp


### PR DESCRIPTION
No clean removal path on DT, different versions supported in dependant
modules:
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/57754

Thanks!