### PR TITLE
Fix eslint-disable check

### DIFF
--- a/packages/dtslint/src/lint.ts
+++ b/packages/dtslint/src/lint.ts
@@ -175,7 +175,7 @@ function testNoLintDisables(disabler: "tslint:disable" | "eslint-disable", text:
     if (
       nextChar !== "-" &&
       !(disabler === "tslint:disable" && nextChar === ":") &&
-      !(disabler === "eslint-disable" && nextChar === " " && nextChar2 === "*")
+      !(disabler === "eslint-disable" && nextChar === " " && nextChar2 !== "*")
     ) {
       const message =
         `'${disabler}' is forbidden. ` +


### PR DESCRIPTION
The last part of the check was backward, so it forbid `eslint-disable rule-name` but not `eslint-disable` on its own.