### PR TITLE
Add @types/glob to list

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -480,6 +480,7 @@
 @types/favicons
 @types/firebase
 @types/generic-pool
+@types/glob
 @types/got
 @types/hapi
 @types/helmet


### PR DESCRIPTION
This is because as of 9.0.0, glob has its own types

Look at the DefinatelyTyped repo PR for more details:

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64810

I have raised this PR because while trying to create the said PR above, I received this error:

```bash
Error: In package.json: Dependency @types/glob not in the allowed dependencies list.
Don't use a 'package.json' for @types dependencies unless this package relies on
an old version of types that have since been moved to the source repo.
For example, if package *P* used to have types on Definitely Typed at @types/P,
but now has its own types, a dependent package *D* will need to use package.json
to refer to @types/P if it relies on old versions of P's types.
In this case, please make a pull request to microsoft/DefinitelyTyped-tools adding @types/P to `packages/definitions-parser/allowedPackageJsonDependencies.txt`.
```