### PR TITLE
Type-check some version strings

### DIFF
--- a/packages/definitions-parser/src/lib/definition-parser.ts
+++ b/packages/definitions-parser/src/lib/definition-parser.ts
@@ -43,7 +43,7 @@ function matchesVersion(
   );
 }
 
-function formattedLibraryVersion(typingsDataRaw: TypingsDataRaw) {
+function formattedLibraryVersion(typingsDataRaw: TypingsDataRaw): `${number}.${number}` {
   return `${typingsDataRaw.libraryMajorVersion}.${typingsDataRaw.libraryMinorVersion}`;
 }
 

--- a/packages/definitions-parser/src/mocks.ts
+++ b/packages/definitions-parser/src/mocks.ts
@@ -38,7 +38,7 @@ class DTMock {
    * @param packageName The package of which an old version is to be added.
    * @param olderVersion The older version that's to be added.
    */
-  public addOldVersionOfPackage(packageName: string, olderVersion: string) {
+  public addOldVersionOfPackage(packageName: string, olderVersion: `${number}`) {
     const latestDir = this.pkgDir(mangleScopedPackage(packageName));
     const index = latestDir.get("index.d.ts") as string;
     const latestHeader = parseHeaderOrFail(index);

--- a/packages/publisher/test/generate-packages.test.ts
+++ b/packages/publisher/test/generate-packages.test.ts
@@ -41,10 +41,10 @@ function createRawPackage(license: License): TypingsDataRaw {
 function createTypesData(): TypesDataFile {
   return {
     jquery: {
-      1: createRawPackage(License.MIT)
+      "1.0": createRawPackage(License.MIT)
     },
     madeira: {
-      1: createRawPackage(License.Apache20)
+      "1.0": createRawPackage(License.Apache20)
     }
   };
 }


### PR DESCRIPTION
Adds some static checks: `` `${major}.${minor}` `` is assignable to `` `${number}.${number}` `` whereas `'1'` and other strings aren't.