### PR TITLE
vivagraphjs: add vivagraphjs npm dependencies with types definition in it

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -454,6 +454,12 @@ msnodesqlv8
 mysql2
 neo4j-driver-lite
 next
+ngraph.events
+ngraph.fromjson
+ngraph.graph
+ngraph.merge
+ngraph.random
+ngraph.tojson
 nock
 node-fetch
 normalize-url


### PR DESCRIPTION
To add @types/vivagraphjs in [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped), these npm dependencies need to be added:

- ngraph.events
- ngraph.fromjson
- ngraph.graph
- ngraph.merge
- ngraph.random
- ngraph.tojson