### PR TITLE
Add types-ramda to allowedPackageJsonDependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -825,6 +825,7 @@ tweetnacl
 typeorm
 typescript
 typescript-tuple
+types-ramda
 unified
 url-pattern
 utility-types


### PR DESCRIPTION
Specifically for this MR: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64939

`ramda` is moving type definitions in house with in the intention for those types to exist within the main `ramda` package. In the meanwhile, `@types/ramda` will re-export the new `types-ramda` package while we solidify the existing types and work on the next `ramda` release that will include those types in-package