### PR TITLE
Change typesVersions format

### DIFF
--- a/packages/dtslint/src/checks.ts
+++ b/packages/dtslint/src/checks.ts
@@ -26,9 +26,6 @@ export async function checkPackageJson(dirPath: string, typesVersions: readonly 
   if (needsTypesVersions) {
     assert.strictEqual((pkgJson as any).types, "index", `"types" in '${pkgJsonPath}' should be "index".`);
     const expected = makeTypesVersionsForPackageJson(typesVersions) as Record<string, object>;
-    if (dirPath.endsWith("/node") || dirPath.endsWith("/node/v14") || dirPath.endsWith("/node/v16")) {
-      expected[">4.9.0-a"] = { "*": ["*"] };
-    }
     assert.deepEqual(
       (pkgJson as any).typesVersions,
       expected,

--- a/packages/header-parser/src/index.ts
+++ b/packages/header-parser/src/index.ts
@@ -1,5 +1,6 @@
 import pm = require("parsimmon");
 import { AllTypeScriptVersion, TypeScriptVersion } from "@definitelytyped/typescript-versions";
+import assert = require("assert");
 
 /*
 
@@ -45,7 +46,9 @@ export function makeTypesVersionsForPackageJson(typesVersions: readonly TypeScri
   oldestFirst.sort((v1, v2) => (v1 > v2 ? 1 : v1 < v2 ? -1 : 0));
   const out: { [key: string]: { readonly "*": readonly string[] } } = {};
   for (const version of oldestFirst) {
-    out[`<=${version}`] = { "*": [`ts${version}/*`] };
+    const next = TypeScriptVersion.next(version);
+    assert(!!next, `ts${version} is too new: it covers all versions of typescript`);
+    out[`<${next}.0-0`] = { "*": [`ts${version}/*`] };
   }
   return out;
 }

--- a/packages/header-parser/test/index.test.ts
+++ b/packages/header-parser/test/index.test.ts
@@ -204,24 +204,24 @@ describe("makeTypesVersionsForPackageJson", () => {
   });
   it("works for one version", () => {
     expect(makeTypesVersionsForPackageJson(["4.3"])).toEqual({
-      "<=4.3": {
+      "<4.4.0-0": {
         "*": ["ts4.3/*"],
       },
     });
   });
   it("orders versions old to new  with old-to-new input", () => {
     expect(JSON.stringify(makeTypesVersionsForPackageJson(["4.1", "4.3", "4.6"]), undefined, 4)).toEqual(`{
-    "<=4.1": {
+    "<4.2.0-0": {
         "*": [
             "ts4.1/*"
         ]
     },
-    "<=4.3": {
+    "<4.4.0-0": {
         "*": [
             "ts4.3/*"
         ]
     },
-    "<=4.6": {
+    "<4.7.0-0": {
         "*": [
             "ts4.6/*"
         ]
@@ -230,22 +230,27 @@ describe("makeTypesVersionsForPackageJson", () => {
   });
   it("orders versions old to new  with new-to-old input", () => {
     expect(JSON.stringify(makeTypesVersionsForPackageJson(["4.6", "4.3", "4.1"]), undefined, 4)).toEqual(`{
-    "<=4.1": {
+    "<4.2.0-0": {
         "*": [
             "ts4.1/*"
         ]
     },
-    "<=4.3": {
+    "<4.4.0-0": {
         "*": [
             "ts4.3/*"
         ]
     },
-    "<=4.6": {
+    "<4.7.0-0": {
         "*": [
             "ts4.6/*"
         ]
     }
 }`);
+  });
+  it("asserts when trying to redirect from newest version and below", () => {
+    expect(() => makeTypesVersionsForPackageJson(["4.9"])).toThrow(
+      /ts4.9 is too new: it covers all versions of typescript/
+    );
   });
 });
 

--- a/packages/typescript-versions/src/index.ts
+++ b/packages/typescript-versions/src/index.ts
@@ -114,6 +114,12 @@ export namespace TypeScriptVersion {
     return index === 0 ? undefined : supported[index - 1];
   }
 
+  export function next(v: TypeScriptVersion): TypeScriptVersion | undefined {
+    const index = supported.indexOf(v);
+    assert(index !== -1);
+    return index === supported.length - 1 ? undefined : supported[index + 1];
+  }
+
   export function isRedirectable(v: TypeScriptVersion): boolean {
     return all.indexOf(v) >= all.indexOf("3.1");
   }


### PR DESCRIPTION
Work around the bug in Typescript semver semantics by using a more precise specifier that works there, as well as standard semver.

The bug in typescript should be fixed soon, so we can change this back later. In the meantime only 13 packages use typesVersions so it's easy to change back and forth.

Also get rid of the node-specific special-case in typesVersion checking, which wouldn't have worked for publishing in any case.