### PR TITLE
add `xlsx` package for `tabulator-tables` types

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -873,6 +873,7 @@ web-tree-sitter
 winston
 winston-transport
 workbox-build
+xlsx
 xmlbuilder
 xpath
 yup


### PR DESCRIPTION
Adds `xlsx` package (SheetJS) for inclusion in tabulator-tables types.

This package is used within Tabulator, and options can be passed in as part of Tabulator's own [XLSX Downloader Options](https://tabulator.info/docs/5.5/release#download).

The package is only available via CDN currently (not NPM) according to their [documentation](https://docs.sheetjs.com/docs/getting-started/installation/nodejs).
