### PR TITLE
chore: Audit unused eslint disables.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "prepare": "lerna bootstrap --no-ci",
     "pretest": "yarn build",
-    "lint": "eslint . --ext .ts",
+    "lint": "eslint . --report-unused-disable-directives --ext .ts",
     "format": "prettier --write 'packages/**/*.ts'",
     "test": "jest",
     "build": "tsc -b .",

--- a/packages/dtslint/src/lint.ts
+++ b/packages/dtslint/src/lint.ts
@@ -156,7 +156,6 @@ interface Err {
 }
 function testNoLintDisables(disabler: "tslint:disable" | "eslint-disable", text: string): Err | undefined {
   let lastIndex = 0;
-  // eslint-disable-next-line no-constant-condition
   while (true) {
     const pos = text.indexOf(disabler, lastIndex);
     if (pos === -1) {

--- a/packages/dtslint/src/rules/expectRule.ts
+++ b/packages/dtslint/src/rules/expectRule.ts
@@ -291,7 +291,6 @@ function parseAssertions(sourceFile: SourceFile): Assertions {
   const lineStarts = sourceFile.getLineStarts();
   let curLine = 0;
 
-  // eslint-disable-next-line no-constant-condition
   while (true) {
     const commentMatch = commentRegexp.exec(text);
     if (commentMatch === null) {

--- a/packages/dtslint/src/rules/noRedundantJsdoc2Rule.ts
+++ b/packages/dtslint/src/rules/noRedundantJsdoc2Rule.ts
@@ -78,7 +78,6 @@ function walk(ctx: Lint.WalkContext<void>): void {
         break;
       }
 
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore (fallthrough)
       case ts.SyntaxKind.JSDocTemplateTag:
         if (tag.comment !== "") {
@@ -161,7 +160,6 @@ function removeTag(tag: ts.JSDocTag, sourceFile: ts.SourceFile): Lint.Replacemen
   // For some tags, like `@name`, `end` will be before the start of the comment.
   // And `@typedef` doesn't end until the last `@property` tag attached to it ends.
   switch (tag.tagName.text) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore (fallthrough)
     case "param": {
       const { isBracketed, isNameFirst, typeExpression } = tag as ts.JSDocParameterTag;
@@ -170,7 +168,6 @@ function removeTag(tag: ts.JSDocTag, sourceFile: ts.SourceFile): Lint.Replacemen
       }
       // falls through
     }
-    // eslint-disable-next-line no-fallthrough
     case "name":
     case "return":
     case "returns":

--- a/packages/eslint-plugin/src/rules/no-dead-reference.ts
+++ b/packages/eslint-plugin/src/rules/no-dead-reference.ts
@@ -24,7 +24,6 @@ const rule = createRule({
       // Start search at the first statement. (`/// <reference>` before that is OK.)
       rgx.lastIndex = source.ast.body[0].range?.[0] ?? 0;
 
-      // eslint-disable-next-line no-constant-condition
       while (true) {
         const match = rgx.exec(source.text);
         if (match === null) {


### PR DESCRIPTION
# What?

Fail the CI/Local build if we are using eslint-disable spuriously.


More information -> [here](https://eslint.org/docs/latest/use/command-line-interface#:~:text=%2D%2Dreport%2Dunused%2Ddisable%2Ddirectives,-This%20option%20causes&text=This%20can%20be%20useful%20to,which%20are%20no%20longer%20applicable.&text=When%20using%20this%20option%2C%20it,or%20custom%20rules%20are%20upgraded.)

# Why?

It's a bit confusing seeing `eslint-disable` on some of the violations like the `@ts-ignores` and some not.

This either was due to accidentally removing that rule or we no longer want to enforce, if the latter, lets clean it up.

# How?

Unfortunately, eslint **only** errors if we have this as part of the CLI Arguments `--report-unused-disable-directives`.

```
/Users/marcinstrzyz/src/DefinitelyTyped-tools/packages/dtslint/src/rules/noRedundantJsdoc2Rule.ts
   81:7  error  Unused eslint-disable directive (no problems were reported from '@typescript-eslint/ban-ts-comment')
  164:5  error  Unused eslint-disable directive (no problems were reported from '@typescript-eslint/ban-ts-comment')
```


adding `reportUnusedDisableDirectives` to eslintrc only provides a warning.



