### PR TITLE
chore[definitions-parser]: whitelist `@types/react`

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -727,6 +727,7 @@
 @types/pino
 @types/puppeteer
 @types/puppeteer-core
+@types/react
 @types/react-native-tab-view
 @types/react-navigation
 @types/react-select


### PR DESCRIPTION
Refer to [New types definition for `next-pwa` - PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/63391) for an overview of why the `@types/react` package is needed and should be added.