### PR TITLE
Drop tslint.json exact "extends" requirement outside of DefinitelyTyped

### DIFF
--- a/packages/dtslint/src/lint.ts
+++ b/packages/dtslint/src/lint.ts
@@ -193,8 +193,6 @@ function testNoLintDisables(disabler: "tslint:disable" | "eslint-disable", text:
 export async function checkTslintJson(dirPath: string, dt: boolean): Promise<void> {
   const configPath = getConfigPath(dirPath);
   const shouldExtend = `@definitelytyped/dtslint/${dt ? "dt" : "dtslint"}.json`;
-  const validateExtends = (extend: string | string[]) =>
-    extend === shouldExtend || (!dt && Array.isArray(extend) && extend.some((val) => val === shouldExtend));
 
   if (!(await pathExists(configPath))) {
     if (dt) {
@@ -206,10 +204,7 @@ export async function checkTslintJson(dirPath: string, dt: boolean): Promise<voi
     return;
   }
 
-  const tslintJson = await readJson(configPath);
-  if (!validateExtends(tslintJson.extends)) {
-    throw new Error(`If 'tslint.json' is present, it should extend "${shouldExtend}"`);
-  }
+  await readJson(configPath);
 }
 
 function getConfigPath(dirPath: string): string {


### PR DESCRIPTION
The below validation rule, where any `tslint.json` file read by `dtslint` must contain `"extends": "@definitelytyped/dtslint/dtslint.json"`, is overly strict.

https://github.com/microsoft/DefinitelyTyped-tools/blob/9b08cd6c2bf48e8683527f4cb88d1bf29eb59e80/packages/dtslint/src/lint.ts#L209-L212

In this PR, I'm suggesting that this logic be reduced — validating that the JSON file is parsable only. (The strict check remains unchanged when `isDT` (within DefinitelyTyped repo) is `true`.)

**Motivation**

- In a monorepo setup, it's common to share config files by extending a file in a parent folder. This is allowed by `eslint`/`tslint`. However, when using `dtslint`, this convention breaks.

```js
{
  // The parent tslint.json *does* extend @definitelytyped/dtslint/dtslint.json
  "extends": "../../../tslint.json"
}
```

<img width="828" alt="image" src="https://user-images.githubusercontent.com/2547783/225111528-7d0dbda4-ade5-4155-9755-cecd87d3e793.png">

- A minimal config extending `@definitelytyped/dtslint/dtslint.json` is already [clearly documented in the README for new users](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint#typestslintjson) — I don't believe this restriction needs to exist within the tool.

**Test plan**

- When locally updated, command passes the `tslint.json` validation step (gets stuck on `tsconfig.json` step instead due to more direct validation of contents 😅).
