### PR TITLE
Allow the use of `glob` in `@types/`-packages

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -645,6 +645,7 @@ fs-jetpack
 generic-pool
 gl-matrix
 glaze
+glob
 globby
 google-auth-library
 google-gax


### PR DESCRIPTION
The types in the `glob` package and the types in the `@types/glob` package are incompatible (as some of their exposed interfaces have different names). Currently, a project using the `glob` dependency which has for whatever reason `@types/glob` in its dependency tree (through `yeoman-test`, or `yeoman-generator`, for example) won't be able to be built using TypeScript.

For that reason, packages in DefinitelyTyped should be updated to use the `glob` dependency rather than the `@types/glob` dependency.

Changes made in this PR make sure that the `glob` dependency is allowed for DefinitelyTyped packages as a preparation for the migration.