### PR TITLE
Pass --legacy-peer-deps at npm install

### DIFF
--- a/packages/utils/src/io.ts
+++ b/packages/utils/src/io.ts
@@ -178,7 +178,7 @@ export async function isDirectory(path: string): Promise<boolean> {
 }
 
 export const npmInstallFlags =
-  "--ignore-scripts --no-shrinkwrap --no-package-lock --no-bin-links --no-save --no-audit --no-fund";
+  "--ignore-scripts --no-shrinkwrap --no-package-lock --no-bin-links --no-save --no-audit --no-fund --legacy-peer-deps";
 const downloadTimeout = 1_000_000; // ms
 const connectionTimeout = 800_000; // ms
 


### PR DESCRIPTION
Unbreaks `wordpress__block-editor`.