### PR TITLE
Find DT root for path assertions

### DIFF
--- a/packages/dtslint/src/index.ts
+++ b/packages/dtslint/src/index.ts
@@ -138,7 +138,7 @@ async function runTests(
   if (dt) {
     // Someone may have copied text from DefinitelyTyped to their type definition and included a header,
     // so assert that we're really on DefinitelyTyped.
-    const dtRoot = findDTRoot(dirPath)
+    const dtRoot = findDTRoot(dirPath);
     const packageName = basename(dirPath);
     assertPathIsInDefinitelyTyped(dirPath, dtRoot);
     assertPathIsNotBanned(packageName);
@@ -237,9 +237,11 @@ async function testTypesVersion(
 }
 
 function findDTRoot(dirPath: string) {
-  const parent = dirname(dirPath);
-  const types = /^v\d+(\.\d+)?$/.test(basename(dirPath)) ? dirname(parent) : parent;
-  return dirname(types);
+  let path = dirPath;
+  while (basename(path) !== "types" && dirname(path) !== "." && dirname(path) !== "/") {
+    path = dirname(path);
+  }
+  return dirname(path);
 }
 
 function assertPathIsInDefinitelyTyped(dirPath: string, dtRoot: string): void {

--- a/packages/dtslint/src/index.ts
+++ b/packages/dtslint/src/index.ts
@@ -3,7 +3,7 @@
 import { parseTypeScriptVersionLine } from "@definitelytyped/header-parser";
 import { AllTypeScriptVersion, TypeScriptVersion } from "@definitelytyped/typescript-versions";
 import assert = require("assert");
-import { readdir, readFile, stat } from "fs-extra";
+import { readdir, readFile, stat, existsSync } from "fs-extra";
 import { basename, dirname, join as joinPaths, resolve } from "path";
 
 import { cleanTypeScriptInstalls, installAllTypeScriptVersions, installTypeScriptNext } from "@definitelytyped/utils";
@@ -138,9 +138,11 @@ async function runTests(
   if (dt) {
     // Someone may have copied text from DefinitelyTyped to their type definition and included a header,
     // so assert that we're really on DefinitelyTyped.
-    assertPathIsInDefinitelyTyped(dirPath);
-    assertPathIsNotBanned(dirPath);
-    assertPackageIsNotDeprecated(dirPath, await readFile("../notNeededPackages.json", "utf-8"));
+    const dtRoot = findDTRoot(dirPath)
+    const packageName = basename(dirPath);
+    assertPathIsInDefinitelyTyped(dirPath, dtRoot);
+    assertPathIsNotBanned(packageName);
+    assertPackageIsNotDeprecated(packageName, await readFile(joinPaths(dtRoot, "notNeededPackages.json"), "utf-8"));
   }
 
   const typesVersions = await mapDefinedAsync(await readdir(dirPath), async name => {
@@ -234,14 +236,17 @@ async function testTypesVersion(
   }
 }
 
-function assertPathIsInDefinitelyTyped(dirPath: string): void {
+function findDTRoot(dirPath: string) {
   const parent = dirname(dirPath);
   const types = /^v\d+(\.\d+)?$/.test(basename(dirPath)) ? dirname(parent) : parent;
-  // TODO: It's not clear whether this assertion makes sense, and it's broken on Azure Pipelines
+  return dirname(types);
+}
+
+function assertPathIsInDefinitelyTyped(dirPath: string, dtRoot: string): void {
+  // TODO: It's not clear whether this assertion makes sense, and it's broken on Azure Pipelines (perhaps because DT isn't cloned into DefinitelyTyped)
   // Re-enable it later if it makes sense.
-  // const dt = dirname(types);
-  // if (basename(dt) !== "DefinitelyTyped" || basename(types) !== "types") {
-  if (basename(types) !== "types") {
+  // if (basename(dtRoot) !== "DefinitelyTyped")) {
+  if (!existsSync(joinPaths(dtRoot, "types"))) {
     throw new Error(
       "Since this type definition includes a header (a comment starting with `// Type definitions for`), " +
         "assumed this was a DefinitelyTyped package.\n" +
@@ -260,24 +265,22 @@ function assertPathIsInDefinitelyTyped(dirPath: string): void {
  * definition package in the `@types` scope. More information:
  * https://github.com/microsoft/DefinitelyTyped-tools/pull/381.
  */
-function assertPathIsNotBanned(dirPath: string) {
-  const basedir = basename(dirPath);
+function assertPathIsNotBanned(packageName: string) {
   if (
-    /(^|\W)download($|\W)/.test(basedir) &&
-    basedir !== "download" &&
-    basedir !== "downloadjs" &&
-    basedir !== "s3-download-stream"
+    /(^|\W)download($|\W)/.test(packageName) &&
+    packageName !== "download" &&
+    packageName !== "downloadjs" &&
+    packageName !== "s3-download-stream"
   ) {
     // Since npm won't release their banned-words list, we'll have to manually add to this list.
-    throw new Error(`${dirPath}: Contains the word 'download', which is banned by npm.`);
+    throw new Error(`${packageName}: Contains the word 'download', which is banned by npm.`);
   }
 }
 
-export function assertPackageIsNotDeprecated(dirPath: string, notNeededPackages: string) {
-  const packageName = basename(dirPath);
+export function assertPackageIsNotDeprecated(packageName: string, notNeededPackages: string) {
   const unneeded = JSON.parse(notNeededPackages).packages;
   if (Object.keys(unneeded).includes(packageName)) {
-    throw new Error(`${dirPath}: notNeededPackages.json has an entry for ${packageName}.
+    throw new Error(`${packageName}: notNeededPackages.json has an entry for ${packageName}.
 That means ${packageName} ships its own types, and @types/${packageName} was deprecated and removed from Definitely Typed.
 If you want to re-add @types/${packageName}, please remove its entry from notNeededPackages.json.`);
   }

--- a/packages/dtslint/test/index.test.ts
+++ b/packages/dtslint/test/index.test.ts
@@ -58,12 +58,12 @@ describe("dtslint", () => {
       );
     });
     it("disallows packages that are in notNeededPackages.json", () => {
-      expect(() => assertPackageIsNotDeprecated("types/foo", '{ "packages": { "foo": { } } }')).toThrow(
+      expect(() => assertPackageIsNotDeprecated("foo", '{ "packages": { "foo": { } } }')).toThrow(
         "notNeededPackages.json has an entry for foo."
       );
     });
     it("allows packages that are not in notNeededPackages.json", () => {
-      expect(assertPackageIsNotDeprecated("types/foo", '{ "packages": { "bar": { } } }')).toBeUndefined();
+      expect(assertPackageIsNotDeprecated("foo", '{ "packages": { "bar": { } } }')).toBeUndefined();
     });
   });
   describe("rules", () => {


### PR DESCRIPTION
dtslint asserts that a package's path is

1. in a DT-like structure -- one with types and packages inside that
2. not in notNeededPackages.json -- this requires reading it from the DT
root
3. not on a list of names that npm bans for being spammy

This PR calculates the DT root independently for and provides it for (1) and (2). Previously only (1) calculated the root and (2) just assumed that notNeededPackages was in the right location relative to the current working directory.