### PR TITLE
Add @types/acorn to allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -265,6 +265,7 @@
 @storybook/react
 @testing-library/dom
 @tweenjs/tween.js
+@types/acorn
 @types/anymatch
 @types/autoprefixer
 @types/base-x


### PR DESCRIPTION
https://github.com/DefinitelyTyped/DefinitelyTyped/runs/5853633195?check_suite_focus=true#step:6:13

[acorn](https://www.npmjs.com/package/acorn) contains built-in TypeScript declarations, @types/detective depends on the deprecated DT types.