### PR TITLE
add @khmyznikov/pwa-install package to allowedPackageJsonDependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -25,6 +25,7 @@
 @jest/test-result
 @jest/transform
 @jest/types
+@khmyznikov/pwa-install
 @loadable/component
 @material-ui/core
 @material-ui/types


### PR DESCRIPTION
This package contains a web component. It also contains types for them. But it does't contain (and should not contain by design) types for using this component with react and preact. So, I plan to add extra types for him in @types.