### PR TITLE
Replace @types/acorn allowed dependency with acorn

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -265,7 +265,6 @@
 @storybook/react
 @testing-library/dom
 @tweenjs/tween.js
-@types/acorn
 @types/anymatch
 @types/autoprefixer
 @types/base-x
@@ -315,6 +314,7 @@
 @wordpress/api-fetch
 @wordpress/element
 abort-controller
+acorn
 actions-on-google
 activex-helpers
 adal-node


### PR DESCRIPTION
- https://github.com/microsoft/DefinitelyTyped-tools/pull/426 added `@types/acorn` for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/59720/commits/a8526bf2c895ace90c8190993d6fb0c558f958b7.
- I've now revised https://github.com/DefinitelyTyped/DefinitelyTyped/pull/59720/commits/70366f810240300c300a2663d13150b57f74d848 to instead depend on Acorn's built-in declarations (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/59720#discussion_r847397166).