### PR TITLE
chore (definitions-parser): whitelist prosemirror-view

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -934,6 +934,7 @@ preact
 pretty-format
 probot
 prom-client
+prosemirror-view
 protobufjs
 protractor
 query-string


### PR DESCRIPTION
one package in DT still depends on it, so we need to whitelist for now