### PR TITLE
Fix npm dist-tags

### DIFF
--- a/packages/retag/src/index.ts
+++ b/packages/retag/src/index.ts
@@ -147,7 +147,7 @@ export async function fetchTypesPackageVersionInfo(
     );
   }
   const needsPublish = canPublish && pkg.contentHash !== latestVersionInfo.typesPublisherContentHash;
-  return { version: needsPublish ? semver.inc(latestVersion!, "patch")! : `${pkg.major}.${pkg.minor}.0`, needsPublish };
+  return { version: needsPublish ? semver.inc(latestVersion!, "patch")! : latestVersion!, needsPublish };
 }
 
 function getHighestVersionForMajor(


### PR DESCRIPTION
Fixes https://github.com/microsoft/DefinitelyTyped-tools/issues/443#issue-1219123741

This was my fault: https://github.com/microsoft/DefinitelyTyped-tools/pull/436/files#diff-db845ec0d026f55c2d985945bf1ca7668fe32dff8ea2251dc000a7009a3a4bf7R150

Landing this fix and [manually triggering](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) the [Update ts* tags for ATA](https://github.com/microsoft/DefinitelyTyped-tools/actions/workflows/update-ts-version-tags.yml) action will fix the issue and repair npm's tags. Only the tags are affected.