### PR TITLE
Added bl to allowedPackageJsonDependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -768,6 +768,7 @@ axios
 base-x
 bee-queue
 bignumber.js
+bl
 bookshelf
 boxen
 broadcast-channel


### PR DESCRIPTION
In order to complete https://github.com/DefinitelyTyped/DefinitelyTyped/pull/62783, I've followed the readme and added rvagg's "bl" to the list. Let me know if I made any mistake 😄 