### PR TITLE
Add fflate to allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -631,6 +631,7 @@ express-graphql
 express-rate-limit
 fast-glob
 fastify
+fflate
 final-form
 filestack-js
 firebase-admin


### PR DESCRIPTION
Needed for three.js types, since three.js re-exports fflate.