### PR TITLE
Registry API no longer needs %2f-encoding

### DIFF
--- a/packages/definitions-parser/src/packages.ts
+++ b/packages/definitions-parser/src/packages.ts
@@ -227,11 +227,6 @@ export abstract class PackageBase {
     return getFullNpmName(this.name);
   }
 
-  /** '@types%2ffoo' for a package 'foo'. */
-  get fullEscapedNpmName(): string {
-    return `@${scopeName}%2f${this.name}`;
-  }
-
   abstract readonly major: number;
   abstract readonly minor: number;
 

--- a/packages/definitions-parser/test/packages.test.ts
+++ b/packages/definitions-parser/test/packages.test.ts
@@ -190,12 +190,6 @@ describe(TypingsData, () => {
       expect(data.fullNpmName).toBe("@types/foo__bar");
     });
   });
-
-  describe("fullEscapedNpmName", () => {
-    it("returns escaped name", () => {
-      expect(data.fullEscapedNpmName).toBe("@types%2fknown");
-    });
-  });
 });
 
 describe(getMangledNameForScopedPackage, () => {

--- a/packages/publisher/src/calculate-versions.ts
+++ b/packages/publisher/src/calculate-versions.ts
@@ -98,12 +98,12 @@ async function isAlreadyDeprecated(
   client: CachedNpmInfoClient,
   log: LoggerWithErrors
 ): Promise<boolean> {
-  const cachedInfo = client.getNpmInfoFromCache(pkg.fullEscapedNpmName);
+  const cachedInfo = client.getNpmInfoFromCache(pkg.fullNpmName);
   let latestVersion = cachedInfo && assertDefined(cachedInfo.distTags.get("latest"));
   let latestVersionInfo = cachedInfo && latestVersion && assertDefined(cachedInfo.versions.get(latestVersion));
   if (!latestVersionInfo || !latestVersionInfo.deprecated) {
     log.info(`Version info not cached for deprecated package ${pkg.desc}`);
-    const info = assertDefined(await client.fetchAndCacheNpmInfo(pkg.fullEscapedNpmName));
+    const info = assertDefined(await client.fetchAndCacheNpmInfo(pkg.fullNpmName));
     latestVersion = assertDefined(info.distTags.get("latest"));
     latestVersionInfo = assertDefined(info.versions.get(latestVersion));
   }

--- a/packages/publisher/src/lib/npm.ts
+++ b/packages/publisher/src/lib/npm.ts
@@ -9,7 +9,7 @@ import * as semver from "semver";
  */
 export function skipBadPublishes(pkg: NotNeededPackage, client: CachedNpmInfoClient, log: Logger) {
   // because this is called right after isAlreadyDeprecated, we can rely on the cache being up-to-date
-  const info = assertDefined(client.getNpmInfoFromCache(pkg.fullEscapedNpmName));
+  const info = assertDefined(client.getNpmInfoFromCache(pkg.fullNpmName));
   const notNeeded = pkg.version;
   const latest = new semver.SemVer(findActualLatest(info.time));
   if (semver.lte(notNeeded, latest)) {

--- a/packages/publisher/src/publish-registry.ts
+++ b/packages/publisher/src/publish-registry.ts
@@ -253,11 +253,9 @@ async function generateRegistry(typings: readonly TypingsData[], client: CachedN
   const entries: { [packageName: string]: { [distTags: string]: string } } = {};
   for (const typing of typings) {
     // Unconditionally use cached info, this should have been set in calculate-versions so should be recent enough.
-    const info = client.getNpmInfoFromCache(typing.fullEscapedNpmName);
+    const info = client.getNpmInfoFromCache(typing.fullNpmName);
     if (!info) {
-      const missings = typings
-        .filter((t) => !client.getNpmInfoFromCache(t.fullEscapedNpmName))
-        .map((t) => t.fullEscapedNpmName);
+      const missings = typings.filter((t) => !client.getNpmInfoFromCache(t.fullNpmName)).map((t) => t.fullNpmName);
       throw new Error(`${missings.toString()} not found in cached npm info.`);
     }
     entries[typing.name] = filterTags(info.distTags);
@@ -284,11 +282,8 @@ interface ProcessedNpmInfo {
   readonly lastModified: Date;
 }
 
-async function fetchAndProcessNpmInfo(
-  escapedPackageName: string,
-  client: UncachedNpmInfoClient
-): Promise<ProcessedNpmInfo> {
-  const info = assertDefined(await client.fetchNpmInfo(escapedPackageName));
+async function fetchAndProcessNpmInfo(packageName: string, client: UncachedNpmInfoClient): Promise<ProcessedNpmInfo> {
+  const info = assertDefined(await client.fetchNpmInfo(packageName));
   const npmVersion = new semver.SemVer(assertDefined(info.distTags.get("latest")));
   const { distTags, versions, time } = info;
   const highestSemverVersion = max(

--- a/packages/retag/src/index.ts
+++ b/packages/retag/src/index.ts
@@ -124,14 +124,14 @@ export async function fetchTypesPackageVersionInfo(
   canPublish: boolean,
   log?: LoggerWithErrors
 ): Promise<{ version: string; needsPublish: boolean }> {
-  let info = client.getNpmInfoFromCache(pkg.fullEscapedNpmName);
+  let info = client.getNpmInfoFromCache(pkg.fullNpmName);
   let latestVersion = info && getHighestVersionForMajor(info.versions, pkg);
   let latestVersionInfo = latestVersion && assertDefined(info!.versions.get(latestVersion));
   if (!latestVersionInfo || latestVersionInfo.typesPublisherContentHash !== pkg.contentHash) {
     if (log) {
       log.info(`Version info not cached for ${pkg.desc}@${latestVersion || "(no latest version)"}`);
     }
-    info = await client.fetchAndCacheNpmInfo(pkg.fullEscapedNpmName);
+    info = await client.fetchAndCacheNpmInfo(pkg.fullNpmName);
     latestVersion = info && getHighestVersionForMajor(info.versions, pkg);
     if (!latestVersion) {
       return { version: `${pkg.major}.${pkg.minor}.0`, needsPublish: true };


### PR DESCRIPTION
I didn't have any luck tracking down when exactly this changed, but the npm registry hasn't needed %2f-encoding for some time, I think? e.g. https://registry.npmjs.org/@types/node

Can we remove the `fullNpmName`/`fullEscapedNpmName` distinction, in view of the similar but unrelated `unescapeName()`: https://github.com/microsoft/DefinitelyTyped-tools/blob/575fd10bc80d3fb50135a429855a3b0864983a95/packages/definitions-parser/src/packages.ts#L203-L204