### PR TITLE
Skip eslint in --expectOnly

### DIFF
--- a/packages/dtslint/src/lint.ts
+++ b/packages/dtslint/src/lint.ts
@@ -64,18 +64,19 @@ export async function lint(
     }
   }
   const result = linter.getResult();
-  const cwd = process.cwd();
-  process.chdir(dirPath);
-  const eslint = new ESLint({
-    rulePaths: [joinPaths(__dirname, "./rules/")],
-  });
-  const formatter = await eslint.loadFormatter("stylish");
-  const eresults = await eslint.lintFiles(esfiles);
-  process.chdir(cwd);
+  let output = result.failures.length ? result.output : "";
+  if (!expectOnly) {
+    const cwd = process.cwd();
+    process.chdir(dirPath);
+    const eslint = new ESLint({
+      rulePaths: [joinPaths(__dirname, "./rules/")],
+    });
+    const formatter = await eslint.loadFormatter("stylish");
+    const eresults = await eslint.lintFiles(esfiles);
+    output += formatter.format(eresults);
+    process.chdir(cwd);
+  }
 
-  let output: string | undefined;
-  if (result.failures.length) output = result.output;
-  output = (output || "") + formatter.format(eresults);
   return output;
 }
 


### PR DESCRIPTION
expectRule hasn't been ported, so no need to run eslint when --expectOnly is provided.

Easier to review with whitespace turned off.