### PR TITLE
Add `phenomenon` to the allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -455,6 +455,7 @@ path-to-regexp
 pdfjs-dist
 pg-protocol
 pg-types
+phenomenon
 pkcs11js
 plugin-error
 polished


### PR DESCRIPTION
In order to create the type declarations of `cobe`, this PR will add the package `phenomenon` to the allowed dependencies.

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58852