### PR TITLE
Add @types/react-leaflet to allowed packages

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -504,6 +504,7 @@
 @types/pino
 @types/puppeteer
 @types/puppeteer-core
+@types/react-leaflet
 @types/react-native-tab-view
 @types/react-navigation
 @types/react-select


### PR DESCRIPTION
Required for DefinitelyTyped/DefinitelyTyped#64062, since @types/react-leaflet-markercluster depends on a version of react-leaflet that doesn't bundle its own types.