### PR TITLE
White-list 'express-rate-limit'

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -268,6 +268,7 @@
 @types/base-x
 @types/expect
 @types/express-handlebars
+@types/express-rate-limit
 @types/express-serve-static-core
 @types/firebase
 @types/got


### PR DESCRIPTION
Required for v3 (older) support when removing from DT:
DefinitelyTyped/DefinitelyTyped#57847

Thanks!