### PR TITLE
testDependencies omits entries from 'declare module'

### DIFF
--- a/packages/definitions-parser/src/lib/definition-parser.ts
+++ b/packages/definitions-parser/src/lib/definition-parser.ts
@@ -1,6 +1,6 @@
 import * as ts from "typescript";
 import { parseHeaderOrFail } from "@definitelytyped/header-parser";
-import { allReferencedFiles, createSourceFile, getModuleInfo, getTestDependencies } from "./module-info";
+import { allReferencedFiles, createSourceFile, getModuleInfo, getTestDependencies, rootName } from "./module-info";
 import {
   DependencyVersion,
   formatTypingVersion,
@@ -340,11 +340,11 @@ function getTypingDataForSingleTypesVersion(
   }
 
   const { dependencies: dependenciesWithDeclaredModules, globals, declaredModules } = getModuleInfo(packageName, types);
-  const declaredModulesSet = new Set(declaredModules);
+  const declaredRootModules = new Set(declaredModules.map(m => rootName(m, types, packageName)));
   // Don't count an import of "x" as a dependency if we saw `declare module "x"` somewhere.
-  const dependenciesSet = new Set(filter(dependenciesWithDeclaredModules, m => !declaredModulesSet.has(m)));
+  const dependenciesSet = new Set(filter(dependenciesWithDeclaredModules, m => !declaredRootModules.has(m)));
   const testDependencies = Array.from(
-    filter(getTestDependencies(packageName, types, tests.keys(), dependenciesSet, fs), m => !declaredModulesSet.has(m))
+    filter(getTestDependencies(packageName, types, tests.keys(), dependenciesSet, fs), m => !declaredRootModules.has(m))
   );
 
   const { paths } = tsconfig.compilerOptions;

--- a/packages/definitions-parser/src/lib/module-info.ts
+++ b/packages/definitions-parser/src/lib/module-info.ts
@@ -127,7 +127,7 @@ function properModuleName(folderName: string, fileName: string): string {
  * "bar/v3" because referencing old versions of *other* packages is illegal;
  * those directories won't exist in the published @types package.
  */
-function rootName(importText: string, typeFiles: Map<string, unknown>, packageName: string): string {
+export function rootName(importText: string, typeFiles: Map<string, unknown>, packageName: string): string {
   let slash = importText.indexOf("/");
   // Root of `@foo/bar/baz` is `@foo/bar`
   if (importText.startsWith("@")) {


### PR DESCRIPTION
The list of declared modules includes deep paths, which I think may be correct for general usage, but not for comparing with the list of dependencies, which must be package names.

Found by @chriskrycho while trying to update Ember's types. I didn't take the time to file a bug since it's pretty simple to write a self-contained test.