### PR TITLE
Add @serverless/typescript to allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -478,6 +478,7 @@
 @react-navigation/native
 @react-navigation/stack
 @sentry/browser
+@serverless/typescript
 @sinonjs/fake-timers
 @storybook/addons
 @storybook/csf


### PR DESCRIPTION
Add [@serverless/typescript](https://www.npmjs.com/package/@serverless/typescript) to allowed dependencies to allow new type definitions for [serverless-step-functions](https://www.npmjs.com/package/serverless-step-functions) to depend on it.

PR: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66693

CI failed due to unallowed dependency:

```
Error: In package.json: Dependency @serverless/typescript not in the allowed dependencies list.
If you are depending on another `@types` package, do *not* add it to a `package.json`. Path mapping should make the import work.
For namespaced dependencies you then have to add a `paths` mapping from `@namespace/*` to `namespace__*` in `tsconfig.json`.
If this is an external library that provides typings,  please make a pull request to microsoft/DefinitelyTyped-tools adding it to `packages/definitions-parser/allowedPackageJsonDependencies.txt`.
    at checkPackageJsonDependencies (/home/runner/work/DefinitelyTyped/DefinitelyTyped/node_modules/@definitelytyped/definitions-parser/src/lib/definition-parser.ts:505:13)
```