### PR TITLE
Add meshoptimizer to allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -722,6 +722,7 @@ logrocket
 lottie-web
 magic-string
 mali
+meshoptimizer
 metascraper
 meteor-typings
 middy


### PR DESCRIPTION
Required for https://github.com/three-types/three-ts-types/pull/514.