### PR TITLE
chore (definition-parser): whitelist react-router-native

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -767,6 +767,9 @@ react-native-svg
 react-native-tab-view
 react-navigation
 react-popper
+react-router
+react-router-dom
+react-router-native
 recast
 recharts
 redis


### PR DESCRIPTION
i actually whitelisted react-router and react-router-dom in this too as ill soon be opening a PR around that over at DT too.

all are depended on by other DT packages (or will be imminently)