### PR TITLE
Fix incorrect relative path for package.json

### DIFF
--- a/packages/dtslint/src/index.ts
+++ b/packages/dtslint/src/index.ts
@@ -20,7 +20,7 @@ async function main(): Promise<void> {
   let lookingForTsLocal = false;
   let tsLocal: string | undefined;
 
-  console.log(`dtslint@${require("../package.json").version}`);
+  console.log(`dtslint@${require("../../package.json").version}`);
 
   for (const arg of args) {
     if (lookingForTsLocal) {


### PR DESCRIPTION
This is causing DefinitelyTyped CI builds to fail.

Updating the relative path to match the one used on line 45 fixed this for me locally.

This seems to have been unintentionally been broken in https://github.com/microsoft/DefinitelyTyped-tools/pull/403