### PR TITLE
chore: add `@jest/expect`

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -18,6 +18,7 @@
 @hapi/podium
 @hapi/wreck
 @jest/environment
+@jest/expect
 @jest/fake-timers
 @jest/globals
 @jest/reporters


### PR DESCRIPTION
I want to use this to replace `jest.Expect` in `@types/jest` with the version from Jest itself.

This is the module that provides `expect` internally in Jest.

Source: https://github.com/facebook/jest/blob/main/packages/jest-expect/package.json

See https://github.com/facebook/jest/issues/12424