### PR TITLE
Special case node's typeVersions for 4.9 beta

### DIFF
--- a/packages/dtslint/src/checks.ts
+++ b/packages/dtslint/src/checks.ts
@@ -25,7 +25,10 @@ export async function checkPackageJson(dirPath: string, typesVersions: readonly 
 
   if (needsTypesVersions) {
     assert.strictEqual((pkgJson as any).types, "index", `"types" in '${pkgJsonPath}' should be "index".`);
-    const expected = makeTypesVersionsForPackageJson(typesVersions);
+      const expected = makeTypesVersionsForPackageJson(typesVersions) as Record<string, object>;
+      if (dirPath.endsWith('/node') || dirPath.endsWith("/node/v14") || dirPath.endsWith("/node/v16")) {
+          expected[">4.9.0-a"] =  { "*" : ["*"] }
+      }
     assert.deepEqual(
       (pkgJson as any).typesVersions,
       expected,

--- a/packages/dtslint/src/checks.ts
+++ b/packages/dtslint/src/checks.ts
@@ -25,10 +25,10 @@ export async function checkPackageJson(dirPath: string, typesVersions: readonly 
 
   if (needsTypesVersions) {
     assert.strictEqual((pkgJson as any).types, "index", `"types" in '${pkgJsonPath}' should be "index".`);
-      const expected = makeTypesVersionsForPackageJson(typesVersions) as Record<string, object>;
-      if (dirPath.endsWith('/node') || dirPath.endsWith("/node/v14") || dirPath.endsWith("/node/v16")) {
-          expected[">4.9.0-a"] =  { "*" : ["*"] }
-      }
+    const expected = makeTypesVersionsForPackageJson(typesVersions) as Record<string, object>;
+    if (dirPath.endsWith("/node") || dirPath.endsWith("/node/v14") || dirPath.endsWith("/node/v16")) {
+      expected[">4.9.0-a"] = { "*": ["*"] };
+    }
     assert.deepEqual(
       (pkgJson as any).typesVersions,
       expected,


### PR DESCRIPTION
Require a ">4.9.0-a" entry to handle 4.9 beta and dev releases.