### PR TITLE
Remove no-import-default-of-export-equals from dtslint.json

### DIFF
--- a/packages/dtslint/dtslint.json
+++ b/packages/dtslint/dtslint.json
@@ -4,7 +4,6 @@
     "rules": {
         // Custom rules
         "expect": true,
-        "no-import-default-of-export-equals": true,
         "no-padding": true,
         "no-relative-import-in-test": true,
         "strict-export-declare-modifiers": true,


### PR DESCRIPTION
I missed it in my earlier PR