### PR TITLE
Update tar dependency

### DIFF
--- a/packages/utils/.gitignore
+++ b/packages/utils/.gitignore
@@ -1,1 +1,2 @@
 logs
+test/data/pack.tgz

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -25,13 +25,12 @@
     "charm": "^1.0.2",
     "fs-extra": "^8.1.0",
     "fstream": "^1.0.12",
-    "tar": "^2.2.2",
+    "tar": "^6.1.11",
     "tar-stream": "^2.1.4"
   },
   "devDependencies": {
     "@types/charm": "^1.0.1",
     "@types/fs-extra": "^8.1.0",
-    "@types/tar": "^4.0.3",
     "@types/tar-stream": "^2.1.0"
   },
   "publishConfig": {

--- a/packages/utils/src/types/tar.ts
+++ b/packages/utils/src/types/tar.ts
@@ -1,0 +1,1 @@
+declare module "tar";

--- a/packages/utils/test/data/pack/test.txt
+++ b/packages/utils/test/data/pack/test.txt
@@ -1,0 +1,1 @@
+Test file

--- a/packages/utils/test/io.test.ts
+++ b/packages/utils/test/io.test.ts
@@ -1,0 +1,27 @@
+import path from "path";
+import fs from "fs";
+import { list } from "tar";
+import { createTgz } from "../src/io";
+
+describe("io", () => {
+  describe(createTgz, () => {
+    it("packs a directory", (done) => {
+      const dir = path.join(__dirname, "data", "pack");
+      const archivePath = path.join(__dirname, "data", "pack.tgz");
+
+      createTgz(dir, (err) => {
+        throw err;
+      })
+        .pipe(fs.createWriteStream(archivePath))
+        .on("finish", () => {
+          expect(fs.existsSync(archivePath)).toBe(true);
+          const entries: string[] = [];
+          list({ file: archivePath, onentry: (e) => entries.push(e.path) }, null, () => {
+            expect(entries[0]).toBe("pack/");
+            expect(entries[1]).toBe("pack/test.txt");
+            done();
+          });
+        });
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1809,13 +1809,6 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/minipass@*":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@types/minipass/-/minipass-2.2.0.tgz#51ad404e8eb1fa961f75ec61205796807b6f9651"
-  integrity sha512-wuzZksN4w4kyfoOv/dlpov4NOunwutLA/q7uc00xU02ZyUY+aoM5PWIXEKBMnm0NHd4a+N71BMjq+x7+2Af1fg==
-  dependencies:
-    "@types/node" "*"
-
 "@types/mz@^0.0.31":
   version "0.0.31"
   resolved "https://registry.yarnpkg.com/@types/mz/-/mz-0.0.31.tgz#a4d80c082fefe71e40a7c0f07d1e6555bbbc7b52"
@@ -1935,14 +1928,6 @@
   resolved "https://registry.yarnpkg.com/@types/tar-stream/-/tar-stream-2.1.0.tgz#884b1cbe6c35ff459c05a5eba86b406805943ef6"
   integrity sha512-s1UQxQUVMHbSkCC0X4qdoiWgHF8DoyY1JjQouFsnk/8ysoTdBaiCHud/exoAZzKDbzAXVc+ah6sczxGVMAohFw==
   dependencies:
-    "@types/node" "*"
-
-"@types/tar@^4.0.3":
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/@types/tar/-/tar-4.0.3.tgz#e2cce0b8ff4f285293243f5971bd7199176ac489"
-  integrity sha512-Z7AVMMlkI8NTWF0qGhC4QIX0zkV/+y0J8x7b/RsHrN0310+YNjoJd8UrApCiGBCWtKjxS9QhNqLi2UJNToh5hA==
-  dependencies:
-    "@types/minipass" "*"
     "@types/node" "*"
 
 "@types/tmp@^0.2.0":
@@ -2523,13 +2508,6 @@ bl@^4.0.3:
     buffer "^5.5.0"
     inherits "^2.0.4"
     readable-stream "^3.4.0"
-
-block-stream@*:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
-  integrity sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=
-  dependencies:
-    inherits "~2.0.0"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -8027,15 +8005,6 @@ tar-stream@^2.1.4:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.2.tgz#0ca8848562c7299b8b446ff6a4d60cdbb23edc40"
-  integrity sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==
-  dependencies:
-    block-stream "*"
-    fstream "^1.0.12"
-    inherits "2"
-
 tar@^4.4.12:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
@@ -8049,7 +8018,7 @@ tar@^4.4.12:
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
 
-tar@^6.0.2, tar@^6.1.0:
+tar@^6.0.2, tar@^6.1.0, tar@^6.1.11:
   version "6.1.11"
   resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
   integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==


### PR DESCRIPTION
Updated the old `tar` dependency to the latest version and used its new API.

The `@types/tar` package seems to be incorrect (it shows the old API), so I decided to remove it completely. As the `tar` package is used in just one place, I think it's not a big deal to use the untyped library.

I haven't been able to definitely verify if setting directory permissions still works. 7Zip on Windows shows full permissions on the packed directory, but I haven't checked it on Linux yet.

Closes #347