### PR TITLE
Try only 20 tasks per child instead of 50

### DIFF
--- a/packages/utils/src/process.ts
+++ b/packages/utils/src/process.ts
@@ -129,7 +129,7 @@ export function runWithListeningChildProcesses<In extends Serializable>({
   return new Promise(async (resolve, reject) => {
     let inputIndex = 0;
     let processesLeft = nProcesses;
-    const tasksPerChild = 50;
+    const tasksPerChild = 20;
     let tasksSoFar = 0;
     let rejected = false;
     const runningChildren = new Set<ChildProcess>();


### PR DESCRIPTION
50 tasks per child avoids about 80% of ooms without slowing down tests much at all. Let's see if 20 tasks per child will avoid closer to 100% without slowing down too much more.