### PR TITLE
Add lil-gui to allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -683,6 +683,7 @@ kleur
 knex
 knockout
 levelup
+lil-gui
 lit-element
 localforage
 log4js


### PR DESCRIPTION
Needed for three.js types, since three.js re-exports lil-gui (see https://github.com/three-types/three-ts-types/pull/358).