### PR TITLE
Add @npm/types to allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -276,6 +276,7 @@
 @maxim_mazurok/gapi.client.youtubereporting
 @middy/core
 @mparticle/event-models
+@npm/types
 @popperjs/core
 @rdfjs/types
 @react-navigation/native


### PR DESCRIPTION
- `@types/libnpmpublish` [uses the `pacote.Manifest` type](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/1d42fa0682cef252716f061f304ec69de88d5464/types/libnpmpublish/index.d.ts#L29) for the publish() argument although `libnpmpublish` doesn't require a `dist` field: The argument can be a parsed package.json.
- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60433 makes additional `pacote.Manifest` fields required ([`_id`, `_nodeVersion`, etc.](https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md#:~:text=each%20package%20version%20data%20object%20contains%20all%20of%20the%20fields%20in%20the%20abbreviated%20document%2C%20plus%20the%20fields%20listed%20above%20as%20hosted%2C%20plus%20at%20least%20the%20following%3A)).
- To keep the CI passing, it makes `@types/libnpmpublish` use the more accurate `PackageJson` type from [`@npm/types`](https://www.npmjs.com/package/@npm/types) instead of `pacote.Manifest`, so this adds `@npm/types` to `allowedPackageJsonDependencies.txt`.