### PR TITLE
Relax not-needed version condition

### DIFF
--- a/packages/definitions-parser/src/check-parse-results.ts
+++ b/packages/definitions-parser/src/check-parse-results.ts
@@ -139,7 +139,7 @@ async function checkNpm(
   log("  yarn not-needed " + yarnargs.join(" "));
   log(`  git add --all && git commit -m "${name}: Provides its own types" && git push -u origin not-needed-${name}`);
   log(`  And comment PR: This will deprecate \`@types/${name}\` in favor of just \`${name}\`. CC ${contributorUrls}`);
-  if (semver.gt(`${major}.${minor}.0`, firstTypedVersion)) {
+  if (semver.gte(`${major}.${minor}.0`, firstTypedVersion)) {
     log("  WARNING: our version is greater!");
   }
   if (dependedOn.has(name)) {

--- a/packages/definitions-parser/test/git.test.ts
+++ b/packages/definitions-parser/test/git.test.ts
@@ -96,32 +96,28 @@ const nonexistentReplacementPackage = new NotNeededPackage("jest", "nonexistent"
 const nonexistentTypesPackage = new NotNeededPackage("nonexistent", "jest", "100.0.0");
 
 testo({
-  missingSource() {
-    return expect(checkNotNeededPackage(nonexistentReplacementPackage)).rejects.toThrow(
-      "The entry for @types/jest in notNeededPackages.json"
-    );
-  },
-  missingTypings() {
+  nonexistentTypesPackage() {
     return expect(checkNotNeededPackage(nonexistentTypesPackage)).rejects.toThrow(
       "@types package not found for @types/nonexistent"
     );
   },
-  deprecatedSameVersion() {
-    return expect(checkNotNeededPackage(sameVersion)).rejects
-      .toThrow(`The specified version 50.0.0 of jest must be newer than the version
-it is supposed to replace, 50.0.0 of @types/jest.`);
+  nonexistentReplacementPackage() {
+    return expect(checkNotNeededPackage(nonexistentReplacementPackage)).rejects.toThrow(
+      "The entry for @types/jest in notNeededPackages.json"
+    );
   },
-  deprecatedOlderVersion() {
-    return expect(checkNotNeededPackage(olderReplacement)).rejects
-      .toThrow(`The specified version 4.0.0 of jest must be newer than the version
-it is supposed to replace, 50.0.0 of @types/jest.`);
-  },
-  missingNpmVersion() {
+  nonexistentReplacementVersion() {
     return expect(checkNotNeededPackage(nonexistentReplacementVersion)).rejects.toThrow(
       "The specified version 999.0.0 of jest is not on npm."
     );
   },
-  ok() {
+  newerReplacement() {
     return checkNotNeededPackage(newerReplacement);
+  },
+  olderReplacement() {
+    return checkNotNeededPackage(olderReplacement);
+  },
+  sameVersion() {
+    return checkNotNeededPackage(sameVersion);
   },
 });


### PR DESCRIPTION
Can we relax this condition (not-need version must be newer than the `@types/package` version)? It [prevents the removal](https://github.com/DefinitelyTyped/DefinitelyTyped/runs/6265402571?check_suite_focus=true#step:6:27) of types that are newer than their target package, and doesn't make a difference to the stub's version, which anyway will be [the max of the not-needed version and the max `@types/package` version + 1](https://github.com/microsoft/DefinitelyTyped-tools/blob/575fd10bc80d3fb50135a429855a3b0864983a95/packages/publisher/src/lib/npm.ts#L15-L16). e.g.
- [AngularUI Router](https://www.npmjs.com/package/angular-ui-router) contains [built-in declarations](https://unpkg.com/angular-ui-router@1.0.30/lib/index.d.ts).
- The [`@types/angular-ui-router` version](https://www.npmjs.com/package/@types/angular-ui-router?activeTab=versions) is 1.1.41.
- None of [`angular-ui-router`'s versions](https://www.npmjs.com/package/angular-ui-router?activeTab=versions) satisfies this condition (is newer than 1.1.41).