### PR TITLE
chore (definitions-parser): whitelist react-router

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -509,6 +509,8 @@
 @types/react-leaflet
 @types/react-native-tab-view
 @types/react-navigation
+@types/react-router
+@types/react-router-dom
 @types/react-select
 @types/redis
 @types/responselike


### PR DESCRIPTION
think im gonna need this for some of the really old packages when i remove the react-router types

a few use types no longer available in the new react-router, with no obvious equivalent. so ill keep them on the old DT types for now