### PR TITLE
Add 'type-fest' to allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -976,6 +976,7 @@ treat
 ts-toolbelt
 tslint
 tweetnacl
+type-fest
 typeorm
 typescript
 typescript-tuple


### PR DESCRIPTION
For https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61681

'rollup-plugin-generate-package-json' requires 'read-pkg' and 'write-pkg', and these packages require 'type-fest'.