### PR TITLE
Remove dt-header from tslint config

### DIFF
--- a/packages/dtslint/dt.json
+++ b/packages/dtslint/dt.json
@@ -1,7 +1,6 @@
 {
 	"extends": "./dtslint.json",
 	"rules": {
-		"dt-header": true,
 		"no-bad-reference": true,
 		"no-declare-current-package": true,
 		"no-self-import": true,


### PR DESCRIPTION
The rule is now in `.eslintrc.json` files, so I _think_ this is right and will get rid of these messages on DT:

```
Could not find implementations for the following rules specified in the configuration:
    dt-header
Try upgrading TSLint and/or ensuring that you have all necessary custom rules installed.
If TSLint was recently upgraded, you may have old rules configured which need to be cleaned up.
```

/cc @JoshuaKGoldberg