### PR TITLE
chore (definitions-parser): whitelist micro package

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -494,6 +494,7 @@
 @types/leaflet
 @types/long
 @types/lru-cache
+@types/micro
 @types/minimatch
 @types/mkdirp-promise
 @types/mongodb


### PR DESCRIPTION
some old packages still depend on the old types.

for DefinitelyTyped/DefinitelyTyped#64246