### PR TITLE
Add @pollyjs/core as allowed dependency 

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -677,6 +677,7 @@
 @mui/material
 @mui/types
 @npm/types
+@pollyjs/core
 @popperjs/core
 @puppeteer/replay
 @rdfjs/types

--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -677,7 +677,9 @@
 @mui/material
 @mui/types
 @npm/types
+@pollyjs/adapter
 @pollyjs/core
+@pollyjs/persister
 @popperjs/core
 @puppeteer/replay
 @rdfjs/types


### PR DESCRIPTION
For PR https://github.com/DefinitelyTyped/DefinitelyTyped/pull/62843

Since the PollyJS team already implemented the types, we could add the following library into the notNeededPackages.json
```
... 
"pollyjs__adapter": {
    "libraryName": "@pollyjs/adapter",
    "asOfVersion": "6.0.4"
},
"pollyjs__adapter-fetch": {
    "libraryName": "@pollyjs/adapter-fetch",
    "asOfVersion": "6.0.5"
},
"pollyjs__adapter-node-http": {
    "libraryName": "@pollyjs/adapter-node-http",
    "asOfVersion": "6.0.5"
},
"pollyjs__adapter-puppeteer": {
    "libraryName": "@pollyjs/adapter-puppeteer",
    "asOfVersion": "6.0.5"
},
"pollyjs__adapter-xhr": {
    "libraryName": "@pollyjs/adapter-xhr",
    "asOfVersion": "6.0.5"
},
"pollyjs__core": {
    "libraryName": "@pollyjs/core",
    "asOfVersion": "6.0.5"
},
"pollyjs__node-server": {
    "libraryName": "@pollyjs/node-server",
    "asOfVersion": "6.0.1"
},
"pollyjs__persister": {
    "libraryName": "@pollyjs/persister",
    "asOfVersion": "6.0.5"
},
"pollyjs__persister-fs": {
    "libraryName": "@pollyjs/persister-fs",
    "asOfVersion": "6.0.5"
},
"pollyjs__persister-local-storage": {
    "libraryName": "@pollyjs/persister-local-storage",
    "asOfVersion": "6.0.5"
},
"pollyjs__persister-rest": {
    "libraryName": "@pollyjs/persister-rest",
    "asOfVersion": "6.0.5"
},
"pollyjs__utils": {
  "libraryName": "@pollyjs/utils",
  "asOfVersion": "6.0.1"
},
 ```
 
 And the system ask me to make this PR for external library during the `npm run test-all`
 
 ```
Error: In package.json: Dependency @pollyjs/adapter not in the allowed dependencies list.
If you are depending on another `@types` package, do *not* add it to a `package.json`. Path mapping should make the import work.
For namespaced dependencies you then have to add a `paths` mapping from `@namespace/*` to `namespace__*` in `tsconfig.json`.
If this is an external library that provides typings,  please make a pull request to microsoft/DefinitelyTyped-tools adding it to `packages/definitions-parser/allowedPackageJsonDependencies.txt`.
```
 
Thanks!