### PR TITLE
whitelist '@types/webpack-dev-server'

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -297,6 +297,7 @@
 @types/webdriverio
 @types/webpack
 @types/webpack-dev-middleware
+@types/webpack-dev-server
 @types/winston
 @types/wonder-commonlib
 @types/wonder-frp


### PR DESCRIPTION
Required to cleanly handle `webpack-dev-server` 4.7.0 changes:
DefinitelyTyped/DefinitelyTyped#57808

Thanks!