### PR TITLE
Allow expected failures in dependents

### DIFF
--- a/packages/dtslint-runner/src/main.ts
+++ b/packages/dtslint-runner/src/main.ts
@@ -56,7 +56,10 @@ export async function runDTSLint({
   }
 
   const allFailures: [string, string][] = [];
-  const expectedFailures = getExpectedFailures(onlyRunAffectedPackages);
+  let expectedFailures = getExpectedFailures();
+  if (onlyRunAffectedPackages) {
+    expectedFailures = new Set(dependents.filter((name) => expectedFailures.has(name)));
+  }
 
   const allPackages = [...packageNames, ...dependents];
   const testedPackages = shard ? allPackages.filter((_, i) => i % shard.count === shard.id - 1) : allPackages;
@@ -161,11 +164,7 @@ export async function runDTSLint({
   return allFailures.length;
 }
 
-function getExpectedFailures(onlyRunAffectedPackages: boolean) {
-  if (onlyRunAffectedPackages) {
-    return undefined;
-  }
-
+function getExpectedFailures() {
   return new Set(
     (readFileSync(joinPaths(__dirname, "../expectedFailures.txt"), "utf8") as string)
       .split("\n")

--- a/packages/dtslint-runner/src/main.ts
+++ b/packages/dtslint-runner/src/main.ts
@@ -56,10 +56,7 @@ export async function runDTSLint({
   }
 
   const allFailures: [string, string][] = [];
-  let expectedFailures = getExpectedFailures();
-  if (onlyRunAffectedPackages) {
-    expectedFailures = new Set(dependents.filter((name) => expectedFailures.has(name)));
-  }
+  const expectedFailures = getExpectedFailures(onlyRunAffectedPackages, dependents);
 
   const allPackages = [...packageNames, ...dependents];
   const testedPackages = shard ? allPackages.filter((_, i) => i % shard.count === shard.id - 1) : allPackages;
@@ -164,12 +161,12 @@ export async function runDTSLint({
   return allFailures.length;
 }
 
-function getExpectedFailures() {
+function getExpectedFailures(onlyRunAffectedPackages: boolean, dependents: readonly string[]) {
   return new Set(
     (readFileSync(joinPaths(__dirname, "../expectedFailures.txt"), "utf8") as string)
       .split("\n")
-      .filter(Boolean)
       .map((s) => s.trim())
+      .filter(onlyRunAffectedPackages ? (line) => line && dependents.includes(line) : Boolean)
   );
 }
 


### PR DESCRIPTION
This change should allow https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61001 and https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61620 to pass CI