### PR TITLE
chore (definitions-parser): whitelist puppeteer

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -724,6 +724,8 @@
 @types/node
 @types/node-fetch
 @types/pino
+@types/puppeteer
+@types/puppeteer-core
 @types/react-native-tab-view
 @types/react-navigation
 @types/react-select
@@ -937,6 +939,8 @@ prom-client
 prosemirror-view
 protobufjs
 protractor
+puppeteer
+puppeteer-core
 query-string
 quill-delta
 raven-js


### PR DESCRIPTION
would be useful to be able to pull these shipped types into dependent dt types

i added the types package equivalents too since some unmaintained packages may need those (before puppeteer shipped types)