### PR TITLE
Allow generic-pool and @types/generic-pool

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -479,6 +479,7 @@
 @types/faker
 @types/favicons
 @types/firebase
+@types/generic-pool
 @types/got
 @types/hapi
 @types/helmet
@@ -633,6 +634,7 @@ flatpickr
 form-data
 fs-capacitor
 fs-jetpack
+generic-pool
 gl-matrix
 glaze
 globby


### PR DESCRIPTION
Allow generic-pool and @types/generic-pool as dependency for types packages.

Required by https://github.com/DefinitelyTyped/DefinitelyTyped/pull/63876