### PR TITLE
Add kleur as an allowed dependency

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -881,6 +881,7 @@ jose
 jsonata
 js-logger
 juice
+kleur
 knex
 knockout
 levelup


### PR DESCRIPTION
Working on updating the types for the `prompts` package, which requires the types published by package `kleur`.