### PR TITLE
4 small fixes

### DIFF
--- a/packages/dtslint-runner/src/index.ts
+++ b/packages/dtslint-runner/src/index.ts
@@ -66,7 +66,7 @@ if (!module.parent) {
         type: "boolean",
         default: false,
       },
-      // Not sure why you’d use this, so I’m hiding it
+      // Only useful for repeated local runs, so I’m hiding it
       noInstall: {
         hidden: true,
         type: "boolean",

--- a/packages/dtslint-runner/src/main.ts
+++ b/packages/dtslint-runner/src/main.ts
@@ -127,7 +127,7 @@ export async function runDTSLint({
           break;
         case CrashRecoveryState.Crashed:
           if (expectedFailures?.has(input.path)) {
-            console.error(`${prefix}${input.path} failed as expected: outof memory.`);
+            console.error(`${prefix}${input.path} failed as expected: out of memory.`);
           } else {
             console.error(`${prefix}${input.path} Out of memory: failed`);
             allFailures.push([input.path, "Out of memory"]);

--- a/packages/dtslint/src/index.ts
+++ b/packages/dtslint/src/index.ts
@@ -51,7 +51,7 @@ async function main(): Promise<void> {
         onlyTestTsNext = true;
         break;
       // Only for use by types-publisher.
-      // Listens for { path, onlyTestTsNext } messages and ouputs { path, status }.
+      // Listens for { path, onlyTestTsNext } messages and outputs { path, status }.
       case "--listen":
         shouldListen = true;
         break;
@@ -66,7 +66,7 @@ async function main(): Promise<void> {
           arg.indexOf("@") === 0 && arg.indexOf("/") !== -1
             ? // we have a scoped module, e.g. @bla/foo
               // which should be converted to   bla__foo
-              arg.substr(1).replace("/", "__")
+              arg.slice(1).replace("/", "__")
             : arg;
         dirPath = joinPaths(dirPath, path);
       }

--- a/packages/dtslint/src/rules/noRedundantJsdoc2Rule.ts
+++ b/packages/dtslint/src/rules/noRedundantJsdoc2Rule.ts
@@ -58,9 +58,11 @@ function walk(ctx: Lint.WalkContext<void>): void {
   function checkTag(tag: ts.JSDocTag): void {
     const jsdocSeeTag = (ts.SyntaxKind as any).JSDocSeeTag || 0;
     const jsdocDeprecatedTag = (ts.SyntaxKind as any).JSDocDeprecatedTag || 0;
+    const jsdocThrowsTag = (ts.SyntaxKind as any).JSDocThrowsTag || 0;
     switch (tag.kind) {
       case jsdocSeeTag:
       case jsdocDeprecatedTag:
+      case jsdocThrowsTag:
       case ts.SyntaxKind.JSDocAuthorTag:
         // @deprecated and @see always have meaning
         break;


### PR DESCRIPTION
1. 2 typo fixes
2. explain what `--noInstall` does for dtslint-runner so we keep it around. (it's for when you've run dtslint-runner locally recently and don't need to `npm install` every package -- that takes about an hour each time.)
3. Use `slice` instead of `substr`, which is deprecated.
4. Add support for JSDocThrowsTag using the workaround for the dependency that doesn't have it in its enum.