### PR TITLE
fix(eslint-plugin): [no-self-import] account for nested ('grandparent') path names

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@definitelytyped/header-parser": "^0.0.175",
+    "@definitelytyped/utils": "^0.0.175",
     "@typescript-eslint/types": "^5.56.0",
     "@typescript-eslint/utils": "^5.55.0"
   },

--- a/packages/eslint-plugin/src/rules/no-declare-current-package.ts
+++ b/packages/eslint-plugin/src/rules/no-declare-current-package.ts
@@ -1,5 +1,6 @@
-import { getCommonDirectoryName, createRule } from "../util";
-import { ESLintUtils, AST_NODE_TYPES } from "@typescript-eslint/utils";
+import { createRule, getTypesPackageForDeclarationFile } from "../util";
+import { AST_NODE_TYPES } from "@typescript-eslint/utils";
+
 const rule = createRule({
   name: "no-declare-current-package",
   defaultOptions: [],
@@ -17,11 +18,8 @@ const rule = createRule({
     schema: [],
   },
   create(context) {
-    if (!context.getFilename().endsWith(".d.ts")) {
-      return {};
-    }
-    const parserServices = ESLintUtils.getParserServices(context);
-    const packageName = getCommonDirectoryName(parserServices.program.getRootFileNames());
+    const packageName = getTypesPackageForDeclarationFile(context.getFilename());
+
     return {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       TSModuleDeclaration(node) {

--- a/packages/eslint-plugin/src/rules/no-self-import.ts
+++ b/packages/eslint-plugin/src/rules/no-self-import.ts
@@ -1,5 +1,4 @@
-import { ESLintUtils } from "@typescript-eslint/utils";
-import { createRule, getCommonDirectoryName } from "../util";
+import { createRule, getTypesPackageForDeclarationFile } from "../util";
 
 const rule = createRule({
   name: "no-self-import",
@@ -16,12 +15,7 @@ const rule = createRule({
     schema: [],
   },
   create(context) {
-    if (!context.getFilename().endsWith(".d.ts")) {
-      return {};
-    }
-
-    const services = ESLintUtils.getParserServices(context);
-    const packageName = getCommonDirectoryName(services.program.getRootFileNames());
+    const packageName = getTypesPackageForDeclarationFile(context.getFilename());
 
     return {
       // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/eslint-plugin/src/util.ts
+++ b/packages/eslint-plugin/src/util.ts
@@ -1,3 +1,4 @@
+import { unmangleScopedPackage } from "@definitelytyped/utils";
 import { ESLintUtils } from "@typescript-eslint/utils";
 import { basename, dirname } from "path";
 
@@ -6,17 +7,17 @@ export const createRule = ESLintUtils.RuleCreator(
     `https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/eslint-plugin/docs/rules/${name}.md`
 );
 
-export function getCommonDirectoryName(files: readonly string[]): string {
-  let minLen = 999;
-  let minDir = "";
-  for (const file of files) {
-    const dir = dirname(file);
-    if (dir.length < minLen) {
-      minDir = dir;
-      minLen = dir.length;
-    }
+export function getTypesPackageForDeclarationFile(file: string) {
+  if (!file.endsWith(".d.ts")) {
+    return undefined;
   }
-  return basename(minDir);
+
+  const match = file.match(/types\/([^\/]+)\//)?.[1];
+  if (!match) {
+    return undefined;
+  }
+
+  return unmangleScopedPackage(match) ?? match;
 }
 
 export function isMainFile(fileName: string, allowNested: boolean) {

--- a/packages/eslint-plugin/test/no-declare-current-package.test.ts
+++ b/packages/eslint-plugin/test/no-declare-current-package.test.ts
@@ -6,16 +6,34 @@ const ruleTester = new ESLintUtils.RuleTester({
   parser: "@typescript-eslint/parser",
   parserOptions: {
     ecmaVersion: 2018,
-    tsconfigRootDir: __dirname,
-    project: "./tsconfig.no-declare-current-package.json",
   },
 });
 
 ruleTester.run("@definitelytyped/no-declare-current-package", noDeclareCurrentPackage, {
   invalid: [
     {
-      filename: "index.d.ts",
+      filename: "types/test/index.d.ts",
       code: `module "test" { }`,
+      errors: [
+        {
+          line: 1,
+          messageId: "noDeclareCurrentPackage",
+        },
+      ],
+    },
+    {
+      filename: "types/test/deep/import.d.ts",
+      code: `module "test/deep/import" { }`,
+      errors: [
+        {
+          line: 1,
+          messageId: "noDeclareCurrentPackage",
+        },
+      ],
+    },
+    {
+      filename: "types/scope__name/index.d.ts",
+      code: `module "@scope/name" { }`,
       errors: [
         {
           line: 1,
@@ -26,36 +44,16 @@ ruleTester.run("@definitelytyped/no-declare-current-package", noDeclareCurrentPa
   ],
   valid: [
     {
-      filename: "index.d.ts",
-      code: `module "foo" { }
-module "foo/bar/baz" { }
-`,
+      filename: "types/other/index.d.ts",
+      code: `module "foo" { }`,
     },
-  ],
-});
-// needed because you can only test one non-file.ts file per tsconfig
-// (and tsconfig is required for typed-based rules)
-const ruleTester2 = new ESLintUtils.RuleTester({
-  parser: "@typescript-eslint/parser",
-  parserOptions: {
-    ecmaVersion: 2018,
-    tsconfigRootDir: __dirname,
-    project: "./tsconfig.no-declare-current-package2.json",
-  },
-});
-
-ruleTester2.run("no-declare-current-package", noDeclareCurrentPackage, {
-  invalid: [
     {
-      filename: "deep/import.d.ts",
-      code: `module "test/deep/import" { }`,
-      errors: [
-        {
-          line: 1,
-          messageId: "noDeclareCurrentPackage",
-        },
-      ],
+      filename: "types/other/index.d.ts",
+      code: `module "foo/bar/baz" { }`,
+    },
+    {
+      filename: "types/deep/other/index.d.ts",
+      code: `module "other" { }`,
     },
   ],
-  valid: [],
 });

--- a/packages/eslint-plugin/test/no-self-import.test.ts
+++ b/packages/eslint-plugin/test/no-self-import.test.ts
@@ -1,14 +1,9 @@
 import { ESLintUtils } from "@typescript-eslint/utils";
-import path from "path";
 
 import * as dtHeader from "../src/rules/no-self-import";
 
 const ruleTester = new ESLintUtils.RuleTester({
   parser: "@typescript-eslint/parser",
-  parserOptions: {
-    tsconfigRootDir: __dirname,
-    project: "./tsconfig.no-self-import.json",
-  },
 });
 
 ruleTester.run("@definitelytyped/no-self-import", dtHeader, {
@@ -21,7 +16,7 @@ ruleTester.run("@definitelytyped/no-self-import", dtHeader, {
           messageId: "useRelativeImport",
         },
       ],
-      filename: "this-package/index.d.ts",
+      filename: "types/this-package/index.d.ts",
     },
     {
       code: `import abc from "this-package/abc.d.ts";`,
@@ -31,17 +26,21 @@ ruleTester.run("@definitelytyped/no-self-import", dtHeader, {
           messageId: "useRelativeImport",
         },
       ],
-      filename: "this-package/index.d.ts",
+      filename: "types/this-package/index.d.ts",
     },
   ],
   valid: [
     {
       code: `import other from "other-package";`,
-      filename: "this-package/index.d.ts",
+      filename: "types/this-package/index.d.ts",
     },
     {
       code: `import other from "other-package/this-package";`,
-      filename: "this-package/index.d.ts",
+      filename: "types/this-package/index.d.ts",
+    },
+    {
+      code: `import myself from "this-package";`,
+      filename: "types/grandparent/this-package/index.d.ts",
     },
   ],
 });

--- a/packages/eslint-plugin/test/util.test.ts
+++ b/packages/eslint-plugin/test/util.test.ts
@@ -1,0 +1,24 @@
+import { getTypesPackageForDeclarationFile } from "../src/util";
+
+describe("getTypesPackageForDeclarationFile", () => {
+  test.each([
+    ["types/abc/index.d.ts", "abc"],
+    ["types/abc/other.d.ts", "abc"],
+    ["types/scope__abc/other.d.ts", "@scope/abc"],
+    ["types/abc/nested/index.d.ts", "abc"],
+    ["types/abc/nested/other.d.ts", "abc"],
+    ["/types/abc/index.d.ts", "abc"],
+    ["/types/abc/other.d.ts", "abc"],
+    ["/types/scope__abc/other.d.ts", "@scope/abc"],
+    ["/types/abc/nested/index.d.ts", "abc"],
+    ["/types/abc/nested/other.d.ts", "abc"],
+    ["DefinitelyTyped/types/abc/index.d.ts", "abc"],
+    ["DefinitelyTyped/types/abc/other.d.ts", "abc"],
+    ["DefinitelyTyped/types/scope__abc/other.d.ts", "@scope/abc"],
+    ["DefinitelyTyped/types/abc/nested/index.d.ts", "abc"],
+    ["DefinitelyTyped/types/abc/nested/other.d.ts", "abc"],
+    ["DefinitelyTyped/types/scope__abc/nested/other.d.ts", "@scope/abc"],
+  ])("%s becomes %s", (input, expected) => {
+    expect(getTypesPackageForDeclarationFile(input)).toEqual(expected);
+  });
+});


### PR DESCRIPTION
I think the existing `getCommonDirectoryName` helper wasn't returning the actual package name. So this should make the behavior more accurate, I think. I'm not sure.