### PR TITLE
Support 5.3

### DIFF
--- a/packages/header-parser/test/index.test.ts
+++ b/packages/header-parser/test/index.test.ts
@@ -169,7 +169,7 @@ describe("isTypeScriptVersion", () => {
 
 describe("range", () => {
   it("works", () => {
-    expect(TypeScriptVersion.range("4.7")).toEqual(["4.7", "4.8", "4.9", "5.0", "5.1", "5.2"]);
+    expect(TypeScriptVersion.range("4.7")).toEqual(["4.7", "4.8", "4.9", "5.0", "5.1", "5.2", "5.3"]);
   });
   it("includes 4.3 onwards", () => {
     expect(TypeScriptVersion.range("4.3")).toEqual(TypeScriptVersion.supported);
@@ -178,7 +178,7 @@ describe("range", () => {
 
 describe("tagsToUpdate", () => {
   it("works", () => {
-    expect(TypeScriptVersion.tagsToUpdate("5.0")).toEqual(["ts5.0", "ts5.1", "ts5.2", "latest"]);
+    expect(TypeScriptVersion.tagsToUpdate("5.0")).toEqual(["ts5.0", "ts5.1", "ts5.2", "ts5.3", "latest"]);
   });
   it("allows 4.4 onwards", () => {
     expect(TypeScriptVersion.tagsToUpdate("4.4")).toEqual(

--- a/packages/typescript-versions/src/index.ts
+++ b/packages/typescript-versions/src/index.ts
@@ -57,7 +57,7 @@ export type UnsupportedTypeScriptVersion =
  * Parseable and supported TypeScript versions.
  * Only add to this list if we will support this version on Definitely Typed.
  */
-export type TypeScriptVersion = "4.4" | "4.5" | "4.6" | "4.7" | "4.8" | "4.9" | "5.0" | "5.1" | "5.2";
+export type TypeScriptVersion = "4.4" | "4.5" | "4.6" | "4.7" | "4.8" | "4.9" | "5.0" | "5.1" | "5.2" | "5.3";
 
 export type AllTypeScriptVersion = UnsupportedTypeScriptVersion | TypeScriptVersion;
 
@@ -65,7 +65,7 @@ export namespace TypeScriptVersion {
   /** Add to this list when a version actually ships.  */
   export const shipped: readonly TypeScriptVersion[] = ["4.4", "4.5", "4.6", "4.7", "4.8", "4.9", "5.0", "5.1"];
   /** Add to this list when a version is available as typescript@next */
-  export const supported: readonly TypeScriptVersion[] = [...shipped, "5.2"];
+  export const supported: readonly TypeScriptVersion[] = [...shipped, "5.2", "5.3"];
   /** Add to this list when it will no longer be supported on Definitely Typed */
   export const unsupported: readonly UnsupportedTypeScriptVersion[] = [
     "2.0",


### PR DESCRIPTION
To be merged after 5.2 has its own branch and `typescript@next`'s version is 5.3