### PR TITLE
Handle EmptyStatement at top-level in global files

### DIFF
--- a/packages/definitions-parser/src/lib/module-info.ts
+++ b/packages/definitions-parser/src/lib/module-info.ts
@@ -65,6 +65,7 @@ export function getModuleInfo(packageName: string, all: Map<string, ts.SourceFil
           case ts.SyntaxKind.ImportEqualsDeclaration:
           case ts.SyntaxKind.InterfaceDeclaration:
           case ts.SyntaxKind.TypeAliasDeclaration:
+          case ts.SyntaxKind.EmptyStatement:
             break;
           default:
             throw new Error(`Unexpected node kind ${ts.SyntaxKind[node.kind]}`);

--- a/packages/definitions-parser/test/definition-parser.test.ts
+++ b/packages/definitions-parser/test/definition-parser.test.ts
@@ -21,8 +21,8 @@ describe(getTypingInfo, () => {
 
   it("works for non-module files with empty statements", async () => {
     const dt = createMockDT();
-    const scopedWithOlderScopedDependency = dt.pkgDir("ckeditor__ckeditor5-engine");
-    scopedWithOlderScopedDependency.set(
+    const d = dt.pkgDir("example");
+    d.set(
       "index.d.ts",
       `// Type definitions for example 1.0
 // Project: https://github.com/example/com
@@ -32,7 +32,7 @@ describe(getTypingInfo, () => {
 ;;`
     );
 
-    scopedWithOlderScopedDependency.set(
+    d.set(
       "tsconfig.json",
       JSON.stringify({
         files: ["index.d.ts"],
@@ -41,7 +41,7 @@ describe(getTypingInfo, () => {
       })
     );
 
-    const info = await getTypingInfo("@ckeditor/ckeditor5-engine", dt.fs);
+    const info = await getTypingInfo("example", dt.fs);
     expect(info).toBeDefined();
   })
   it("works for a scoped package with scoped older dependencies", async () => {

--- a/packages/definitions-parser/test/definition-parser.test.ts
+++ b/packages/definitions-parser/test/definition-parser.test.ts
@@ -19,6 +19,31 @@ describe(getTypingInfo, () => {
     expect(info).toBeDefined();
   });
 
+  it("works for non-module files with empty statements", async () => {
+    const dt = createMockDT();
+    const scopedWithOlderScopedDependency = dt.pkgDir("ckeditor__ckeditor5-engine");
+    scopedWithOlderScopedDependency.set(
+      "index.d.ts",
+      `// Type definitions for example 1.0
+// Project: https://github.com/example/com
+// Definitions by: My Self <https://github.com/ñ>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+;;`
+    );
+
+    scopedWithOlderScopedDependency.set(
+      "tsconfig.json",
+      JSON.stringify({
+        files: ["index.d.ts"],
+        compilerOptions: {
+        },
+      })
+    );
+
+    const info = await getTypingInfo("@ckeditor/ckeditor5-engine", dt.fs);
+    expect(info).toBeDefined();
+  })
   it("works for a scoped package with scoped older dependencies", async () => {
     const dt = createMockDT();
     const scopedWithOlderScopedDependency = dt.pkgDir("ckeditor__ckeditor5-engine");
@@ -71,7 +96,7 @@ export function myFunction(arg:string): string;
   });
 
   it("allows path mapping to older versions", () => {
-    // Actually, the default seup already has 'has-older-test-dependency', so probably doesn't need an explicit test
+    // Actually, the default setup already has 'has-older-test-dependency', so probably doesn't need an explicit test
     const dt = createMockDT();
     dt.addOldVersionOfPackage("jquery", "1.42");
     dt.addOldVersionOfPackage("jquery", "2");


### PR DESCRIPTION
getModuleInfo's per-node handling of top-level statements in a non-module sourcefile forgot to include EmptyStatement.