### PR TITLE
Add deprecated field to not-needed package.json

### DIFF
--- a/packages/publisher/src/generate-packages.ts
+++ b/packages/publisher/src/generate-packages.ts
@@ -210,20 +210,19 @@ function dependencySemver(dependency: DependencyVersion): string {
   return dependency === "*" ? dependency : "^" + formatTypingVersion(dependency);
 }
 
-export function createNotNeededPackageJSON({ libraryName, license, fullNpmName, version }: NotNeededPackage): string {
+export function createNotNeededPackageJSON(pkg: NotNeededPackage): string {
   const out = {
-    name: fullNpmName,
-    version: String(version),
-    typings: null, // tslint:disable-line no-null-keyword
-    description: `Stub TypeScript definitions entry for ${libraryName}, which provides its own types definitions`,
+    name: pkg.fullNpmName,
+    version: String(pkg.version),
+    description: `Stub TypeScript definitions entry for ${pkg.libraryName}, which provides its own types definitions`,
     main: "",
     scripts: {},
-    author: "",
-    license,
+    license: pkg.license,
     // No `typings`, that's provided by the dependency.
     dependencies: {
-      [libraryName]: "*",
+      [pkg.libraryName]: "*",
     },
+    deprecated: pkg.deprecatedMessage(),
   };
   return JSON.stringify(out, undefined, 4);
 }

--- a/packages/publisher/src/lib/package-publisher.ts
+++ b/packages/publisher/src/lib/package-publisher.ts
@@ -33,27 +33,10 @@ export async function publishNotNeededPackage(
 ): Promise<void> {
   log(`Deprecating ${pkg.name}`);
   await common(client, pkg, log, dry);
-  // Don't use a newline in the deprecation message because it will be displayed as "\n" and not as a newline.
-  await deprecateNotNeededPackage(client, pkg, dry, log);
 }
 
 async function common(client: NpmPublishClient, pkg: AnyPackage, log: Logger, dry: boolean): Promise<void> {
   const packageDir = outputDirectory(pkg);
   const packageJson = await readFileAndWarn("generate", joinPaths(packageDir, "package.json"));
   await client.publish(packageDir, packageJson, dry, log);
-}
-
-export async function deprecateNotNeededPackage(
-  client: NpmPublishClient,
-  pkg: NotNeededPackage,
-  dry = false,
-  log: Logger
-): Promise<void> {
-  const name = pkg.fullNpmName;
-  if (dry) {
-    log("(dry) Skip deprecate not needed package " + name + " at " + pkg.version);
-  } else {
-    log(`Deprecating ${name} at ${pkg.version} with message: ${pkg.deprecatedMessage()}.`);
-    await client.deprecate(name, String(pkg.version), pkg.deprecatedMessage());
-  }
 }

--- a/packages/publisher/src/publish-packages.ts
+++ b/packages/publisher/src/publish-packages.ts
@@ -2,7 +2,7 @@ import applicationinsights = require("applicationinsights");
 import * as yargs from "yargs";
 
 import { defaultLocalOptions } from "./lib/common";
-import { deprecateNotNeededPackage, publishNotNeededPackage, publishTypingsPackage } from "./lib/package-publisher";
+import { publishNotNeededPackage, publishTypingsPackage } from "./lib/package-publisher";
 import { getDefinitelyTyped, AllPackages } from "@definitelytyped/definitions-parser";
 import {
   loggerWithErrors,
@@ -21,28 +21,14 @@ import { cacheDirPath } from "./lib/settings";
 
 if (!module.parent) {
   const dry = !!yargs.argv.dry;
-  const deprecateName = yargs.argv.deprecate as string | undefined;
   logUncaughtErrors(async () => {
     const dt = await getDefinitelyTyped(defaultLocalOptions, loggerWithErrors()[0]);
-    if (deprecateName !== undefined) {
-      // A '--deprecate' command is available in case types-publisher got stuck *while* trying to deprecate a package.
-      // Normally this should not be needed.
-
-      const log = logger()[0];
-      await deprecateNotNeededPackage(
-        await NpmPublishClient.create(await getSecret(Secret.NPM_TOKEN), undefined),
-        AllPackages.readSingleNotNeeded(deprecateName, dt),
-        /*dry*/ false,
-        log
-      );
-    } else {
-      await publishPackages(
-        await readChangedPackages(await AllPackages.read(dt)),
-        dry,
-        process.env.GH_API_TOKEN || "",
-        new Fetcher()
-      );
-    }
+    await publishPackages(
+      await readChangedPackages(await AllPackages.read(dt)),
+      dry,
+      process.env.GH_API_TOKEN || "",
+      new Fetcher()
+    );
   });
 }
 

--- a/packages/publisher/test/generate-packages.test.ts
+++ b/packages/publisher/test/generate-packages.test.ts
@@ -141,15 +141,14 @@ testo({
     expect(s).toEqual(`{
     "name": "@types/absalom",
     "version": "1.1.1",
-    "typings": null,
     "description": "Stub TypeScript definitions entry for alternate, which provides its own types definitions",
     "main": "",
     "scripts": {},
-    "author": "",
     "license": "MIT",
     "dependencies": {
         "alternate": "*"
-    }
+    },
+    "deprecated": "This is a stub types definition. alternate provides its own type definitions, so you do not need this installed."
 }`);
   },
   scopedNotNeededPackageJson() {
@@ -158,15 +157,14 @@ testo({
     expect(s).toEqual(`{
     "name": "@types/google-cloud__pubsub",
     "version": "0.26.0",
-    "typings": null,
     "description": "Stub TypeScript definitions entry for @google-cloud/chubdub, which provides its own types definitions",
     "main": "",
     "scripts": {},
-    "author": "",
     "license": "MIT",
     "dependencies": {
         "@google-cloud/chubdub": "*"
-    }
+    },
+    "deprecated": "This is a stub types definition. @google-cloud/chubdub provides its own type definitions, so you do not need this installed."
 }`);
   },
 });


### PR DESCRIPTION
Currently we publish and deprecate not-needed stubs in two steps, and frequently the first step succeeds and the second doesn't, e.g. [`@types/asn1js` versions 3.0.0 - 3.0.6](https://www.npmjs.com/package/@types/asn1js?activeTab=versions). By adding the deprecated field to the package.json, this PR will publish and deprecate in a single step, eliminating these "bad publishes".