### PR TITLE
Remove the last aws-sdk@2 dependents from expectedFailures

### DIFF
--- a/packages/dtslint-runner/expectedFailures.txt
+++ b/packages/dtslint-runner/expectedFailures.txt
@@ -1,13 +1,11 @@
 absinthe__socket-apollo-link
 bookshelf
 dialogflow-fulfillment
-dynamodb-lock-client
 electron-clipboard-extended
 electron-notifications
 electron-notify
 fhir
 graphql-resolvers
-http-aws-es
 keystonejs__adapter-knex
 keystonejs__app-graphql
 keystonejs__auth-passport
@@ -16,10 +14,7 @@ keystonejs__fields
 keystonejs__file-adapters
 keystonejs__keystone
 keystonejs__oembed-adapters
-mapbox__aws-sdk-jest
 mobx-apollo
-mock-aws-s3
 ng-cordova
-nodecredstash
 redux-orm
 resourcejs


### PR DESCRIPTION
I updated them so that https://github.com/DefinitelyTyped/DefinitelyTyped/pull/63878 would pass.