### PR TITLE
Turn off no-redundant-jsdoc explicitly

### DIFF
--- a/.changeset/rude-geese-bow.md
+++ b/.changeset/rude-geese-bow.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/dtslint": patch
+---
+
+Restore explicit disabling of no-redundant-jsdoc

--- a/packages/dtslint/dt.json
+++ b/packages/dtslint/dt.json
@@ -1,6 +1,7 @@
 {
 	"extends": "./dtslint.json",
 	"rules": {
+		"no-redundant-jsdoc": false,
 		"npm-naming": [true, { "mode": "code" }]
 	}
 }


### PR DESCRIPTION
It's part of tslint:all and needs to be disabled explicitly. Mistake in #684 that I didn't catch because I didn't run it on DT.