### PR TITLE
feat: add @mparticle/event-models to allowed packages

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -255,6 +255,7 @@
 @maxim_mazurok/gapi.client.youtubeanalytics
 @maxim_mazurok/gapi.client.youtubereporting
 @middy/core
+@mparticle/event-models
 @popperjs/core
 @rdfjs/types
 @react-navigation/native


### PR DESCRIPTION
In the DefinitelyTyped repository, I added a [draft PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60362) updating typings for the mParticle SDK.  When the tests ran, I received [this error](https://github.com/DefinitelyTyped/DefinitelyTyped/runs/6457645722?check_suite_focus=true#step:6:16) telling me I had to submit a PR to add an package as an allowable dependency in order to use it in the mParticle typings package.json file.