### PR TITLE
Default not-needed version

### DIFF
--- a/packages/definitions-parser/src/git.ts
+++ b/packages/definitions-parser/src/git.ts
@@ -151,6 +151,9 @@ Unneeded packages have to be replaced with a package on npm.`
       `Unexpected error: ${unneeded.fullNpmName} is missing the "latest" tag.`
     )
   );
+  if (!unneeded.version) {
+    return;
+  }
   assert(
     unneeded.version.greaterThan(latestTypings),
     `The specified version ${unneeded.version.versionString} of ${unneeded.libraryName} must be newer than the version

--- a/packages/definitions-parser/test/packages.test.ts
+++ b/packages/definitions-parser/test/packages.test.ts
@@ -224,8 +224,6 @@ describe(NotNeededPackage, () => {
       minor: 0,
       patch: 0
     });
-    expect(data.major).toBe(1);
-    expect(data.minor).toBe(0);
     expect(data.isLatest).toBe(true);
     expect(data.isNotNeeded()).toBe(true);
     expect(data.declaredModules).toEqual([]);

--- a/packages/publisher/src/calculate-versions.ts
+++ b/packages/publisher/src/calculate-versions.ts
@@ -102,7 +102,7 @@ async function isAlreadyDeprecated(
   let latestVersion = cachedInfo && assertDefined(cachedInfo.distTags.get("latest"));
   let latestVersionInfo = cachedInfo && latestVersion && assertDefined(cachedInfo.versions.get(latestVersion));
   if (!latestVersionInfo || !latestVersionInfo.deprecated) {
-    log.info(`Version info not cached for deprecated package ${pkg.desc}`);
+    log.info(`Version info not cached for deprecated package ${pkg.name}`);
     const info = assertDefined(await client.fetchAndCacheNpmInfo(pkg.fullEscapedNpmName));
     latestVersion = assertDefined(info.distTags.get("latest"));
     latestVersionInfo = assertDefined(info.versions.get(latestVersion));

--- a/packages/publisher/src/crawl-npm.ts
+++ b/packages/publisher/src/crawl-npm.ts
@@ -7,10 +7,11 @@ import {
   ProgressBar,
   strProgress,
   UncachedNpmInfoClient,
+  getTypes,
   npmRegistry
 } from "@definitelytyped/utils";
 import { defaultLocalOptions } from "./lib/common";
-import { ParseDefinitionsOptions, writeDataFile, packageHasTypes } from "@definitelytyped/definitions-parser";
+import { ParseDefinitionsOptions, writeDataFile } from "@definitelytyped/definitions-parser";
 
 if (!module.parent) {
   logUncaughtErrors(main(defaultLocalOptions));
@@ -24,7 +25,7 @@ async function main(options: ParseDefinitionsOptions): Promise<void> {
   const allTyped = await filterNAtATimeOrdered(
     10,
     all,
-    pkg => packageHasTypes(pkg, client),
+    async pkg => getTypes((await client.fetchRawNpmInfo(pkg))!),
     options.progress
       ? {
           name: "Checking for types...",

--- a/packages/publisher/src/lib/npm.ts
+++ b/packages/publisher/src/lib/npm.ts
@@ -6,10 +6,9 @@ import { Logger, assertDefined, Semver, best, CachedNpmInfoClient } from "@defin
  * So the keys of 'time' give the actual 'latest'.
  * If that's not equal to the expected latest, try again by bumping the patch version of the last attempt by 1.
  */
-export function skipBadPublishes(pkg: NotNeededPackage, client: CachedNpmInfoClient, log: Logger) {
+export function skipBadPublishes(pkg: NotNeededPackage, notNeeded: Semver, client: CachedNpmInfoClient, log: Logger) {
   // because this is called right after isAlreadyDeprecated, we can rely on the cache being up-to-date
   const info = assertDefined(client.getNpmInfoFromCache(pkg.fullEscapedNpmName));
-  const notNeeded = pkg.version;
   const latest = Semver.parse(findActualLatest(info.time));
   if (
     latest.equals(notNeeded) ||
@@ -19,9 +18,9 @@ export function skipBadPublishes(pkg: NotNeededPackage, client: CachedNpmInfoCli
   ) {
     const plusOne = new Semver(latest.major, latest.minor, latest.patch + 1);
     log(`Deprecation of ${notNeeded.versionString} failed, instead using ${plusOne.versionString}.`);
-    return new NotNeededPackage(pkg.name, pkg.libraryName, plusOne.versionString);
+    return plusOne;
   }
-  return pkg;
+  return notNeeded;
 }
 
 function findActualLatest(times: Map<string, string>) {

--- a/packages/publisher/src/lib/package-publisher.ts
+++ b/packages/publisher/src/lib/package-publisher.ts
@@ -28,13 +28,14 @@ export async function publishTypingsPackage(
 export async function publishNotNeededPackage(
   client: NpmPublishClient,
   pkg: NotNeededPackage,
+  version: string,
   dry: boolean,
   log: Logger
 ): Promise<void> {
   log(`Deprecating ${pkg.name}`);
   await common(client, pkg, log, dry);
   // Don't use a newline in the deprecation message because it will be displayed as "\n" and not as a newline.
-  await deprecateNotNeededPackage(client, pkg, dry, log);
+  await deprecateNotNeededPackage(client, pkg, version, dry, log);
 }
 
 async function common(client: NpmPublishClient, pkg: AnyPackage, log: Logger, dry: boolean): Promise<void> {
@@ -46,14 +47,15 @@ async function common(client: NpmPublishClient, pkg: AnyPackage, log: Logger, dr
 export async function deprecateNotNeededPackage(
   client: NpmPublishClient,
   pkg: NotNeededPackage,
+  version: string,
   dry = false,
   log: Logger
 ): Promise<void> {
   const name = pkg.fullNpmName;
   if (dry) {
-    log("(dry) Skip deprecate not needed package " + name + " at " + pkg.version.versionString);
+    log("(dry) Skip deprecate not needed package " + name + " at " + version);
   } else {
-    log(`Deprecating ${name} at ${pkg.version.versionString} with message: ${pkg.deprecatedMessage()}.`);
-    await client.deprecate(name, pkg.version.versionString, pkg.deprecatedMessage());
+    log(`Deprecating ${name} at ${version} with message: ${pkg.deprecatedMessage()}.`);
+    await client.deprecate(name, version, pkg.deprecatedMessage());
   }
 }

--- a/packages/publisher/src/util/util.ts
+++ b/packages/publisher/src/util/util.ts
@@ -8,7 +8,7 @@ export function currentTimeStamp(): string {
 }
 
 export function outputDirectory(pkg: AnyPackage) {
-  return joinPaths(outputDirPath, pkg.desc);
+  return joinPaths(outputDirPath, (pkg as typeof pkg & Record<PropertyKey, never>).desc || pkg.name);
 }
 
 export const numberOfOsProcesses = os.cpus().length;

--- a/packages/publisher/test/generate-packages.test.ts
+++ b/packages/publisher/test/generate-packages.test.ts
@@ -137,7 +137,7 @@ testo({
 }`);
   },
   basicNotNeededPackageJson() {
-    const s = createNotNeededPackageJSON(createUnneededPackage());
+    const s = createNotNeededPackageJSON(createUnneededPackage(), "1.1.1");
     expect(s).toEqual(`{
     "name": "@types/absalom",
     "version": "1.1.1",
@@ -154,7 +154,7 @@ testo({
   },
   scopedNotNeededPackageJson() {
     const scopedUnneeded = new NotNeededPackage("google-cloud__pubsub", "@google-cloud/chubdub", "0.26.0");
-    const s = createNotNeededPackageJSON(scopedUnneeded);
+    const s = createNotNeededPackageJSON(scopedUnneeded, "0.26.0");
     expect(s).toEqual(`{
     "name": "@types/google-cloud__pubsub",
     "version": "0.26.0",

--- a/packages/utils/src/async.ts
+++ b/packages/utils/src/async.ts
@@ -39,7 +39,7 @@ export async function nAtATime<T, U>(
   return results;
 }
 
-export function filter<T>(iterable: Iterable<T>, predicate: (value: T) => boolean): IterableIterator<T> {
+export function filter<T>(iterable: Iterable<T>, predicate: (value: T) => unknown): IterableIterator<T> {
   const iter = iterable[Symbol.iterator]();
   return {
     [Symbol.iterator](): IterableIterator<T> {
@@ -61,10 +61,10 @@ export type Awaitable<T> = T | Promise<T>;
 export async function filterNAtATimeOrdered<T>(
   n: number,
   inputs: readonly T[],
-  shouldKeep: (input: T) => Awaitable<boolean>,
+  shouldKeep: (input: T) => unknown,
   progress?: ProgressOptions<T, boolean>
 ): Promise<T[]> {
-  const shouldKeeps: boolean[] = await nAtATime(n, inputs, shouldKeep, progress);
+  const shouldKeeps: unknown[] = await nAtATime(n, inputs, shouldKeep, progress);
   return inputs.filter((_, idx) => shouldKeeps[idx]);
 }
 


### PR DESCRIPTION
Like https://github.com/microsoft/DefinitelyTyped-tools/pull/142, can we get the not-needed stub version from the npm registry, and leave it out of `notNeededPackages.json`?

What I did was:
- Extract the logic from `check-parse-results.ts` and `crawl-npm.ts` that gets the first version of the target package to contain built-in declarations.
- Use that logic to add a new, `minTypedVersion` field to our cached npm info.
- Make `asOfVersion` optional in `notNeededPackages.json`, and default to the `minTypedVersion` of its `libraryName`.
  That's the desired value: https://github.com/microsoft/types-publisher/pull/415/files#diff-8b7574dd77ee07295cf9fd5da671115eabc66bd7b0996d06e4208c97ff27df90R130
- Move `major`, `minor`, `desc`, and `id`, which depend on `version`, from `PackageBase` -> `TypingsData`.
- Add `version` parameters to `createNotNeededPackageJSON()`, `publishNotNeededPackage()`, and `deprecateNotNeededPackage()`, for the version of the incipient stub.

Already, the version of the incipient stub isn't necessarily `notNeededPackages.json`'s `asOfVersion`: It's the `skipBadPublishes()` version, which is the max of `asOfVersion` and the latest published types version, + 1: https://github.com/microsoft/types-publisher/pull/592/files#diff-ebe506ff86d233c1d2a4ff8cb9c196b74e578fbdef4f6ac5d6fb347202962a93R83

Instead of patching the `NotNeededPackage` instance, first with the default, then in `skipBadPublishes()`, I made `skipBadPublishes()` take and return a version. It takes `asOfVersion` (default: `minTypedVersion`) --- it returns the actual incipient stub version.