### PR TITLE
Remove storybook dependents from expectedFailures.txt

### DIFF
--- a/packages/dtslint-runner/expectedFailures.txt
+++ b/packages/dtslint-runner/expectedFailures.txt
@@ -18,8 +18,3 @@ mobx-apollo
 ng-cordova
 redux-orm
 resourcejs
-sparql-http-client
-storybook-addon-jsx
-storybook-react-router
-storybook-readme
-storybook__addon-info


### PR DESCRIPTION
Fixed by https://github.com/DefinitelyTyped/DefinitelyTyped/pull/62782