### PR TITLE
Disable tslint rules broken in TS5.0

### DIFF
--- a/packages/dtslint/dtslint.json
+++ b/packages/dtslint/dtslint.json
@@ -2,6 +2,11 @@
     "extends": "tslint:all",
     "rulesDirectory": "./dist/rules",
     "rules": {
+        // Broken in Typescript 5.0 and above:
+        "unnecessary-bind": false,
+        "no-unnecessary-initializer": false,
+        "prefer-for-of": false,
+        "only-arrow-functions": false,
         // Custom rules
         "expect": true,
         "no-padding": true,
@@ -29,7 +34,6 @@
             "check-whitespace"
         ],
         "one-variable-per-declaration": [true, "ignore-for-loop"],
-        "only-arrow-functions": [true, "allow-declarations", "allow-named-functions"],
         "prefer-template": [true, "allow-single-concat"],
         "whitespace": [
             true,


### PR DESCRIPTION
These are only the ones that fail on a full run; in theory any of them could fail at any time because they nearly all import tsutils, which uses Identifier.originalKeywordKind, the property that is deprecated in TS 5.0.

I don't think any of these are worth looking for an eslint equivalent.