### PR TITLE
feat: export `install` function from typescript-installer

### DIFF
--- a/packages/utils/src/typescript-installer.ts
+++ b/packages/utils/src/typescript-installer.ts
@@ -25,7 +25,7 @@ export async function installTypeScriptNext() {
   await install("next");
 }
 
-async function install(version: TsVersion | "next" | "rc"): Promise<void> {
+export async function install(version: TsVersion | "next" | "rc"): Promise<void> {
   if (version === "local") {
     return;
   }


### PR DESCRIPTION
Hi,

We'd like to install some old versions to test the generated types to check compatibility, but current exposed `installAllTypeScriptVersions` can only install the supported (shipped/rc/next) versions.

So I want to suggest exporting the `install` function to enable the ability to install any needed version of typescript.
(Resolves #434)

Thank you.