### PR TITLE
add ember-source as allowed dependency

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -645,6 +645,7 @@ electron-store
 ember-cli-htmlbars
 ember-qunit
 ember-resolver
+ember-source
 eris
 ethers
 eventemitter2


### PR DESCRIPTION
ember-source ships types directly as a replacement for the @types/ember types in newer versions of ember.js

required for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66086