### PR TITLE
Add @types/hapi to allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -277,6 +277,7 @@
 @types/faker
 @types/firebase
 @types/got
+@types/hapi
 @types/helmet
 @types/highcharts
 @types/highlight.js


### PR DESCRIPTION
https://github.com/DefinitelyTyped/DefinitelyTyped/runs/5854418101?check_suite_focus=true#step:6:13
- [hapi](https://www.npmjs.com/package/hapi) is a deprecated npm package: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/59709
- @types/swagger-node-runner depends on v16 of the DT types.