### PR TITLE
Remove no-bad-reference from dt.json

### DIFF
--- a/packages/dtslint/dt.json
+++ b/packages/dtslint/dt.json
@@ -1,7 +1,6 @@
 {
 	"extends": "./dtslint.json",
 	"rules": {
-		"no-bad-reference": true,
 		"no-declare-current-package": true,
 		"no-self-import": true,
 		"no-outside-dependencies": true,


### PR DESCRIPTION
This rule was converted in #521 but apparently we also referenced it from `dt.json` which causes it to pop up on DT like in: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/62838/files/cbb9e230d36db8a77e2a88dd161d1aff47a65eac#r1003664609