### PR TITLE
Delete estree.clearProgramCache

### DIFF
--- a/packages/dtslint/src/lint.ts
+++ b/packages/dtslint/src/lint.ts
@@ -76,7 +76,6 @@ export async function lint(
     const formatter = await eslint.loadFormatter("stylish");
     const eresults = await eslint.lintFiles(esfiles);
     output += formatter.format(eresults);
-    estree.clearProgramCache();
     estree.clearCaches();
     process.chdir(cwd);
   }


### PR DESCRIPTION
1. The newest version of estree makes clearCaches clear all caches, not just the watch caches.
2. The newest version of estree also mistakenly exports clearProgramCache as the *call* of clearCaches, not an alias for it.

Previous to the new version of estree, clearCaches and clearProgramCache were two different things, and both were needed to avoid running out of memory in dtslint-runner.