### PR TITLE
typescript-eslint workaround + misc fixes

### DIFF
--- a/packages/dtslint-runner/src/main.ts
+++ b/packages/dtslint-runner/src/main.ts
@@ -206,21 +206,13 @@ function logPerformance() {
     console.log("\n\n=== PERFORMANCE ===\n");
     for (const filename of readdirSync(perfDir, { encoding: "utf8" })) {
       const x = JSON.parse(readFileSync(joinPaths(perfDir, filename), { encoding: "utf8" })) as {
-        [s: string]: { typeCount: number; memory: number };
+        [s: string]: { types: number; memory: number };
       };
       for (const k of Object.keys(x)) {
-        big.push([k, x[k].typeCount]);
-        types.push(x[k].typeCount);
+        big.push([k, x[k].types]);
+        types.push(x[k].types);
       }
     }
-    console.log(
-      "{" +
-        big
-          .sort((a, b) => b[1] - a[1])
-          .map(([name, count]) => ` "${name}": ${count}`)
-          .join(",") +
-        "}"
-    );
 
     console.log("  * Percentiles: ");
     console.log("99:", percentile(types, 0.99));

--- a/packages/dtslint/src/lint.ts
+++ b/packages/dtslint/src/lint.ts
@@ -22,7 +22,7 @@ export async function lint(
 ): Promise<string | undefined> {
   const tsconfigPath = joinPaths(dirPath, "tsconfig.json");
   const estree = await import(require.resolve("@typescript-eslint/typescript-estree", { paths: [dirPath] }));
-  process.env.TSESTREE_SINGLE_RUN = 'true'
+  process.env.TSESTREE_SINGLE_RUN = "true";
   // TODO: To remove tslint, replace this with a ts.createProgram (probably)
   const lintProgram = Linter.createProgram(tsconfigPath);
 

--- a/packages/dtslint/src/lint.ts
+++ b/packages/dtslint/src/lint.ts
@@ -21,6 +21,8 @@ export async function lint(
   tsLocal: string | undefined
 ): Promise<string | undefined> {
   const tsconfigPath = joinPaths(dirPath, "tsconfig.json");
+  const estree = await import(require.resolve("@typescript-eslint/typescript-estree", { paths: [dirPath] }));
+  process.env.TSESTREE_SINGLE_RUN = 'true'
   // TODO: To remove tslint, replace this with a ts.createProgram (probably)
   const lintProgram = Linter.createProgram(tsconfigPath);
 
@@ -74,6 +76,8 @@ export async function lint(
     const formatter = await eslint.loadFormatter("stylish");
     const eresults = await eslint.lintFiles(esfiles);
     output += formatter.format(eresults);
+    estree.clearProgramCache();
+    estree.clearCaches();
     process.chdir(cwd);
   }
 

--- a/packages/dtslint/src/rules/noRedundantJsdoc2Rule.ts
+++ b/packages/dtslint/src/rules/noRedundantJsdoc2Rule.ts
@@ -59,10 +59,12 @@ function walk(ctx: Lint.WalkContext<void>): void {
     const jsdocSeeTag = (ts.SyntaxKind as any).JSDocSeeTag || 0;
     const jsdocDeprecatedTag = (ts.SyntaxKind as any).JSDocDeprecatedTag || 0;
     const jsdocThrowsTag = (ts.SyntaxKind as any).JSDocThrowsTag || 0;
+    const jsdocOverrideTag = (ts.SyntaxKind as any).JSDocOverrideTag || 0;
     switch (tag.kind) {
       case jsdocSeeTag:
       case jsdocDeprecatedTag:
       case jsdocThrowsTag:
+      case jsdocOverrideTag:
       case ts.SyntaxKind.JSDocAuthorTag:
         // @deprecated and @see always have meaning
         break;


### PR DESCRIPTION
1. typescript-eslint memory usage workaround provided by @bradzacher in https://github.com/typescript-eslint/typescript-eslint/issues/6462. Clear caches after each run so that ts.Program objects aren't retained forever.
2. typescript-eslint speedup provided the same way. Avoid constructing some objects that are only needed for editors.
3. Add yet another jsdoc tag to no-redundant-jsdoc2
4. Correct and reduce amount of perf-related printing at end of ExpectRule. The correction is needed now that ExpectRule saves the equivalent of --extendedDiagnostics after running; I changed the name of the properties to match.