### PR TITLE
[publisher] use consistent order for dependencies in the generated README

### DIFF
--- a/packages/publisher/src/generate-packages.ts
+++ b/packages/publisher/src/generate-packages.ts
@@ -243,7 +243,7 @@ export function createReadme(typing: TypingsData, packageFS: FS): string {
   lines.push("");
   lines.push("### Additional Details");
   lines.push(` * Last updated: ${new Date().toUTCString()}`);
-  const dependencies = Object.keys(typing.dependencies).map(getFullNpmName);
+  const dependencies = Object.keys(typing.dependencies).map(getFullNpmName).sort();
   lines.push(
     ` * Dependencies: ${
       dependencies.length ? dependencies.map((d) => `[${d}](https://npmjs.com/package/${d})`).join(", ") : "none"

--- a/packages/publisher/test/generate-packages.test.ts
+++ b/packages/publisher/test/generate-packages.test.ts
@@ -89,6 +89,16 @@ testo({
       expect.stringContaining("Dependencies: [@types/madeira](https://npmjs.com/package/@types/madeira)")
     );
   },
+  readmeMultipleDependencies() {
+    const typing = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
+    // @ts-expect-error - dependencies is readonly
+    typing.dependencies.example = { major: 2 };
+    expect(createReadme(typing, defaultFS())).toEqual(
+      expect.stringContaining(
+        "Dependencies: [@types/example](https://npmjs.com/package/@types/example), [@types/madeira](https://npmjs.com/package/@types/madeira)"
+      )
+    );
+  },
   readmeContainsSingleFileDTS() {
     const typing = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
     expect(createReadme(typing, defaultFS())).toContain("type T = import");


### PR DESCRIPTION
The order of dependencies in the README of `@types/...` packages changes depending on how the object is constructed in [this function](https://github.com/microsoft/DefinitelyTyped-tools/blob/master/packages/publisher/src/generate-packages.ts#L172-L194). 

This PR changes the order so that it is always consistent. This reduces the diff when a package is updated.