### PR TITLE
Remove jest-environment-puppeteer from expectedFailures.txt

### DIFF
--- a/packages/dtslint-runner/expectedFailures.txt
+++ b/packages/dtslint-runner/expectedFailures.txt
@@ -1,7 +1,6 @@
 electron-clipboard-extended
 electron-notifications
 electron-notify
-jest-environment-puppeteer
 ng-cordova
 redux-orm
 sketchapp


### PR DESCRIPTION
Looks like jest shipped its new version.