### PR TITLE
Link to DT support window rather than mentioning TS 2.0

### DIFF
--- a/packages/dtslint/README.md
+++ b/packages/dtslint/README.md
@@ -107,7 +107,7 @@ f("one");
 
 ## Specify a TypeScript version
 
-Normally packages will be tested using TypeScript 2.0.
+Normally packages will be tested according to [DefinitelyType's support window](https://github.com/DefinitelyTyped/DefinitelyTyped#support-window).
 To use a newer version, specify it by including a comment like so:
 
 ```ts


### PR DESCRIPTION
This came up in a DT PR review, where the author thought they had to specify the version if it needed something newer than 2.0.

Maybe the example should say something newer too.