### PR TITLE
chore (definitions-parser): add bull to whitelist

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -774,6 +774,7 @@ boxen
 broadcast-channel
 bson
 buffer
+bull
 bullmq
 cac
 canvas


### PR DESCRIPTION
similar to #548 we need to whitelist bull so the `bull-arena` package can depend on it in DT once we drop bull's types for the shipped ones