### PR TITLE
Allow `@glimmer/interfaces` in DT types

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -13,6 +13,7 @@
 @emotion/react
 @emotion/serialize
 @emotion/styled
+@glimmer/interfaces
 @hapi/boom
 @hapi/iron
 @hapi/podium


### PR DESCRIPTION
Correctly supporting Ember v4 types takes a dependency on this package for a couple key APIs.