### PR TITLE
chore (definitions-parser): add fs-capacitor to whitelist

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -827,6 +827,7 @@ filestack-js
 firebase-admin
 flatpickr
 form-data
+fs-capacitor
 fs-jetpack
 gl-matrix
 glaze


### PR DESCRIPTION
we need this since fs-capacitor's types will soon be removed from DT (they ship their own types now).

one package remains in DT which depends on fs-capacitor, so will need it as a dependency.