### PR TITLE
Add TS4.8 to supported versions

### DIFF
--- a/packages/header-parser/test/index.test.ts
+++ b/packages/header-parser/test/index.test.ts
@@ -169,7 +169,7 @@ describe("isTypeScriptVersion", () => {
 
 describe("range", () => {
   it("works", () => {
-    expect(TypeScriptVersion.range("4.0")).toEqual(["4.0", "4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7"]);
+    expect(TypeScriptVersion.range("4.0")).toEqual(["4.0", "4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7", "4.8"]);
   });
   it("includes 3.8 onwards", () => {
     expect(TypeScriptVersion.range("3.9")).toEqual(TypeScriptVersion.supported);
@@ -188,6 +188,7 @@ describe("tagsToUpdate", () => {
       "ts4.5",
       "ts4.6",
       "ts4.7",
+      "ts4.8",
       "latest",
     ]);
   });

--- a/packages/typescript-versions/src/index.ts
+++ b/packages/typescript-versions/src/index.ts
@@ -50,7 +50,7 @@ export type UnsupportedTypeScriptVersion =
  * Parseable and supported TypeScript versions.
  * Only add to this list if we will support this version on DefinitelyTyped.
  */
-export type TypeScriptVersion = "3.9" | "4.0" | "4.1" | "4.2" | "4.3" | "4.4" | "4.5" | "4.6" | "4.7";
+export type TypeScriptVersion = "3.9" | "4.0" | "4.1" | "4.2" | "4.3" | "4.4" | "4.5" | "4.6" | "4.7" | "4.8";
 
 export type AllTypeScriptVersion = UnsupportedTypeScriptVersion | TypeScriptVersion;
 
@@ -58,7 +58,7 @@ export namespace TypeScriptVersion {
   /** Add to this list when a version actually ships.  */
   export const shipped: readonly TypeScriptVersion[] = ["3.9", "4.0", "4.1", "4.2", "4.3", "4.4", "4.5", "4.6"];
   /** Add to this list when a version is available as typescript@next */
-  export const supported: readonly TypeScriptVersion[] = [...shipped, "4.7"];
+  export const supported: readonly TypeScriptVersion[] = [...shipped, "4.7", "4.8"];
   /** Add to this list when it will no longer be supported on Definitely Typed */
   export const unsupported: readonly UnsupportedTypeScriptVersion[] = [
     "2.0",


### PR DESCRIPTION
For use after typescript's main branch switches to 4.8 at the start of the 4.7 RC period.