### PR TITLE
Allow @aws-sdk/client-s3 dependency

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -1,4 +1,5 @@
 @apollo/client
+@aws-sdk/client-s3
 @azure/functions
 @babel/code-frame
 @babel/core


### PR DESCRIPTION
Allow DefinitelyTyped types to depend on @aws-sdk/client-s3. This is to unblock https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60684