### PR TITLE
feat(web3): allow web3 to provide type definitions

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -550,6 +550,8 @@ vite
 vue
 vue-router
 vuex
+web3
+web3-core
 webpack
 webpack-chain
 web-tree-sitter


### PR DESCRIPTION
Would like to allow for web3 and Block Number to be used in ethereum-events definition