### PR TITLE
no-relative-import-in-test: also skip .d.mts/cts

### DIFF
--- a/packages/eslint-plugin/src/rules/no-relative-import-in-test.ts
+++ b/packages/eslint-plugin/src/rules/no-relative-import-in-test.ts
@@ -18,7 +18,11 @@ const rule = createRule({
     schema: [],
   },
   create(context) {
-    if (context.getFilename().endsWith(".d.ts")) {
+    if (
+      context.getFilename().endsWith(".d.ts") ||
+      context.getFilename().endsWith(".d.mts") ||
+      context.getFilename().endsWith(".d.cts")
+    ) {
       return {};
     }
 


### PR DESCRIPTION
I haven't figured out to get the test to pass for this, so I left it untested. Fixes the failure in fs-extra on DT.