### PR TITLE
Fix retag bin name

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "format": "prettier --write 'packages/**/*.ts'",
     "test": "jest",
     "build": "tsc -b .",
-    "retag": "node packages/retag/dist/retag.js",
+    "retag": "node packages/retag/dist/index.js",
     "ci:publish": "pnpm changeset tag && pnpm publish -r"
   },
   "devDependencies": {

--- a/packages/retag/package.json
+++ b/packages/retag/package.json
@@ -33,7 +33,7 @@
   },
   "main": "dist/index.js",
   "bin": {
-    "retag": "./dist/retag.js"
+    "retag": "./dist/index.js"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
It's index.js now, not retag.js.