### PR TITLE
Forbid adding packages in notNeededPackages.json

### DIFF
--- a/packages/dtslint/src/index.ts
+++ b/packages/dtslint/src/index.ts
@@ -138,6 +138,7 @@ async function runTests(
     // so assert that we're really on DefinitelyTyped.
     assertPathIsInDefinitelyTyped(dirPath);
     assertPathIsNotBanned(dirPath);
+    assertPackageIsNotDeprecated(dirPath, await readFile("../notNeededPackages.json", "utf-8"));
   }
 
   const typesVersions = await mapDefinedAsync(await readdir(dirPath), async name => {
@@ -258,6 +259,16 @@ function assertPathIsNotBanned(dirPath: string) {
   ) {
     // Since npm won't release their banned-words list, we'll have to manually add to this list.
     throw new Error(`${dirPath}: Contains the word 'download', which is banned by npm.`);
+  }
+}
+
+export function assertPackageIsNotDeprecated(dirPath: string, notNeededPackages: string) {
+  const packageName = basename(dirPath)
+  const unneeded = JSON.parse(notNeededPackages).packages
+  if (Object.keys(unneeded).includes(packageName)) {
+    throw new Error(`${dirPath}: notNeededPackages.json has an entry for ${packageName}.
+That means ${packageName} ships its own types, and @types/${packageName} was deprecated and removed from Definitely Typed.
+If you want to re-add @types/${packageName}, please remove its entry from notNeededPackages.json.`);
   }
 }
 

--- a/packages/dtslint/test/index.test.ts
+++ b/packages/dtslint/test/index.test.ts
@@ -3,6 +3,7 @@ import { join } from "path";
 import { consoleTestResultHandler, runTest } from "tslint/lib/test";
 import { existsSync, readdirSync } from "fs";
 import { checkTsconfig } from "../src/checks";
+import { assertPackageIsNotDeprecated } from "../src/index"
 
 const testDir = __dirname;
 
@@ -55,6 +56,14 @@ describe("dtslint", () => {
       expect(() => checkTsconfig({ ...base, exactOptionalPropertyTypes: false }, { relativeBaseUrl: "../" })).toThrow(
         'When "exactOptionalPropertyTypes" is present, it must be set to `true`.'
       );
+    });
+    it("disallows packages that are in notNeededPackages.json", () => {
+      expect(() => assertPackageIsNotDeprecated('types/foo', '{ "packages": { "foo": { } } }')).toThrow(
+        'notNeededPackages.json has an entry for foo.'
+      );
+    });
+    it("allows packages that are not in notNeededPackages.json", () => {
+      expect(assertPackageIsNotDeprecated('types/foo', '{ "packages": { "bar": { } } }')).toBeUndefined()
     });
   });
   describe("rules", () => {


### PR DESCRIPTION
It leaves DT in an inconsistent state, which causes the publisher to assert.