### PR TITLE
Ignore pending packages in publish registry

### DIFF
--- a/packages/publisher/src/publish-registry.ts
+++ b/packages/publisher/src/publish-registry.ts
@@ -232,7 +232,13 @@ async function generateRegistry(typings: readonly TypingsData[]): Promise<Regist
       await Promise.all(
         typings.map(async (typing) => [
           typing.name,
-          filterTags((await pacote.packument(typing.fullNpmName, { cache: cacheDir }))["dist-tags"]),
+          await pacote
+            .packument(typing.fullNpmName, { cache: cacheDir })
+            .then((packument) => filterTags(packument["dist-tags"]))
+            .catch((reason) => {
+              if (reason.code !== "E404") throw reason;
+              return undefined;
+            }),
         ])
       )
     ),


### PR DESCRIPTION
Since https://github.com/microsoft/DefinitelyTyped-tools/pull/449 it's possible to run the publish registry workflow in between merging a new types package into the DT repo and publishing it to npm. When we gather metadata from npm to generate the types registry, we get a 404.

Like, what are the chances of *that* actually happening? Heh:
- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61079#issue-1293097303
- https://github.com/microsoft/DefinitelyTyped-tools/runs/7186936298?check_suite_focus=true#step:8:16