### PR TITLE
Add markdownlint as allowed package.json dependency

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -721,6 +721,7 @@ loglevel
 logrocket
 lottie-web
 magic-string
+markdownlint
 mali
 metascraper
 meteor-typings


### PR DESCRIPTION
In support of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66413.