### PR TITLE
add vanillajs-datepicker to allowedPackageJsonDependencies.txt

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -540,6 +540,7 @@ typescript
 typescript-tuple
 unified
 utility-types
+vanillajs-datepicker
 vega-typings
 vfile
 vfile-message


### PR DESCRIPTION
Adds vanillajs-datepicker to allowedPackageJsonDependencies.txt.

Required for DefinitelyTyped/DefinitelyTyped#58166.