### PR TITLE
Add `execa` to the allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -379,6 +379,7 @@ eris
 ethers
 eventemitter2
 eventemitter3
+execa
 expect
 express-graphql
 express-rate-limit


### PR DESCRIPTION
In order to update the type declarations of `yeoman-environment`, this PR will add the package `execa` to the allowed dependencies.

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58614