### PR TITLE
feat: remove comment-space from dtslint.json too

### DIFF
--- a/packages/dtslint/dtslint.json
+++ b/packages/dtslint/dtslint.json
@@ -15,7 +15,6 @@
         "void-return": true,
         "npm-naming": true,
 
-        "comment-format": [true, "check-space"], // But not check-uppercase or check-lowercase
         "interface-name": [true, "never-prefix"],
         "member-access": [true, "no-public"],
         "no-unnecessary-callback-wrapper": true,


### PR DESCRIPTION
Followup to #699. @sandersn pointed out that it was missed - I hadn't realized dprint covers this too! 