### PR TITLE
Add gray-matter to allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -674,6 +674,7 @@ google-gax
 got
 graphql
 graphql-tools
+gray-matter
 grpc
 handlebars
 helmet


### PR DESCRIPTION
Add gray-matter to the allowed dependencies for DefinitelyTyped definitions.  I am updating `@types/metalsmith`, and the updates include a reference to `gray-matter`.