### PR TITLE
Added `filestack-js` to allowed `package.json` dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -812,6 +812,7 @@ express-rate-limit
 fast-glob
 fastify
 final-form
+filestack-js
 firebase-admin
 flatpickr
 form-data


### PR DESCRIPTION
Adding `filestack-js` to the allowed dependencies. It's required for types definitions for `filestack-react`.

[Related PR in DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/62164)