### PR TITLE
Fix incorrect relative path to notNeededPackages.json

### DIFF
--- a/packages/dtslint/src/index.ts
+++ b/packages/dtslint/src/index.ts
@@ -138,7 +138,7 @@ async function runTests(
     // so assert that we're really on DefinitelyTyped.
     assertPathIsInDefinitelyTyped(dirPath);
     assertPathIsNotBanned(dirPath);
-    assertPackageIsNotDeprecated(dirPath, await readFile("../notNeededPackages.json", "utf-8"));
+    assertPackageIsNotDeprecated(dirPath, await readFile(joinPaths(dirPath, "..", "..", "notNeededPackages.json"), "utf-8"));
   }
 
   const typesVersions = await mapDefinedAsync(await readdir(dirPath), async name => {


### PR DESCRIPTION
Fixes #402 

I think this does fix this particular bug, but - assuming I have built everything correctly in my local env - I now get linting errors that I don't on 0.0.103:

Eg, `npm test through` now gives me a bunch of TypeError chatter, then:
```
ERROR: 3:5  prefer-const  Identifier 'i' is never reassigned; use 'const' instead of 'var'.
```

I don't know if this is expected.