### PR TITLE
Add `stylelint` to the allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -517,6 +517,7 @@ sonic-boom
 source-map
 ssim.js
 styled-components
+stylelint
 svelte
 sw-toolbox
 swagger-parser


### PR DESCRIPTION
In order to create the type declarations of gulp-stylelint, this PR will add the package stylelint to the allowed dependencies.

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58898