### PR TITLE
Add 4 storybook dependents to expectedFailures.txt

### DIFF
--- a/packages/dtslint-runner/expectedFailures.txt
+++ b/packages/dtslint-runner/expectedFailures.txt
@@ -19,3 +19,7 @@ ng-cordova
 redux-orm
 resourcejs
 sparql-http-client
+storybook-addon-jsx
+storybook-react-router
+storybook-readme
+storybook__addon-info


### PR DESCRIPTION
storybook types copy+extend a Node type (EventTarget) and rely on structural typing to make them assignable. But [this fails with the newest version of node types](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/results?buildId=141198&view=logs&j=9d906afe-3eb5-5d79-316d-86f3f3fa360c&t=09716206-abc7-5ba2-2ea2-6c6fe97a3aad). @thw0rted created https://github.com/storybookjs/storybook/pull/19373 to make storybook correctly extend EventTarget, but I'm going to disable the failures for these four packages until it's merged and the new version of storybook ships.