### PR TITLE
Stop and restart each dtslint individually

### DIFF
--- a/packages/utils/src/process.ts
+++ b/packages/utils/src/process.ts
@@ -157,7 +157,9 @@ export function runWithListeningChildProcesses<In extends Serializable>({
               console.log(`${processIndex}> Restarting...`);
               restartChild(nextTask, process.execArgv);
             } else {
-              nextTask();
+              stopChild(/*done*/ false);
+              startChild(nextTask, process.execArgv);
+              // nextTask();
             }
           }
         } catch (e) {


### PR DESCRIPTION
See if it stops out-of-memory crashes, even though it will be considerably slower.