### PR TITLE
Remove ts-ignore check, to be replaced with eslint rule

### DIFF
--- a/packages/dtslint/dtslint.json
+++ b/packages/dtslint/dtslint.json
@@ -63,6 +63,7 @@
         "prefer-method-signature": false, // TODO?
 
         // Pretty sure we don't want these
+        "ban-ts-ignore": false, // Provided by ts-eslint
         "binary-expression-operand-order": false,
         "class-name": false,
         "completed-docs": false,

--- a/packages/dtslint/src/lint.ts
+++ b/packages/dtslint/src/lint.ts
@@ -48,7 +48,6 @@ export async function lint(
     const { fileName, text } = file;
     if (!fileName.includes("node_modules")) {
       const err =
-        testNoTsIgnore(text) ||
         testNoLintDisables("tslint:disable", text) ||
         testNoLintDisables("eslint-disable", text);
       if (err) {
@@ -158,11 +157,6 @@ function startsWithDirectory(filePath: string, dirPath: string): boolean {
 interface Err {
   pos: number;
   message: string;
-}
-function testNoTsIgnore(text: string): Err | undefined {
-  const tsIgnore = "ts-ignore";
-  const pos = text.indexOf(tsIgnore);
-  return pos === -1 ? undefined : { pos, message: "'ts-ignore' is forbidden." };
 }
 function testNoLintDisables(disabler: "tslint:disable" | "eslint-disable", text: string): Err | undefined {
   let lastIndex = 0;


### PR DESCRIPTION
See: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65703#discussion_r1282552441

This will be replaced with `@typescript-eslint/ban-ts-comment` in the eslint config in the DT repo (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66274)