### PR TITLE
Add cssnano to the allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -356,6 +356,7 @@ cordova-plugin-file
 cordova-plugin-file-transfer
 cosmiconfig
 cropperjs
+cssnano
 csstype
 cypress
 date-fns


### PR DESCRIPTION
cssnano now ships its own types, so this is setting the infrastructure up to deprecate @types/cssnano by adding `cssnano` to the allowed dependencies.