### PR TITLE
Allow tests to depend on npm packages

### DIFF
--- a/packages/dtslint/src/checks.ts
+++ b/packages/dtslint/src/checks.ts
@@ -38,6 +38,7 @@ export async function checkPackageJson(dirPath: string, typesVersions: readonly 
     switch (key) {
       case "private":
       case "dependencies":
+      case "devDependencies":
       case "license":
       case "imports":
       case "exports":


### PR DESCRIPTION
Should we allow `devDependencies` in `types/*/package.json`? The `package.json` in the DT repo, not the one e.g. generated and published to npm.
- [hapi](https://www.npmjs.com/package/hapi) is a deprecated npm package: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/59709
- `@types/swagger-hapi` doesn't depend on `@types/hapi` but its tests do: https://github.com/DefinitelyTyped/DefinitelyTyped/runs/5856100773?check_suite_focus=true#step:6:425
  ```sh
  npm view @types/swagger-hapi dependencies
  { '@types/swagger-node-runner': '*' } # <- No @types/hapi
  ```
- Adding a "production" dependency on `@types/hapi` to `types/swagger-hapi/package.json` pacifies the DT CI, but would also publish the unnecessary dependency.
- [Adding `devDependencies`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/59709/commits/c63ad3b2e35c7183bca3d95b8f4a90e42af34a11#diff-a724707ba5035978f69d885c80eb31c3c70782b50fd1798aa3453052cfc2886dR2-R4) instead pacifies it without publishing the dependency, because dtslint-runner installs `devDependencies` already, if they were [allowed](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/results?buildId=127397&view=logs&j=8635df7d-ecde-52a7-c7a8-84b998e35690&t=c264d665-0b79-59b7-7e04-9965cbe74860&l=479).
- &therefore; This PR adds `devDependencies` to the list of fields that dtslint allows in `package.json`.

Are `@types/swagger-hapi`'s tests wrong to depend on types that the types themselves do not? I had a look, and testing that the `hapi` and `swagger-hapi` types [are compatible](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/swagger-hapi/swagger-hapi-tests.ts#L2) seems legit?