### PR TITLE
chore: add ioredis to the allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -417,6 +417,7 @@ immer
 immutable
 indefinite-observable
 inversify
+ioredis
 itty-router
 javascript-obfuscator
 jest-cucumber


### PR DESCRIPTION
ioredis now ships its own types as of v5 (https://github.com/luin/ioredis/wiki/Upgrading-from-v4-to-v5), so ioredis would need to be allowed dependency to reference ioredis in dependent type packages and deprecate @types/ioredis.