### PR TITLE
Improve unused path mapping error.

### DIFF
--- a/packages/definitions-parser/src/check-parse-results.ts
+++ b/packages/definitions-parser/src/check-parse-results.ts
@@ -79,9 +79,9 @@ function checkTypeScriptVersions(allPackages: AllPackages): void {
   }
 }
 
-function checkPathMappings(allPackages: AllPackages): void {
+export function checkPathMappings(allPackages: AllPackages): void {
   for (const pkg of allPackages.allTypings()) {
-    const unusedPathMappings = new Set(Object.keys(pkg.pathMappings));
+    const unusedPathMappings = new Set(Object.keys(pkg.pathMappings).filter(m => m !== pkg.name && m !== pkg.unescapedName));
 
     // If A depends on B, and B has path mappings, A must have the same mappings.
     for (const dependency of allPackages.allDependencyTypings(pkg)) {
@@ -102,14 +102,12 @@ function checkPathMappings(allPackages: AllPackages): void {
         }
         unusedPathMappings.delete(transitiveDependencyName);
       }
-
       unusedPathMappings.delete(dependency.name);
     }
-
-    for (const unusedPathMapping of unusedPathMappings) {
-      if (pkg.name !== unusedPathMapping && pkg.unescapedName !== unusedPathMapping) {
-        throw new Error(`${pkg.desc} has unused path mapping for ${unusedPathMapping}`);
-      }
+    if (unusedPathMappings.size > 0) {
+      throw new Error(`${pkg.desc} has unused path mappings for [${Array.from(unusedPathMappings).join(", ")}].
+If these mappings are actually used, they could be missing in a dependency's tsconfig.json instead.
+Check the path mappings for [${Array.from(allPackages.allDependencyTypings(pkg)).map(d => d.name).join(", ")}].`);
     }
   }
 }

--- a/packages/definitions-parser/test/check-parse-results.test.ts
+++ b/packages/definitions-parser/test/check-parse-results.test.ts
@@ -1,0 +1,72 @@
+import { checkPathMappings } from "../src/check-parse-results";
+import { TypesDataFile, AllPackages, DirectoryParsedTypingVersion } from "../src/packages";
+import { testo, createTypingsVersionRaw } from "./utils";
+
+/** make a list of mappings, all to version 1 since these tests don't care */
+function makeMappings(...names: string[]) {
+  const o = {} as Record<string, DirectoryParsedTypingVersion>
+  for (const name of names) {
+    o[name] = { major: 1 }
+  }
+  return o
+}
+testo({
+  transitivePathMappingDependencies() {
+    // based on ember's structure, but corrected
+    const typesData: TypesDataFile = {
+      application: createTypingsVersionRaw(
+        "application",
+        { engine: "*", object: "*", routing: "*" },
+        [],
+        makeMappings("engine", 'object', 'routing', 'controller', 'service')),
+      controller: createTypingsVersionRaw("controller", {}, [], {}),
+      engine: createTypingsVersionRaw("engine", {}, [], {}),
+      error: createTypingsVersionRaw("error", {}, [], {}),
+      object: createTypingsVersionRaw("object", {}, [], {}),
+      routing: createTypingsVersionRaw(
+        "routing",
+        { controller: "*", service: "*" },
+        [],
+        makeMappings('controller', 'service')),
+      service: createTypingsVersionRaw("service", {}, [], {}),
+      "test-helper": createTypingsVersionRaw(
+        "test-helper",
+        { application: "*", error: "*" },
+        [],
+    makeMappings('application', 'engine', 'object', 'routing', 'controller', 'service', 'error')),
+};
+    expect(checkPathMappings(AllPackages.from(typesData, []))).toBeUndefined()
+  },
+  /**
+   * test-helper depends on application, which is missing transitive mappings for
+   * controller and service
+   */
+  missingTransitivePathMappingDependencies() {
+    const typesData: TypesDataFile = {
+      application: createTypingsVersionRaw(
+        "application",
+        { engine: "*", object: "*", routing: "*" },
+        [],
+        makeMappings("engine", 'object', 'routing')),
+      controller: createTypingsVersionRaw("controller", {}, [], {}),
+      engine: createTypingsVersionRaw("engine", {}, [], {}),
+      error: createTypingsVersionRaw("error", {}, [], {}),
+      object: createTypingsVersionRaw("object", {}, [], {}),
+      routing: createTypingsVersionRaw(
+        "routing",
+        { controller: "*", service: "*" },
+        [],
+        makeMappings('controller', 'service')),
+      service: createTypingsVersionRaw("service", {}, [], {}),
+      "test-helper": createTypingsVersionRaw(
+        "test-helper",
+        { application: "*", error: "*" },
+        [],
+        makeMappings('application', 'engine', 'object', 'routing', 'controller', 'service', 'error')),
+    };
+    expect(() => checkPathMappings(AllPackages.from(typesData, []))).toThrow(
+      `test-helper has unused path mappings for [controller, service].
+If these mappings are actually used, they could be missing in a dependency's tsconfig.json instead.
+Check the path mappings for [application, error].`)
+  },
+})

--- a/packages/definitions-parser/test/utils.ts
+++ b/packages/definitions-parser/test/utils.ts
@@ -1,4 +1,4 @@
-import { TypingsVersionsRaw, License, DependencyVersion, TypingVersion } from "../src/packages";
+import { TypingsVersionsRaw, License, DependencyVersion, DirectoryParsedTypingVersion } from "../src/packages";
 
 export function testo(o: { [s: string]: () => void }) {
   for (const k of Object.keys(o)) {
@@ -10,7 +10,7 @@ export function createTypingsVersionRaw(
   name: string,
   dependencies: { readonly [name: string]: DependencyVersion },
   testDependencies: string[],
-  pathMappings: { readonly [packageName: string]: TypingVersion }
+  pathMappings: { readonly [packageName: string]: DirectoryParsedTypingVersion }
 ): TypingsVersionsRaw {
   return {
     "1.0": {


### PR DESCRIPTION
1. Report all unused path mappings of the first unused-having package. Previously it was only the first unused path mapping of the first package.
2. Direct the user to check for missing mappings in dependencies in the case of path mappings that aren't actually unused.
3. Tests! Two of them.

Once again discovered while trying to debug ember v4's types.