### PR TITLE
Lint against supported TS versions not just shipped

### DIFF
--- a/packages/dtslint/src/lint.ts
+++ b/packages/dtslint/src/lint.ts
@@ -257,14 +257,14 @@ function range(minVersion: TsVersion, maxVersion: TsVersion): readonly TsVersion
   }
   assert(maxVersion !== "local");
 
-  const minIdx = TypeScriptVersion.shipped.indexOf(minVersion);
+  const minIdx = TypeScriptVersion.supported.indexOf(minVersion);
   assert(minIdx >= 0);
   if (maxVersion === TypeScriptVersion.latest) {
-    return [...TypeScriptVersion.shipped.slice(minIdx), TypeScriptVersion.latest];
+    return [...TypeScriptVersion.supported.slice(minIdx), TypeScriptVersion.latest];
   }
-  const maxIdx = TypeScriptVersion.shipped.indexOf(maxVersion as TypeScriptVersion);
+  const maxIdx = TypeScriptVersion.supported.indexOf(maxVersion as TypeScriptVersion);
   assert(maxIdx >= minIdx);
-  return TypeScriptVersion.shipped.slice(minIdx, maxIdx + 1);
+  return TypeScriptVersion.supported.slice(minIdx, maxIdx + 1);
 }
 
 export type TsVersion = TypeScriptVersion | "local";


### PR DESCRIPTION
Fixes
```
AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:

  assert(minIdx >= 0)

    at range (/home/runner/work/DefinitelyTyped/DefinitelyTyped/node_modules/@definitelytyped/dtslint-runner/node_modules/@definitelytyped/dtslint/src/lint.ts:261:3)
    at getLintConfig (/home/runner/work/DefinitelyTyped/DefinitelyTyped/node_modules/@definitelytyped/dtslint-runner/node_modules/@definitelytyped/dtslint/src/lint.ts:239:28)
    at lint (/home/runner/work/DefinitelyTyped/DefinitelyTyped/node_modules/@definitelytyped/dtslint-runner/node_modules/@definitelytyped/dtslint/src/lint.ts:40:18)
    at testTypesVersion (/home/runner/work/DefinitelyTyped/DefinitelyTyped/node_modules/@definitelytyped/dtslint-runner/node_modules/@definitelytyped/dtslint/src/index.ts:233:15)
    at runTests (/home/runner/work/DefinitelyTyped/DefinitelyTyped/node_modules/@definitelytyped/dtslint-runner/node_modules/@definitelytyped/dtslint/src/index.ts:197:7)
Error: Process completed with exit code 1.
```
-- https://github.com/DefinitelyTyped/DefinitelyTyped/actions/runs/5030923969/jobs/9023668157?pr=65135#step:6:1920
Only verified these changes locally with `npm run test react`.