### PR TITLE
Add `pino-pretty` to the list of allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -504,6 +504,7 @@ pg-types
 phenomenon
 pino
 pino-http
+pino-pretty
 pkcs11js
 plugin-error
 polished


### PR DESCRIPTION
Add [`pino-pretty`](https://www.npmjs.com/package/pino-pretty) to the list of allowed dependencies, because it's shipped with its own typings.

<img width="345" alt="Screen Shot 2022-06-21 at 22 17 38" src="https://user-images.githubusercontent.com/1210210/174797081-dc6b5100-b355-4ffb-ac1f-0e5c3439f154.png">

This will help fix the build for `@types/koa-pino-logger`, which has been reported as flaky a few times.

Related PR: [(Koa) Specify the response body type for Koa #60767](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60767)
Previous PR: [Add `pino` and `pino-http` to the list of allowed dependencies #481](https://github.com/microsoft/DefinitelyTyped-tools/pull/481)