### PR TITLE
Add flatbush to allowed dependencies now that it ships its own types

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -659,6 +659,7 @@ fflate
 final-form
 filestack-js
 firebase-admin
+flatbush
 flatpickr
 form-data
 fs-capacitor


### PR DESCRIPTION
Required for the DefinitelyTyped update to remove `flatbush` there (required for `geoflatbush`)
https://github.com/mourner/flatbush/releases/tag/v4.2.0