### PR TITLE
feat: Added aggregate-error to allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -577,6 +577,7 @@ acorn
 actions-on-google
 activex-helpers
 adal-node
+aggregate-error
 ajv
 algoliasearch
 algoliasearch-helper


### PR DESCRIPTION
Aggregate error is a package uses by semantic-release, and is required for the type definitions for v21.

https://www.npmjs.com/package/aggregate-error

PR on DT: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66223