### PR TITLE
Add sparql-http-client to expectedFailures

### DIFF
--- a/packages/dtslint-runner/expectedFailures.txt
+++ b/packages/dtslint-runner/expectedFailures.txt
@@ -19,4 +19,5 @@ ng-cordova
 redux-orm
 resourcejs
 sketchapp
+sparql-http-client
 vscode-webview


### PR DESCRIPTION
sparql-http-client is the one package currently exhibiting a conflict between DOM and node's versions of the AbortSignal type. [I tried to break the DOM dependency by copying the required types into the package](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60749), but that's clunky and brittle.

Few people use this package so I think it's better to ignore the failure until we come up with a comprehensive dual-environment solution.