### PR TITLE
fix: set comment-format to false, explicitly

### DIFF
--- a/packages/dtslint/dtslint.json
+++ b/packages/dtslint/dtslint.json
@@ -46,6 +46,7 @@
         "ban-ts-ignore": false, // Provided by ts-eslint
         "binary-expression-operand-order": false,
         "class-name": false,
+        "comment-format": false,
         "completed-docs": false,
         "curly": false,
         "cyclomatic-complexity": false,


### PR DESCRIPTION
dtslint extends from `tslint:all`, so it's not enough to just remove a rule...

Follow-up to #721. 