### PR TITLE
whitelist '@vue/reactivity' in allowed package json dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -305,6 +305,7 @@
 @types/wonder-commonlib
 @types/wonder-frp
 @uirouter/angularjs
+@vue/reactivity
 @vue/test-utils
 @wordpress/api-fetch
 @wordpress/element


### PR DESCRIPTION
required for types of alpinejs in DT:
DefinitelyTyped/DefinitelyTyped#58130