### PR TITLE
Added `canvas` to the allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -343,9 +343,9 @@ bson
 buffer
 bullmq
 cac
+canvas
 cash-dom
 cassandra-driver
-canvas
 chalk
 chokidar
 ci-info

--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -345,6 +345,7 @@ bullmq
 cac
 cash-dom
 cassandra-driver
+canvas
 chalk
 chokidar
 ci-info


### PR DESCRIPTION
Add `node-canvas` to the allowed dependency list.
Required for this PR [DefinitelyTyped/DefinitelyTyped#59177](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/59177)