### PR TITLE
Add @react-native/virtualized-lists to allowed deps

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -474,6 +474,7 @@
 @popperjs/core
 @puppeteer/replay
 @rdfjs/types
+@react-native/virtualized-lists
 @react-navigation/native
 @react-navigation/stack
 @sentry/browser


### PR DESCRIPTION
Adding [@react-native/virtualized-lists](https://www.npmjs.com/package/@react-native/virtualized-lists?activeTab=versions) to allowed dependencies as React Native 0.72 typings depend on it. 

Adding this here because of the error running `yarn test-all` in DefinitelyTyped
```
Error: In package.json: Dependency @react-native/virtualized-lists not in the allowed dependencies list.
If you are depending on another `@types` package, do *not* add it to a `package.json`. Path mapping should make the import work.
For namespaced dependencies you then have to add a `paths` mapping from `@namespace/*` to `namespace__*` in `tsconfig.json`.
If this is an external library that provides typings,  please make a pull request to microsoft/DefinitelyTyped-tools adding it to `packages/definitions-parser/allowedPackageJsonDependencies.txt`.
```
This is the active branch of releasing React Native 0.72 types: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65282/files#diff-2d08ee5e33d7446c67ab29224efa740bfde978bfb9f0109e061e87f7ff7af6dbR4