### PR TITLE
Check for bsdtar explicitly before passing --warning=none

### DIFF
--- a/packages/dts-critic/index.ts
+++ b/packages/dts-critic/index.ts
@@ -321,8 +321,9 @@ function downloadNpmPackage(name: string, version: string, outDir: string): stri
     .replace(/\//, "-");
   const outPath = path.join(outDir, name);
   initDir(outPath);
+  const isBsdTar = cp.execFileSync("tar", ["--version"], cpOpts).includes("bsdtar");
   const args =
-    os.platform() === "darwin"
+    isBsdTar
       ? ["-xz", "-f", tarballName, "-C", outPath]
       : ["-xz", "-f", tarballName, "-C", outPath, "--warning=none"];
   cp.execFileSync("tar", args, cpOpts);

--- a/packages/dts-critic/index.ts
+++ b/packages/dts-critic/index.ts
@@ -1,7 +1,6 @@
 import yargs = require("yargs");
 import headerParser = require("@definitelytyped/header-parser");
 import fs = require("fs");
-import os = require("os");
 import cp = require("child_process");
 import path = require("path");
 import semver = require("semver");


### PR DESCRIPTION
Any OS can pretty much have any tar:

- Windows now ships with bsdtar at `C:\System32\tar.exe`, but people can also get tar while inside cygwin/msys/git-bash, which is likely GNU tar.
- macOS ships with bsdtar too, but it's also possible to install GNU tar via `brew` and replace the system one (like one can replace ssh, python, zsh, etc).
- Linux is effectively always GNU tar, though some distros offer bsdtar as a `bsdtar` executable.

But, there's thankfully only two tar implementations still around, bsdtar and GNU tar, so rather than using the platform, just check which tar is being used before passing `--warning=none`.

`downloadNpmPackage` is not a hot function; it's called only once, so this shouldn't cause any overhead issues.

Previously:

- https://github.com/DefinitelyTyped/dts-critic/issues/30
- https://github.com/DefinitelyTyped/dts-critic/pull/32