### PR TITLE
Add openapi-types to allowed packages

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -920,6 +920,7 @@ nock
 node-fetch
 normalize-url
 objection
+openapi-types
 opentracing
 parchment
 parse5


### PR DESCRIPTION
I wish to add type definitions for the module swagger2openapi, but it depends on openapi-types and the contribution guide says it needs to be added here first

ref: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/63631