### PR TITLE
Tag during publish in changeset action

### DIFF
--- a/.github/workflows/version-or-publish.yml
+++ b/.github/workflows/version-or-publish.yml
@@ -44,11 +44,9 @@ jobs:
             git commit -am "Format"
             git push
           fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.TYPESCRIPT_BOT_TOKEN }}
       - uses: changesets/action@v1
         with:
-          publish: pnpm ci:publish
+          publish: pnpm changeset tag && pnpm publish -r
         env:
           GITHUB_TOKEN: ${{ secrets.TYPESCRIPT_BOT_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "format": "prettier --write 'packages/**/*.ts'",
     "test": "jest",
     "build": "tsc -b .",
-    "retag": "node packages/retag/dist/retag.js",
-    "ci:publish": "pnpm publish -r"
+    "retag": "node packages/retag/dist/retag.js"
   },
   "devDependencies": {
     "@changesets/cli": "^2.26.2",


### PR DESCRIPTION
This has to be done manually when not using `changeset publish`.

While here, drop the env var from the format step; it's preserved from checkout and isn't used there.