### PR TITLE
Add child restart interval flag

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,7 +32,7 @@
                 "selector": ["variable", "function", "method", "accessor"],
                 "format": ["camelCase"],
                 "filter": {
-                    "regex": "Reader|DEFAULT_CRASH_RECOVERY_MAX_OLD_SPACE_SIZE",
+                    "regex": "Reader|DEFAULT_CRASH_RECOVERY_MAX_OLD_SPACE_SIZE|DEFAULT_CHILD_RESTART_TASK_INTERVAL",
                     "match": false
                 }
             },

--- a/packages/dtslint-runner/expectedFailures.txt
+++ b/packages/dtslint-runner/expectedFailures.txt
@@ -4,7 +4,6 @@ dialogflow-fulfillment
 electron-clipboard-extended
 electron-notifications
 electron-notify
-fhir
 graphql-resolvers
 keystonejs__adapter-knex
 keystonejs__app-graphql

--- a/packages/dtslint-runner/src/index.ts
+++ b/packages/dtslint-runner/src/index.ts
@@ -72,6 +72,10 @@ if (!module.parent) {
         type: "boolean",
         default: false,
       },
+      childRestartTaskInterval: {
+        type: "number",
+        description: "How often to restart child processes, in number of tasks. Useful to work around memory leaks. Default is not to restart.",
+      }
     })
     .wrap(Math.min(yargs.terminalWidth(), 120)).argv;
 
@@ -92,6 +96,7 @@ if (!module.parent) {
     onlyTestTsNext: !!args.onlyTestTsNext,
     expectOnly: args.expectOnly,
     noInstall: args.noInstall,
+    childRestartTaskInterval: args.childRestartTaskInterval,
   };
 
   logUncaughtErrors(async () => {

--- a/packages/dtslint-runner/src/main.ts
+++ b/packages/dtslint-runner/src/main.ts
@@ -25,6 +25,7 @@ export async function runDTSLint({
   localTypeScriptPath,
   nProcesses,
   shard,
+  childRestartTaskInterval,
 }: RunDTSLintOptions) {
   let definitelyTypedPath;
   console.log("Node version: ", process.version);
@@ -80,6 +81,7 @@ export async function runDTSLint({
     cwd: typesPath,
     crashRecovery: true,
     crashRecoveryMaxOldSpaceSize: 0, // disable retry with more memory
+    childRestartTaskInterval,
     handleStart(input, processIndex) {
       const prefix = processIndex === undefined ? "" : `${processIndex}> `;
       console.log(`${prefix}${input.path} START`);

--- a/packages/dtslint-runner/src/types.ts
+++ b/packages/dtslint-runner/src/types.ts
@@ -28,4 +28,5 @@ export interface RunDTSLintOptions {
   localTypeScriptPath?: string;
   nProcesses: number;
   shard?: { id: number; count: number };
+  childRestartTaskInterval?: number;
 }


### PR DESCRIPTION
Also remove `fhir` from expected failures, which passes every time now that memory pressure is relieved.