### PR TITLE
Document banned npm names

### DIFF
--- a/packages/dtslint/src/index.ts
+++ b/packages/dtslint/src/index.ts
@@ -248,6 +248,15 @@ function assertPathIsInDefinitelyTyped(dirPath: string): void {
   }
 }
 
+/**
+ * Starting at some point in time, npm has banned all new packages whose names
+ * contain the word `download`. However, some older packages exist that still
+ * contain this name.
+ * @NOTE for contributors: The list of literal exceptions below should ONLY be
+ * extended with packages for which there already exists a corresponding type
+ * definition package in the `@types` scope. More information:
+ * https://github.com/microsoft/dtslint/pull/351.
+ */
 function assertPathIsNotBanned(dirPath: string) {
   const basedir = basename(dirPath);
   if (

--- a/packages/dtslint/src/index.ts
+++ b/packages/dtslint/src/index.ts
@@ -255,7 +255,7 @@ function assertPathIsInDefinitelyTyped(dirPath: string): void {
  * @NOTE for contributors: The list of literal exceptions below should ONLY be
  * extended with packages for which there already exists a corresponding type
  * definition package in the `@types` scope. More information:
- * https://github.com/microsoft/dtslint/pull/351.
+ * https://github.com/microsoft/DefinitelyTyped-tools/pull/381.
  */
 function assertPathIsNotBanned(dirPath: string) {
   const basedir = basename(dirPath);


### PR DESCRIPTION
See also https://github.com/microsoft/dtslint/pull/349 and https://github.com/microsoft/dtslint/pull/350. As soon as an official decision for this issue exists, that should be referenced in the docs as well.

Cherry-picked from https://github.com/microsoft/dtslint/pull/351.