### PR TITLE
Ignore files outside of DT repo for module resolution when detecting used files

### DIFF
--- a/packages/definitions-parser/src/lib/definition-parser.ts
+++ b/packages/definitions-parser/src/lib/definition-parser.ts
@@ -68,7 +68,7 @@ export async function getTypingInfo(packageName: string, dt: FS): Promise<Typing
     }
   );
 
-  const moduleResolutionHost = createModuleResolutionHost(dt);
+  const moduleResolutionHost = createModuleResolutionHost(dt, dt.debugPath());
   const considerLibraryMinorVersion = olderVersionDirectories.some(({ version }) => version.minor !== undefined);
 
   const latestData: TypingsDataRaw = {

--- a/packages/definitions-parser/src/lib/module-info.ts
+++ b/packages/definitions-parser/src/lib/module-info.ts
@@ -164,9 +164,12 @@ export function allReferencedFiles(
     // E.g. 'index.d.ts' - suitable for lookups in `fs` and for our result
     const relativeFileName = path.relative(baseDirectory, resolvedFileName);
     if (path.relative(packageDirectory, resolvedFileName).startsWith("..")) {
+      // We only collected references that started with the current package name or were relative,
+      // so if we resolve an import to something outside the package, we know it was a relative
+      // import to a different package.
       throw new Error(
         `${containingFileName ?? "tsconfig.json"}: ` +
-          'Definitions must use global references to other packages, not parent ("../xxx") references.' +
+          'Definitions must use global references to other packages, not parent ("../xxx") references. ' +
           `(Based on reference '${ref.text}')`
       );
     }

--- a/packages/utils/src/fs.ts
+++ b/packages/utils/src/fs.ts
@@ -38,15 +38,18 @@ export interface FS {
   debugPath(): string;
 }
 
-export function createModuleResolutionHost(fs: FS): import("typescript").ModuleResolutionHost {
+export function createModuleResolutionHost(fs: FS, ignoreFilesAboveDirectory?: string): import("typescript").ModuleResolutionHost {
   return {
-    fileExists: (filename) => fs.exists(filename),
-    readFile: (filename) => fs.readFile(filename),
-    directoryExists: (directoryName) => fs.exists(directoryName),
+    fileExists: (fileName) => !isIgnored(fileName) && fs.exists(fileName),
+    readFile: (fileName) => (assert(!isIgnored(fileName)), fs.readFile(fileName)),
+    directoryExists: (directoryName) => !isIgnored(directoryName) && fs.exists(directoryName),
     getCurrentDirectory: () => "",
     realpath: (path) => path,
     useCaseSensitiveFileNames: () => true,
   };
+  function isIgnored(path: string): boolean {
+    return ignoreFilesAboveDirectory !== undefined && path !== ignoreFilesAboveDirectory && !path.startsWith(ignoreFilesAboveDirectory);
+  }
 }
 
 interface ReadonlyDir extends ReadonlyMap<string, ReadonlyDir | string> {

--- a/packages/utils/test/fs.test.ts
+++ b/packages/utils/test/fs.test.ts
@@ -1,0 +1,25 @@
+import { createModuleResolutionHost, InMemoryFS, Dir } from "../src/fs";
+
+describe("fs", () => {
+  describe("createModuleResolutionHost", () => {
+    it("can ignore files above a given directory", () => {
+      // a/
+      //  a.ts
+      //  b/
+      //   b.ts
+      const dirA = new Dir(undefined);
+      const dirB = new Dir(dirA);
+      dirA.set("a.ts", "a");
+      dirA.set("b", dirB);
+      dirB.set("b.ts", "b");
+      const rootFs = new InMemoryFS(dirA, "/a/");
+      const host = createModuleResolutionHost(rootFs, /*ignoreFilesAboveDirectory*/ "/a/b");
+
+      expect(rootFs.exists("/a/a.ts")).toBe(true);
+      expect(rootFs.exists("/a/b/b.ts")).toBe(true);
+
+      expect(host.fileExists("/a/a.ts")).toBe(false); // <-- ignored
+      expect(host.fileExists("/a/b/b.ts")).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Imports of ambient module names won’t resolve to local files without the use of the type checker, and are supposed to be ignored during used file detection. But instead, they might resolve to something in a rogue ancestor node_modules present on the CI runner. This makes the module resolution host pretend those files don’t exist.