### PR TITLE
Add `workbox-webpack-plugin` to allowed packages

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -1037,6 +1037,7 @@ web-tree-sitter
 winston
 winston-transport
 workbox-build
+workbox-webpack-plugin
 xmlbuilder
 xpath
 yup


### PR DESCRIPTION
There are multiple now-stale `workbox-_` DT packages that need to be removed, and in doing so, the original bundled definitions will be the default dependency. This PR adds only one more to the list, but many more may need to be added going foward.

- [CI job error](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/546d5ccd80955ef4aa9d35c4eb336e1f3365e450/checks?check_suite_id=10018574487#step:6:14)
- [PR to remove workbox-_ DT packages](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/63682) 
- [DT discord thread where the issue first surfaced](https://discordapp.com/channels/508357248330760243/1055115632372371496)

`workbox-webpack-plugin` is a dependency inside the [customize-cra DT package](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/customize-cra/src/webpack.d.ts#L3). This change enables the previously mentioned PR to remove workbox-_ DT packages to go through.