### PR TITLE
add asn1js as allowed package depenency

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -329,6 +329,7 @@ apollo-client
 apollo-link
 apollo-link-http-common
 arweave
+asn1js
 ast-types
 async-done
 autoprefixer


### PR DESCRIPTION
This package now provides its own typings and is a dependency of other typings. Please see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60315