### PR TITLE
Add `pino` and `pino-http` to the list of allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -502,6 +502,8 @@ pdfjs-dist
 pg-protocol
 pg-types
 phenomenon
+pino
+pino-http
 pkcs11js
 plugin-error
 polished


### PR DESCRIPTION
Add [`pino`](https://www.npmjs.com/package/pino) and [`pino-http`](https://www.npmjs.com/package/pino-http) to the list of allowed dependencies, since these packages come with their own typings now.

npm: [`pino`](https://www.npmjs.com/package/pino) | npm: [`pino-http`](https://www.npmjs.com/package/pino-http)
---|---
<img width="344" alt="Screen Shot 2022-06-12 at 00 42 54" src="https://user-images.githubusercontent.com/1210210/173192546-1f07941e-2c9e-4625-a2a2-133d09bb6fb7.png"> | <img width="338" alt="Screen Shot 2022-06-12 at 00 42 59" src="https://user-images.githubusercontent.com/1210210/173192544-2d790704-d113-42d9-952d-bcfd20017444.png">


This will help fix the build for `@types/koa-pino-logger`, which has been reported as flaky a few times.

Related PR: [(Koa) Specify the response body type for Koa #60767](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60767)