### PR TITLE
Add 4.7 to supported versions

### DIFF
--- a/packages/header-parser/test/index.test.ts
+++ b/packages/header-parser/test/index.test.ts
@@ -169,7 +169,7 @@ describe("isTypeScriptVersion", () => {
 
 describe("range", () => {
   it("works", () => {
-    expect(TypeScriptVersion.range("4.0")).toEqual(["4.0", "4.1", "4.2", "4.3", "4.4", "4.5", "4.6"]);
+    expect(TypeScriptVersion.range("4.0")).toEqual(["4.0", "4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7"]);
   });
   it("includes 3.8 onwards", () => {
     expect(TypeScriptVersion.range("3.8")).toEqual(TypeScriptVersion.supported);
@@ -187,6 +187,7 @@ describe("tagsToUpdate", () => {
       "ts4.4",
       "ts4.5",
       "ts4.6",
+      "ts4.7",
       "latest"
     ]);
   });

--- a/packages/typescript-versions/src/index.ts
+++ b/packages/typescript-versions/src/index.ts
@@ -8,20 +8,20 @@ import assert from "assert";
 
   1. Add a new version to the end of `TypeScriptVersion` and `supported`.
   2. Update failing tests.
-  3. Publish and update dependents. Outside the monorepo, current dependents are dtslint, dts-critic.
 
   For the release:
 
   1. Move the newly-released version from `supported` to `shipped`.
   2. Update failing tests.
-  3. Publish and update dependents. (dtslint and dts-critic)
 
   # How to deprecate an old version on Definitely Typed #
 
   1. Move the old version from `TypeScriptVersion` to `UnsupportedTypeScriptVersion`.
   2. Move the old version from `shipped` to `unsupported`.
-  4. Update failing tests.
-  5. Publish and update dependents. (dtslint and dts-critic)
+  3. Update failing tests.
+
+  Currently, it's possible to release a new version and deprecate an old version
+  at the same time because of the way release schedule overlaps.
 
 */
 
@@ -49,7 +49,7 @@ export type UnsupportedTypeScriptVersion =
  * Parseable and supported TypeScript versions.
  * Only add to this list if we will support this version on DefinitelyTyped.
  */
-export type TypeScriptVersion = "3.8" | "3.9" | "4.0" | "4.1" | "4.2" | "4.3" | "4.4" | "4.5" | "4.6";
+export type TypeScriptVersion = "3.8" | "3.9" | "4.0" | "4.1" | "4.2" | "4.3" | "4.4" | "4.5" | "4.6" | "4.7";
 
 export type AllTypeScriptVersion = UnsupportedTypeScriptVersion | TypeScriptVersion;
 
@@ -57,7 +57,7 @@ export namespace TypeScriptVersion {
   /** Add to this list when a version actually ships.  */
   export const shipped: readonly TypeScriptVersion[] = ["3.8", "3.9", "4.0", "4.1", "4.2", "4.3", "4.4", "4.5"];
   /** Add to this list when a version is available as typescript@next */
-  export const supported: readonly TypeScriptVersion[] = [...shipped, "4.6"];
+  export const supported: readonly TypeScriptVersion[] = [...shipped, "4.6", "4.7"];
   /** Add to this list when it will no longer be supported on Definitely Typed */
   export const unsupported: readonly UnsupportedTypeScriptVersion[] = [
     "2.0",


### PR DESCRIPTION
Update the in-source instructions since @definitelytyped now includes dtslint and dts-critic.