### PR TITLE
Schedule retag and publish registry together

### DIFF
--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -1,8 +1,7 @@
 name: Publish registry
+#description: Publish the types-registry package to npm (a list of all @types packages in the DT repo).
 on:
-  schedule:
-    # https://crontab.guru/#0_0_*_*_0
-    - cron: 0 0 * * 0
+  workflow_call:
   workflow_dispatch:
 jobs:
   publish-registry:

--- a/.github/workflows/update-ts-version-tags.yml
+++ b/.github/workflows/update-ts-version-tags.yml
@@ -5,15 +5,13 @@ name: Update ts* tags for ATA
 
 # For production
 on:
+  workflow_call:
   workflow_dispatch:
     inputs:
       checkout:
         description: ref to deploy
         required: true
         default: master
-  schedule:
-    # https://crontab.guru/#5_8_*_*_1
-    - cron: "5 8 * * 1"
 
 jobs:
   publish:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,0 +1,13 @@
+name: Weekly
+#description: Update npm tags, then publish the types-registry package.
+on:
+  schedule:
+    # https://crontab.guru/#0_0_*_*_0
+    - cron: 0 0 * * 0
+jobs:
+  publish-registry:
+    needs: retag
+    uses: ./.github/workflows/publish-registry.yml
+  retag:
+    if: github.repository == 'microsoft/DefinitelyTyped-tools'
+    uses: ./.github/workflows/update-ts-version-tags.yml


### PR DESCRIPTION
Scheduling the retag and publish registry workflows independently (as we do today) works fine, but it's pretty simple to coordinate them (this PR), so we update the npm tags first, then publish the types-registry. That's slightly better because the retag workflow updates the tags that the publish registry workflow reads (the types-registry package is [an aggregation of npm tags](https://github.com/microsoft/types-publisher/pull/425#issue-287935472)). Scheduling them together minimizes the interval between updating npm and updating the types-registry package.