### PR TITLE
Add @types/lru-cache to allowedPackageJsonDependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -285,6 +285,7 @@
 @types/ink
 @types/js-data
 @types/leaflet
+@types/lru-cache
 @types/mkdirp-promise
 @types/mongodb
 @types/mongoose


### PR DESCRIPTION
Add @types/lru-cache as lru-cache now declares its own typings and other packages rely on older typings.

see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60297