### PR TITLE
Fix cache dir path

### DIFF
--- a/packages/utils/src/lib/settings.ts
+++ b/packages/utils/src/lib/settings.ts
@@ -2,3 +2,4 @@ import { joinPaths } from "../fs";
 const root = joinPaths(__dirname, "..", "..");
 const storageDirPath = process.env.STORAGE_DIR || root;
 export const logDir = joinPaths(storageDirPath, "logs");
+export const cacheDirPath = joinPaths(storageDirPath, "cache");

--- a/packages/utils/src/npm.ts
+++ b/packages/utils/src/npm.ts
@@ -4,11 +4,12 @@ import { resolve as resolveUrl } from "url";
 import { joinPaths } from "./fs";
 import { Logger } from "./logging";
 import { createTgz } from "./io";
+import { cacheDirPath } from "./lib/settings.js";
 
 export const npmRegistryHostName = "registry.npmjs.org";
 export const npmRegistry = `https://${npmRegistryHostName}/`;
 
-export const defaultCacheDir = joinPaths(__dirname, "..", "cache");
+export const defaultCacheDir = cacheDirPath;
 
 type NeedToFixNpmRegistryClientTypings = any;
 


### PR DESCRIPTION
I’m not sure why this was changed in #451 but it breaks production because the app lives on a read-only filesystem.