### PR TITLE
Turn off config cascading.

### DIFF
--- a/packages/eslint-config-dtslint/index.js
+++ b/packages/eslint-config-dtslint/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+    "root": true,
     "env": {
         "browser": true,
         "es2021": true,


### PR DESCRIPTION
It's unwanted in CI and broken in DT on-demand tests, which are run inside two (!) other repos with their own .eslintrc.json files.

(Attempt 1 -- I don't know if this will work since the documentation never mentions config packages, only .eslintrc.json)

Based on the description at https://eslint.org/docs/latest/user-guide/configuring/configuration-files#cascading-and-hierarchy and the example at https://eslint.org/docs/latest/user-guide/configuring/configuration-files#using-configuration-files