### PR TITLE
Allow .eslintrc.json

### DIFF
--- a/packages/definitions-parser/src/lib/definition-parser.ts
+++ b/packages/definitions-parser/src/lib/definition-parser.ts
@@ -736,6 +736,7 @@ function checkAllUsedRecur(ls: Iterable<string>, usedFiles: Set<string>, unusedF
         lsEntry.toLowerCase() !== "readme.md" &&
         lsEntry !== "NOTICE" &&
         lsEntry !== ".editorconfig" &&
+        lsEntry !== ".eslintrc.json" &&
         lsEntry !== unusedFilesName
       ) {
         throw new Error(

--- a/packages/utils/src/fs.ts
+++ b/packages/utils/src/fs.ts
@@ -192,7 +192,7 @@ export class DiskFS implements FS {
 
 /** FS only handles simple paths like `foo/bar` or `../foo`. No `./foo` or `/foo`. */
 function validatePath(path: string): void {
-  if (path.startsWith(".") && path !== ".editorconfig" && !path.startsWith("../")) {
+  if (path.startsWith(".") && path !== ".editorconfig" && path !== ".eslintrc.json" && !path.startsWith("../")) {
     throw new Error(`${path}: filesystem doesn't support paths of the form './x'.`);
   }
   if (path.startsWith("/")) {


### PR DESCRIPTION
The FS wrapper and unused-files check both need to know about .eslintrc.json.

The FS check for `./foo` is too simple, but I expanded the existing allow-list instead of making the check stricter.