### PR TITLE
chore(definitions-parser): allow `@types/sharp` as dependency

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -516,6 +516,7 @@
 @types/responselike
 @types/rimraf
 @types/rsmq
+@types/sharp
 @types/socket.io
 @types/socket.io-client
 @types/svgo


### PR DESCRIPTION
Required for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64983/files as sharp >= 0.32 now includes official typings.