### PR TITLE
Add `workbox-build` to allowed packages

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -1036,6 +1036,7 @@ webpack-chain
 web-tree-sitter
 winston
 winston-transport
+workbox-build
 xmlbuilder
 xpath
 yup


### PR DESCRIPTION
The current `workbox-build` typing reference inside the [@types/next-pwa](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/next-pwa) package points to `@types/workbox-build`, which has not updated its definitions since `v5.0` of the parent module. Currently, the original `workbox-build` package sits at `v6.5.4`. This package version mismatch may compromise the extended [webpackConfigOptions](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/next-pwa/index.d.ts#L44) type referenced within the `@types/next-pwa` package. 

To solve this issue, adding the dependency to the allowed packages list will ensure that the reference won't ripple any **possibly** stale and/or mismatched types.

###### BTW, to further reiterate the issue, see the current workaround to the [mismatched types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/next-pwa/index.d.ts#L11-L16).