### PR TITLE
Add wordpress components to allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -568,6 +568,7 @@
 @wordpress/core-data
 @wordpress/data
 @wordpress/element
+@wordpress/components
 abort-controller
 acorn
 actions-on-google

--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -565,10 +565,10 @@
 @vue/reactivity
 @vue/test-utils
 @wordpress/api-fetch
+@wordpress/components
 @wordpress/core-data
 @wordpress/data
 @wordpress/element
-@wordpress/components
 abort-controller
 acorn
 actions-on-google


### PR DESCRIPTION
`@wordpress/components` now ships types (see https://www.npmjs.com/package/@wordpress/components)

Since I'd like to remove the DT types here (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65213), and since we now need to use npm to import this package for some other `@types/wordpress` packages, it should be added to this lsit