### PR TITLE
Rename name-related fields

### DIFF
--- a/packages/definitions-parser/src/get-affected-packages.ts
+++ b/packages/definitions-parser/src/get-affected-packages.ts
@@ -4,11 +4,11 @@ import {
   AllPackages,
   PackageId,
   PackageBase,
-  getMangledNameForScopedPackage,
   formatDependencyVersion,
   removeTypesScope,
 } from "./packages";
 import { tryParsePackageVersion } from "./lib/definition-parser";
+import { scopeName } from "./lib/settings";
 
 export interface Affected {
   readonly changedPackages: readonly TypingsData[];
@@ -87,7 +87,7 @@ function getReverseDependencies(
     for (const [name, version] of typing.allPackageJsonDependencies()) {
       const dependencies = map.get(
         packageIdToKey(
-          allPackages.tryResolve({ name: removeTypesScope(name), version: tryParsePackageVersion(version) })
+          allPackages.tryResolve({ typesDirectoryName: removeTypesScope(name), version: tryParsePackageVersion(version) })
         )
       );
       if (dependencies) {
@@ -99,5 +99,6 @@ function getReverseDependencies(
 }
 
 function packageIdToKey(pkg: PackageId): string {
-  return getMangledNameForScopedPackage(pkg.name) + "/v" + formatDependencyVersion(pkg.version);
+  const typesDirectoryName = pkg.typesDirectoryName ?? pkg.name.slice(scopeName.length + 2);
+  return typesDirectoryName + "/v" + formatDependencyVersion(pkg.version);
 }

--- a/packages/definitions-parser/src/lib/definition-parser.ts
+++ b/packages/definitions-parser/src/lib/definition-parser.ts
@@ -1,35 +1,36 @@
-import * as ts from "typescript";
-import { validatePackageJson, Header } from "@definitelytyped/header-parser";
-import { allReferencedFiles, createSourceFile, getDeclaredGlobals } from "./module-info";
-import {
-  DependencyVersion,
-  formatTypingVersion,
-  getLicenseFromPackageJson,
-  TypingsDataRaw,
-  TypingsVersionsRaw,
-  DirectoryParsedTypingVersion,
-  getMangledNameForScopedPackage,
-} from "../packages";
-import { getAllowedPackageJsonDependencies } from "./settings";
+import { validatePackageJson } from "@definitelytyped/header-parser";
+import { TypeScriptVersion } from "@definitelytyped/typescript-versions";
 import {
   FS,
-  split,
-  hasWindowsSlashes,
-  mapDefined,
-  filter,
-  sort,
-  withoutStart,
+  assertDefined,
   computeHash,
-  join,
-  flatMap,
-  unique,
   createModuleResolutionHost,
+  filter,
+  flatMap,
+  hasWindowsSlashes,
+  join,
+  mapDefined,
   parsePackageSemver,
+  sort,
+  split,
+  unique,
+  withoutStart,
 } from "@definitelytyped/utils";
-import { TypeScriptVersion } from "@definitelytyped/typescript-versions";
-import { slicePrefixes } from "./utils";
-import path from "path";
 import assert from "assert";
+import path from "path";
+import * as ts from "typescript";
+import {
+  DependencyVersion,
+  DirectoryParsedTypingVersion,
+  TypingsDataRaw,
+  TypingsVersionsRaw,
+  formatTypingVersion,
+  getLicenseFromPackageJson,
+  getMangledNameForScopedPackage,
+} from "../packages";
+import { allReferencedFiles, createSourceFile, getDeclaredGlobals } from "./module-info";
+import { getAllowedPackageJsonDependencies } from "./settings";
+import { slicePrefixes } from "./utils";
 
 function matchesVersion(
   typingsDataRaw: TypingsDataRaw,
@@ -37,15 +38,15 @@ function matchesVersion(
   considerLibraryMinorVersion: boolean
 ) {
   return (
-    typingsDataRaw.libraryMajorVersion === version.major &&
+    typingsDataRaw.header.libraryMajorVersion === version.major &&
     (considerLibraryMinorVersion
-      ? version.minor === undefined || typingsDataRaw.libraryMinorVersion === version.minor
+      ? version.minor === undefined || typingsDataRaw.header.libraryMinorVersion === version.minor
       : true)
   );
 }
 
 function formattedLibraryVersion(typingsDataRaw: TypingsDataRaw): `${number}.${number}` {
-  return `${typingsDataRaw.libraryMajorVersion}.${typingsDataRaw.libraryMinorVersion}`;
+  return `${typingsDataRaw.header.libraryMajorVersion}.${typingsDataRaw.header.libraryMinorVersion}`;
 }
 
 export async function getTypingInfo(packageName: string, dt: FS): Promise<TypingsVersionsRaw | string[]> {
@@ -78,12 +79,12 @@ export async function getTypingInfo(packageName: string, dt: FS): Promise<Typing
   const older = await Promise.all(
     olderVersionDirectories.map(async ({ directoryName, version: directoryVersion }) => {
       if (matchesVersion(latestData, directoryVersion, considerLibraryMinorVersion)) {
-        const latest = `${latestData.libraryMajorVersion}.${latestData.libraryMinorVersion}`;
+        const latest = `${latestData.header.libraryMajorVersion}.${latestData.header.libraryMinorVersion}`;
         errors.push(
           `The latest version of the '${packageName}' package is ${latest}, so the subdirectory '${directoryName}' is not allowed` +
             (`v${latest}` === directoryName
               ? "."
-              : `; since it applies to any ${latestData.libraryMajorVersion}.* version, up to and including ${latest}.`)
+              : `; since it applies to any ${latestData.header.libraryMajorVersion}.* version, up to and including ${latest}.`)
         );
       }
 
@@ -107,12 +108,12 @@ export async function getTypingInfo(packageName: string, dt: FS): Promise<Typing
             `Directory ${directoryName} indicates major.minor version ${directoryVersion.major}.${
               directoryVersion.minor ?? "*"
             }, ` +
-              `but package.json indicates major.minor version ${data.libraryMajorVersion}.${data.libraryMinorVersion}`
+              `but package.json indicates major.minor version ${data.header.libraryMajorVersion}.${data.header.libraryMinorVersion}`
           );
         } else {
           errors.push(
             `Directory ${directoryName} indicates major version ${directoryVersion.major}, but package.json indicates major version ` +
-              data.libraryMajorVersion.toString()
+              data.header.libraryMajorVersion.toString()
           );
         }
       }
@@ -248,14 +249,7 @@ async function combineDataForAllTypesVersions(
     errors.push(...packageJsonResult);
   }
 
-  const {
-    contributors,
-    libraryMajorVersion,
-    libraryMinorVersion,
-    typeScriptVersion: minTsVersion,
-    libraryName,
-    projects,
-  } = Array.isArray(packageJsonResult) ? ({} as Header) : packageJsonResult;
+  const header = Array.isArray(packageJsonResult) ? undefined : packageJsonResult;
   const allowedDependencies = await getAllowedPackageJsonDependencies();
   errors.push(...checkPackageJsonDependencies(packageJson.dependencies, packageJsonName, allowedDependencies));
   errors.push(...checkPackageJsonDependencies(packageJson.devDependencies, packageJsonName, allowedDependencies));
@@ -281,13 +275,7 @@ async function combineDataForAllTypesVersions(
 
   // Note that only the first project is collected right now
   return {
-    libraryName,
-    typingsPackageName,
-    projectName: projects[0],
-    contributors,
-    libraryMajorVersion,
-    libraryMinorVersion,
-    minTsVersion,
+    header: assertDefined(header),
     typesVersions,
     files,
     license,

--- a/packages/definitions-parser/src/packages.ts
+++ b/packages/definitions-parser/src/packages.ts
@@ -219,10 +219,6 @@ export abstract class PackageBase {
   }
 }
 
-export function getFullNpmName(packageName: string): string {
-  return `@${scopeName}/${getMangledNameForScopedPackage(packageName)}`;
-}
-
 interface NotNeededPackageRaw {
   /**
    * The npm name of the implementation library that the types package was for.

--- a/packages/definitions-parser/src/packages.ts
+++ b/packages/definitions-parser/src/packages.ts
@@ -198,7 +198,7 @@ export abstract class PackageBase {
 
   /**
    * The immediate subdirectory name in DefinitelyTyped/types/.
-   * Must be equal to the package.json "name" field withouth the "@types/" prefix.
+   * Must be equal to the package.json "name" field without the "@types/" prefix.
    * Does not include the version directory.
    */
   get typesDirectoryName(): string {

--- a/packages/definitions-parser/src/packages.ts
+++ b/packages/definitions-parser/src/packages.ts
@@ -1,11 +1,11 @@
 import assert = require("assert");
-import { Author } from "@definitelytyped/header-parser";
-import { FS, mapValues, assertSorted, assertDefined, unique } from "@definitelytyped/utils";
-import { AllTypeScriptVersion, TypeScriptVersion } from "@definitelytyped/typescript-versions";
+import { Author, Header } from "@definitelytyped/header-parser";
+import { TypeScriptVersion } from "@definitelytyped/typescript-versions";
+import { FS, assertDefined, assertSorted, mapValues, unique, unmangleScopedPackage } from "@definitelytyped/utils";
 import * as semver from "semver";
 import { readDataFile } from "./data-file";
-import { scopeName, typesDirectoryName } from "./lib/settings";
 import { parseVersionFromDirectoryName } from "./lib/definition-parser";
+import { scopeName, typesDirectoryName } from "./lib/settings";
 import { slicePrefixes } from "./lib/utils";
 
 export class AllPackages {
@@ -41,22 +41,14 @@ export class AllPackages {
     return new TypingsData(versions[0], /*isLatest*/ true);
   }
 
-  static readSingleNotNeeded(name: string, dt: FS): NotNeededPackage {
-    const notNeeded = readNotNeededPackages(dt);
-    const pkg = notNeeded.find((p) => p.name === name);
-    if (pkg === undefined) {
-      throw new Error(`Cannot find not-needed package ${name}`);
-    }
-    return pkg;
-  }
-
   private constructor(
+    /** Keys are `typesDirectoryName` strings */
     private readonly data: ReadonlyMap<string, TypingsVersions>,
     private readonly notNeeded: readonly NotNeededPackage[]
   ) {}
 
-  getNotNeededPackage(name: string): NotNeededPackage | undefined {
-    return this.notNeeded.find((p) => p.name === name);
+  getNotNeededPackage(typesDirectoryName: string): NotNeededPackage | undefined {
+    return this.notNeeded.find((p) => p.typesDirectoryName === typesDirectoryName);
   }
 
   hasTypingFor(dep: PackageId): boolean {
@@ -67,22 +59,24 @@ export class AllPackages {
    * Whether a package maintains multiple minor versions of typings simultaneously by
    * using minor-versioned directories like 'react-native/v14.1'
    */
-  hasSeparateMinorVersions(name: string) {
-    const versions = Array.from(assertDefined(this.data.get(getMangledNameForScopedPackage(name))).getAll());
+  hasSeparateMinorVersions(typesDirectoryName: string) {
+    const versions = Array.from(assertDefined(this.data.get(typesDirectoryName)).getAll());
     const minors = versions.map((v) => v.minor);
     return minors.length !== unique(minors).length;
   }
 
   tryResolve(dep: PackageId): PackageId {
-    const versions = this.data.get(getMangledNameForScopedPackage(dep.name));
+    const typesDirectoryName = dep.typesDirectoryName ?? dep.name.slice(scopeName.length + 2);
+    const versions = this.data.get(typesDirectoryName);
     const depVersion = new semver.Range(dep.version === "*" ? "*" : `^${formatTypingVersion(dep.version)}`);
     return (versions && versions.tryGet(depVersion)?.id) || dep;
   }
 
   resolve(dep: PackageId): PackageIdWithDefiniteVersion {
-    const versions = this.data.get(getMangledNameForScopedPackage(dep.name));
+    const typesDirectoryName = dep.typesDirectoryName ?? dep.name.slice(scopeName.length + 2);
+    const versions = this.data.get(typesDirectoryName);
     if (!versions) {
-      throw new Error(`No typings found with name '${dep.name}'.`);
+      throw new Error(`No typings found with directory name '${dep.typesDirectoryName}'.`);
     }
     const depVersion = new semver.Range(dep.version === "*" ? "*" : `^${formatTypingVersion(dep.version)}`);
     return versions.get(depVersion).id;
@@ -90,19 +84,19 @@ export class AllPackages {
 
   /** Gets the latest version of a package. E.g. getLatest(node v6) was node v10 (before node v11 came out). */
   getLatest(pkg: TypingsData): TypingsData {
-    return pkg.isLatest ? pkg : this.getLatestVersion(pkg.name);
+    return pkg.isLatest ? pkg : this.getLatestVersion(pkg.typesDirectoryName);
   }
 
-  private getLatestVersion(packageName: string): TypingsData {
-    const latest = this.tryGetLatestVersion(packageName);
+  private getLatestVersion(typesDirectoryName: string): TypingsData {
+    const latest = this.tryGetLatestVersion(typesDirectoryName);
     if (!latest) {
-      throw new Error(`No such package ${packageName}.`);
+      throw new Error(`No such package ${typesDirectoryName}.`);
     }
     return latest;
   }
 
-  tryGetLatestVersion(packageName: string): TypingsData | undefined {
-    const versions = this.data.get(getMangledNameForScopedPackage(packageName));
+  tryGetLatestVersion(typesDirectoryName: string): TypingsData | undefined {
+    const versions = this.data.get(typesDirectoryName);
     return versions && versions.getLatest();
   }
 
@@ -114,9 +108,10 @@ export class AllPackages {
     return pkg;
   }
 
-  tryGetTypingsData({ name, version }: PackageId): TypingsData | undefined {
-    const versions = this.data.get(getMangledNameForScopedPackage(name));
-    return versions && versions.tryGet(new semver.Range(version === "*" ? "*" : `^${formatTypingVersion(version)}`));
+  tryGetTypingsData(pkg: PackageId): TypingsData | undefined {
+    const typesDirectoryName = pkg.typesDirectoryName ?? pkg.name.slice(scopeName.length + 2);
+    const versions = this.data.get(typesDirectoryName);
+    return versions && versions.tryGet(new semver.Range(pkg.version === "*" ? "*" : `^${formatTypingVersion(pkg.version)}`));
   }
 
   allPackages(): readonly AnyPackage[] {
@@ -146,9 +141,9 @@ export class AllPackages {
       // TODO: chart.js@3 has types; @types/chart.js@2.9 is the last version on DT.
       // It shouldn't be an error to depend on chart.js@3 but it's currently ambiguous with @types/chart.js.
       if (!name.startsWith(`@${scopeName}/`)) continue;
-      const dtName = removeTypesScope(name);
-      if (pkg.name === dtName) continue;
-      const versions = this.data.get(dtName);
+      if (pkg.name === name) continue;
+      const typesDirectoryName = removeTypesScope(name);
+      const versions = this.data.get(typesDirectoryName);
       if (versions) {
         yield versions.get(new semver.Range(version), pkg.name + ":" + JSON.stringify((versions as any).versions));
       }
@@ -181,51 +176,44 @@ function* flattenData(data: ReadonlyMap<string, TypingsVersions>): Iterable<Typi
 
 export type AnyPackage = NotNeededPackage | TypingsData;
 
-interface BaseRaw {
-  /**
-   * The name of the library.
-   *
-   * A human readable version, e.g. it might be "Moment.js" even though `packageName` is "moment".
-   */
-  readonly libraryName: string;
-}
-
 /** Prefer to use `AnyPackage` instead of this. */
 export abstract class PackageBase {
   static compare(a: PackageBase, b: PackageBase): number {
     return a.name.localeCompare(b.name);
   }
 
-  /** Note: for "foo__bar" this is still "foo__bar", not "@foo/bar". */
+  /** The package.json "name" field */
   abstract readonly name: string;
-  readonly libraryName: string;
+  /**
+   * For non-npm packages, the human-readable library name recorded in
+   * the package.json "nonNpmDescription" field. Otherwise, the name of
+   * the implementation library, as computed from the package.json "name".
+   */
+  abstract readonly libraryName: string;
+  abstract readonly major: number;
+  abstract readonly minor: number;
+  abstract readonly isLatest: boolean;
+
+  /**
+   * The immediate subdirectory name in DefinitelyTyped/types/.
+   * Must be equal to the package.json "name" field withouth the "@types/" prefix.
+   * Does not include the version directory.
+   */
+  get typesDirectoryName(): string {
+    return this.name.slice(scopeName.length + 2);
+  }
 
   /** Short description for debug output. */
   get desc(): string {
     return this.isLatest ? this.name : `${this.name} v${this.major}.${this.minor}`;
   }
 
-  constructor(data: BaseRaw) {
-    this.libraryName = data.libraryName;
+  get id(): PackageIdWithDefiniteVersion {
+    return { typesDirectoryName: this.typesDirectoryName, version: { major: this.major, minor: this.minor } };
   }
-
+  
   isNotNeeded(): this is NotNeededPackage {
     return this instanceof NotNeededPackage;
-  }
-
-  abstract readonly isLatest: boolean;
-  abstract readonly minTypeScriptVersion: TypeScriptVersion;
-
-  /** '@types/foo' for a package 'foo'. */
-  get fullNpmName(): string {
-    return getFullNpmName(this.name);
-  }
-
-  abstract readonly major: number;
-  abstract readonly minor: number;
-
-  get id(): PackageIdWithDefiniteVersion {
-    return { name: this.name, version: { major: this.major, minor: this.minor } };
   }
 }
 
@@ -233,7 +221,11 @@ export function getFullNpmName(packageName: string): string {
   return `@${scopeName}/${getMangledNameForScopedPackage(packageName)}`;
 }
 
-interface NotNeededPackageRaw extends BaseRaw {
+interface NotNeededPackageRaw {
+  /**
+   * The npm name of the implementation library that the types package was for.
+   */
+  readonly libraryName: string;
   /**
    * If this is available, @types typings are deprecated as of this version.
    * This is useful for packages that previously had DefinitelyTyped definitions but which now provide their own.
@@ -266,9 +258,10 @@ export class NotNeededPackage extends PackageBase {
   }
 
   constructor(readonly name: string, readonly libraryName: string, asOfVersion: string) {
-    super({ libraryName });
+    super();
     assert(libraryName && name && asOfVersion);
     this.version = new semver.SemVer(asOfVersion);
+    this.name = name.startsWith(`@${scopeName}/`) ? name : `@${scopeName}/${name}`;
   }
 
   get major(): number {
@@ -327,13 +320,11 @@ export function formatDependencyVersion(version: DependencyVersion) {
 /** Maps name to version */
 export type PackageJsonDependencies = Record<string, string>;
 
-export interface TypingsDataRaw extends BaseRaw {
+export interface TypingsDataRaw {
   /**
-   * The NPM name to publish this under, e.g. "jquery".
-   *
-   * This does not include "@types".
+   * Header info contained in package.json
    */
-  readonly typingsPackageName: string;
+  readonly header: Header;
 
   /**
    * Package `imports`, as read in the `package.json` file
@@ -362,37 +353,11 @@ export interface TypingsDataRaw extends BaseRaw {
   readonly packageJsonDevDependencies: PackageJsonDependencies;
 
   /**
-   * List of people that have contributed to the definitions in this package.
-   *
-   * These people will be requested for issue/PR review in the https://github.com/DefinitelyTyped/DefinitelyTyped repo.
-   */
-  readonly contributors: readonly Author[];
-
-  /**
    * The [older] version of the library that this definition package refers to, as represented *on-disk*.
    *
    * @note The latest version always exists in the root of the package tree and thus does not have a value for this property.
    */
   readonly libraryVersionDirectoryName?: string;
-
-  /**
-   * Major version of the library.
-   *
-   * This data is parsed from a header comment in the entry point `.d.ts` and will be `0` if the file did not specify a version.
-   */
-  readonly libraryMajorVersion: number;
-
-  /**
-   * Minor version of the library.
-   *
-   * This data is parsed from a header comment in the entry point `.d.ts` and will be `0` if the file did not specify a version.
-   */
-  readonly libraryMinorVersion: number;
-
-  /**
-   * Minimum required TypeScript version to consume the definitions from this package.
-   */
-  readonly minTsVersion: AllTypeScriptVersion;
 
   /**
    * List of TS versions that have their own directories, and corresponding "typesVersions" in package.json.
@@ -419,11 +384,6 @@ export interface TypingsDataRaw extends BaseRaw {
    * A hash of the names and contents of the `files` list, used for versioning.
    */
   readonly contentHash: string;
-
-  /**
-   * Name or URL of the project, e.g. "http://cordova.apache.org".
-   */
-  readonly projectName: string;
 
   /**
    * A list of *values* declared in the global namespace.
@@ -503,25 +463,31 @@ export class TypingsVersions {
 
 export class TypingsData extends PackageBase {
   constructor(private readonly data: TypingsDataRaw, readonly isLatest: boolean) {
-    super(data);
+    super();
   }
 
-  get name() {
-    return this.data.typingsPackageName;
+  get name(): string {
+    return this.data.header.name;
   }
-
+  get libraryName(): string {
+    return (
+      this.data.header.nonNpmDescription ?? unmangleScopedPackage(this.typesDirectoryName) ?? this.typesDirectoryName
+    );
+  }
   get contributors(): readonly Author[] {
-    return this.data.contributors;
+    return this.data.header.contributors;
   }
   get major(): number {
-    return this.data.libraryMajorVersion;
+    return this.data.header.libraryMajorVersion;
   }
   get minor(): number {
-    return this.data.libraryMinorVersion;
+    return this.data.header.libraryMinorVersion;
   }
 
   get minTypeScriptVersion(): TypeScriptVersion {
-    return TypeScriptVersion.isSupported(this.data.minTsVersion) ? this.data.minTsVersion : TypeScriptVersion.lowest;
+    return TypeScriptVersion.isSupported(this.data.header.typeScriptVersion)
+      ? this.data.header.typeScriptVersion
+      : TypeScriptVersion.lowest;
   }
   get typesVersions(): readonly TypeScriptVersion[] {
     return this.data.typesVersions;
@@ -554,8 +520,8 @@ export class TypingsData extends PackageBase {
   get contentHash(): string {
     return this.data.contentHash;
   }
-  get projectName(): string {
-    return this.data.projectName;
+  get projectName(): string | undefined {
+    return this.data.header.projects[0];
   }
   get globals(): readonly string[] {
     return this.data.globals;
@@ -578,28 +544,39 @@ export class TypingsData extends PackageBase {
 
   /** Path to this package, *relative* to the DefinitelyTyped directory. */
   get subDirectoryPath(): string {
-    return this.isLatest ? this.name : `${this.name}/${this.versionDirectoryName}`;
+    return this.isLatest ? this.typesDirectoryName : `${this.typesDirectoryName}/${this.versionDirectoryName}`;
   }
 }
 
 /** Uniquely identifies a package. */
-export interface PackageId {
-  readonly name: string;
-  readonly version: DependencyVersion;
-}
+export type PackageId =
+  | {
+      readonly typesDirectoryName: string;
+      readonly version: DependencyVersion;
+    }
+  | {
+      readonly name: string;
+      readonly typesDirectoryName?: undefined;
+      readonly version: DependencyVersion;
+    };
 
-export interface PackageIdWithDefiniteVersion {
-  readonly name: string;
-  readonly version: HeaderParsedTypingVersion;
-}
+export type PackageIdWithDefiniteVersion =
+  | {
+      readonly typesDirectoryName: string;
+      readonly version: HeaderParsedTypingVersion;
+    }
+  | {
+      readonly name: string;
+      readonly version: HeaderParsedTypingVersion;
+    };
 
-export interface TypesDataFile {
-  readonly [packageName: string]: TypingsVersionsRaw;
-}
-function readTypesDataFile(): Promise<TypesDataFile> {
-  return readDataFile("parse-definitions", typesDataFilename) as Promise<TypesDataFile>;
-}
-
+    export interface TypesDataFile {
+      readonly [packageName: string]: TypingsVersionsRaw;
+    }
+    function readTypesDataFile(): Promise<TypesDataFile> {
+      return readDataFile("parse-definitions", typesDataFilename) as Promise<TypesDataFile>;
+    }
+    
 export function readNotNeededPackages(dt: FS): readonly NotNeededPackage[] {
   const rawJson = dt.readJson("notNeededPackages.json"); // tslint:disable-line await-promise (tslint bug)
   return Object.entries((rawJson as { readonly packages: readonly NotNeededPackageRaw[] }).packages).map((entry) =>
@@ -612,7 +589,7 @@ export function readNotNeededPackages(dt: FS): readonly NotNeededPackage[] {
  * For "types/a/v3/c", returns { name: "a", version: 3 }.
  * For "x", returns undefined.
  */
-export function getDependencyFromFile(file: string): PackageId | undefined {
+export function getDependencyFromFile(file: string): { typesDirectoryName: string, version: DependencyVersion } | undefined {
   const parts = file.split("/");
   if (parts.length <= 2) {
     // It's not in a typings directory at all.
@@ -628,9 +605,9 @@ export function getDependencyFromFile(file: string): PackageId | undefined {
   if (subDirName) {
     const version = parseVersionFromDirectoryName(subDirName);
     if (version !== undefined) {
-      return { name, version };
+      return { typesDirectoryName: name, version };
     }
   }
 
-  return { name, version: "*" };
+  return { typesDirectoryName: name, version: "*" };
 }

--- a/packages/definitions-parser/src/packages.ts
+++ b/packages/definitions-parser/src/packages.ts
@@ -111,7 +111,9 @@ export class AllPackages {
   tryGetTypingsData(pkg: PackageId): TypingsData | undefined {
     const typesDirectoryName = pkg.typesDirectoryName ?? pkg.name.slice(scopeName.length + 2);
     const versions = this.data.get(typesDirectoryName);
-    return versions && versions.tryGet(new semver.Range(pkg.version === "*" ? "*" : `^${formatTypingVersion(pkg.version)}`));
+    return (
+      versions && versions.tryGet(new semver.Range(pkg.version === "*" ? "*" : `^${formatTypingVersion(pkg.version)}`))
+    );
   }
 
   allPackages(): readonly AnyPackage[] {
@@ -211,7 +213,7 @@ export abstract class PackageBase {
   get id(): PackageIdWithDefiniteVersion {
     return { typesDirectoryName: this.typesDirectoryName, version: { major: this.major, minor: this.minor } };
   }
-  
+
   isNotNeeded(): this is NotNeededPackage {
     return this instanceof NotNeededPackage;
   }
@@ -560,23 +562,18 @@ export type PackageId =
       readonly version: DependencyVersion;
     };
 
-export type PackageIdWithDefiniteVersion =
-  | {
-      readonly typesDirectoryName: string;
-      readonly version: HeaderParsedTypingVersion;
-    }
-  | {
-      readonly name: string;
-      readonly version: HeaderParsedTypingVersion;
-    };
+export interface PackageIdWithDefiniteVersion {
+  readonly typesDirectoryName: string;
+  readonly version: HeaderParsedTypingVersion;
+}
 
-    export interface TypesDataFile {
-      readonly [packageName: string]: TypingsVersionsRaw;
-    }
-    function readTypesDataFile(): Promise<TypesDataFile> {
-      return readDataFile("parse-definitions", typesDataFilename) as Promise<TypesDataFile>;
-    }
-    
+export interface TypesDataFile {
+  readonly [packageName: string]: TypingsVersionsRaw;
+}
+function readTypesDataFile(): Promise<TypesDataFile> {
+  return readDataFile("parse-definitions", typesDataFilename) as Promise<TypesDataFile>;
+}
+
 export function readNotNeededPackages(dt: FS): readonly NotNeededPackage[] {
   const rawJson = dt.readJson("notNeededPackages.json"); // tslint:disable-line await-promise (tslint bug)
   return Object.entries((rawJson as { readonly packages: readonly NotNeededPackageRaw[] }).packages).map((entry) =>
@@ -589,7 +586,9 @@ export function readNotNeededPackages(dt: FS): readonly NotNeededPackage[] {
  * For "types/a/v3/c", returns { name: "a", version: 3 }.
  * For "x", returns undefined.
  */
-export function getDependencyFromFile(file: string): { typesDirectoryName: string, version: DependencyVersion } | undefined {
+export function getDependencyFromFile(
+  file: string
+): { typesDirectoryName: string; version: DependencyVersion } | undefined {
   const parts = file.split("/");
   if (parts.length <= 2) {
     // It's not in a typings directory at all.

--- a/packages/definitions-parser/test/get-affected-packages.test.ts
+++ b/packages/definitions-parser/test/get-affected-packages.test.ts
@@ -11,7 +11,7 @@ const typesData: TypesDataFile = {
   unknown: createTypingsVersionRaw("unknown", { "@types/COMPLETELY-UNKNOWN": "1.0.0" }, {}),
   "unknown-test": createTypingsVersionRaw("unknown-test", {}, { "@types/WAT": "*" }),
 };
-typesData.jquery["2.0"] = { ...typesData.jquery["1.0"], libraryMajorVersion: 2 };
+typesData.jquery["2.0"] = { ...typesData.jquery["1.0"], header: { ...typesData.jquery["1.0"].header, libraryMajorVersion: 2 } };
 
 const notNeeded = [new NotNeededPackage("jest", "jest", "100.0.0")];
 const allPackages = AllPackages.from(typesData, notNeeded);

--- a/packages/definitions-parser/test/get-affected-packages.test.ts
+++ b/packages/definitions-parser/test/get-affected-packages.test.ts
@@ -19,33 +19,33 @@ const allPackages = AllPackages.from(typesData, notNeeded);
 testo({
   updatedPackage() {
     const { changedPackages, dependentPackages } = getAffectedPackages(allPackages, [
-      { name: "jquery", version: { major: 2 } },
+      { typesDirectoryName: "jquery", version: { major: 2 } },
     ]);
-    expect(changedPackages.map(({ id }) => id)).toEqual([{ name: "jquery", version: { major: 2, minor: 0 } }]);
+    expect(changedPackages.map(({ id }) => id)).toEqual([{ typesDirectoryName: "jquery", version: { major: 2, minor: 0 } }]);
     expect((changedPackages[0] as any).data).toEqual(typesData.jquery["2.0"]);
     expect(dependentPackages.map(({ id }) => id)).toEqual([
-      { name: "known-test", version: { major: 1, minor: 0 } },
-      { name: "most-recent", version: { major: 1, minor: 0 } },
+      { typesDirectoryName: "known-test", version: { major: 1, minor: 0 } },
+      { typesDirectoryName: "most-recent", version: { major: 1, minor: 0 } },
     ]);
   },
   deletedPackage() {
-    const { changedPackages, dependentPackages } = getAffectedPackages(allPackages, [{ name: "WAT", version: "*" }]);
+    const { changedPackages, dependentPackages } = getAffectedPackages(allPackages, [{ typesDirectoryName: "WAT", version: "*" }]);
     expect(changedPackages.map(({ id }) => id)).toEqual([]);
-    expect(dependentPackages.map(({ id }) => id)).toEqual([{ name: "unknown-test", version: { major: 1, minor: 0 } }]);
+    expect(dependentPackages.map(({ id }) => id)).toEqual([{ typesDirectoryName: "unknown-test", version: { major: 1, minor: 0 } }]);
   },
   deletedVersion() {
-    const { changedPackages } = getAffectedPackages(allPackages, [{ name: "jquery", version: { major: 0 } }]);
+    const { changedPackages } = getAffectedPackages(allPackages, [{ typesDirectoryName: "jquery", version: { major: 0 } }]);
     expect(changedPackages).toEqual([]);
   },
   olderVersion() {
     debugger;
     const { changedPackages, dependentPackages } = getAffectedPackages(allPackages, [
-      { name: "jquery", version: { major: 1 } },
+      { typesDirectoryName: "jquery", version: { major: 1 } },
     ]);
-    expect(changedPackages.map(({ id }) => id)).toEqual([{ name: "jquery", version: { major: 1, minor: 0 } }]);
+    expect(changedPackages.map(({ id }) => id)).toEqual([{ typesDirectoryName: "jquery", version: { major: 1, minor: 0 } }]);
     expect(dependentPackages.map(({ id }) => id)).toEqual([
-      { name: "has-older-test-dependency", version: { major: 1, minor: 0 } },
-      { name: "known", version: { major: 1, minor: 0 } },
+      { typesDirectoryName: "has-older-test-dependency", version: { major: 1, minor: 0 } },
+      { typesDirectoryName: "known", version: { major: 1, minor: 0 } },
     ]);
   },
 });

--- a/packages/definitions-parser/test/git.test.ts
+++ b/packages/definitions-parser/test/git.test.ts
@@ -5,12 +5,12 @@ import { GitDiff, getNotNeededPackages, checkNotNeededPackage } from "../src/git
 import { NotNeededPackage, TypesDataFile, AllPackages } from "../src/packages";
 
 const typesData: TypesDataFile = {
-  jquery: createTypingsVersionRaw("jquery", {}, [], {}),
-  known: createTypingsVersionRaw("known", { jquery: { major: 1 } }, [], {}),
-  "known-test": createTypingsVersionRaw("known-test", {}, ["jquery"], {}),
-  "most-recent": createTypingsVersionRaw("most-recent", { jquery: "*" }, [], {}),
-  unknown: createTypingsVersionRaw("unknown", { "COMPLETELY-UNKNOWN": { major: 1 } }, [], {}),
-  "unknown-test": createTypingsVersionRaw("unknown-test", {}, ["WAT"], {}),
+  jquery: createTypingsVersionRaw("jquery", {}, {}),
+  known: createTypingsVersionRaw("known", { "@types/jquery": "1.0.0" }, {}),
+  "known-test": createTypingsVersionRaw("known-test", {}, { "@types/jquery": "*" }),
+  "most-recent": createTypingsVersionRaw("most-recent", { "@types/jquery": "*" }, {}),
+  unknown: createTypingsVersionRaw("unknown", { "@types/COMPLETELY-UNKNOWN": "1.0.0" }, {}),
+  "unknown-test": createTypingsVersionRaw("unknown-test", {}, { "@types/WAT": "*" }),
 };
 
 const jestNotNeeded = [new NotNeededPackage("jest", "jest", "100.0.0")];
@@ -29,7 +29,7 @@ testo({
   forgotToDeleteFiles() {
     expect(() =>
       getNotNeededPackages(
-        AllPackages.from({ jest: createTypingsVersionRaw("jest", {}, [], {}) }, jestNotNeeded),
+        AllPackages.from({ jest: createTypingsVersionRaw("jest", {}, {}) }, jestNotNeeded),
         deleteJestDiffs
       )
     ).toThrow("Please delete all files in jest");

--- a/packages/definitions-parser/test/packages.test.ts
+++ b/packages/definitions-parser/test/packages.test.ts
@@ -29,7 +29,7 @@ describe(AllPackages, () => {
   it("applies path mappings to test dependencies", () => {
     const pkg = allPackages.tryGetLatestVersion("has-older-test-dependency")!;
     expect(Array.from(allPackages.allDependencyTypings(pkg), ({ id }) => id)).toEqual([
-      { name: "jquery", version: { major: 1, minor: 0 } },
+      { typesDirectoryName: "jquery", version: { major: 1, minor: 0 } },
     ]);
   });
 
@@ -45,13 +45,19 @@ describe(AllPackages, () => {
     it("returns true if typings exist", () => {
       expect(
         allPackages.hasTypingFor({
-          name: "jquery",
+          name: "@types/jquery",
           version: "*",
         })
       ).toBe(true);
       expect(
         allPackages.hasTypingFor({
-          name: "nonExistent",
+          typesDirectoryName: "jquery",
+          version: "*",
+        })
+      ).toBe(true);
+      expect(
+        allPackages.hasTypingFor({
+          name: "@types/nonExistent",
           version: "*",
         })
       ).toBe(false);
@@ -128,7 +134,9 @@ describe(TypingsData, () => {
   });
 
   it("sets the correct properties", () => {
-    expect(data.name).toBe("known");
+    expect(data.name).toBe("@types/known");
+    expect(data.typesDirectoryName).toBe("known");
+    expect(data.libraryName).toBe("known");
     expect(data.contributors).toEqual([
       {
         name: "Bender",
@@ -152,7 +160,7 @@ describe(TypingsData, () => {
       "@types/known": "workspace:.",
     });
     expect(data.id).toEqual({
-      name: "known",
+      typesDirectoryName: "known",
       version: {
         major: 1,
         minor: 0,
@@ -163,14 +171,14 @@ describe(TypingsData, () => {
 
   describe("desc", () => {
     it("returns the name if latest version", () => {
-      expect(data.desc).toBe("known");
+      expect(data.desc).toBe("@types/known");
     });
 
     it("returns the verioned name if not latest", () => {
       const versions = createTypingsVersionRaw("known", {}, {});
       data = new TypingsData(versions["1.0"], false);
 
-      expect(data.desc).toBe("known v1.0");
+      expect(data.desc).toBe("@types/known v1.0");
     });
   });
 
@@ -207,7 +215,7 @@ describe(NotNeededPackage, () => {
 
   it("sets the correct properties", () => {
     expect(data.license).toBe(License.MIT);
-    expect(data.name).toBe("types-package");
+    expect(data.name).toBe("@types/types-package");
     expect(data.libraryName).toBe("real-package");
     expect(data.version).toMatchObject({
       major: 1,
@@ -268,14 +276,14 @@ describe(getDependencyFromFile, () => {
 
   it("returns parsed version for versioned paths", () => {
     expect(getDependencyFromFile("types/a/v3.5")).toEqual({
-      name: "a",
+      typesDirectoryName: "a",
       version: {
         major: 3,
         minor: 5,
       },
     });
     expect(getDependencyFromFile("types/a/v3")).toEqual({
-      name: "a",
+      typesDirectoryName: "a",
       version: {
         major: 3,
         minor: undefined,
@@ -285,7 +293,7 @@ describe(getDependencyFromFile, () => {
 
   it("returns undefined for unversioned subpaths", () => {
     expect(getDependencyFromFile("types/a/vnotaversion")).toEqual({
-      name: "a",
+      typesDirectoryName: "a",
       version: "*",
     });
   });

--- a/packages/definitions-parser/test/packages.test.ts
+++ b/packages/definitions-parser/test/packages.test.ts
@@ -174,16 +174,16 @@ describe(TypingsData, () => {
     });
   });
 
-  describe("fullNpmName", () => {
-    it("returns scoped name", () => {
-      expect(data.fullNpmName).toBe("@types/known");
+  describe("typesDirectoryName", () => {
+    it("returns unscoped name", () => {
+      expect(data.typesDirectoryName).toBe("known");
     });
 
     it("returns mangled name if scoped", () => {
       const versions = createTypingsVersionRaw("@foo/bar", {}, {});
       data = new TypingsData(versions["1.0"], false);
 
-      expect(data.fullNpmName).toBe("@types/foo__bar");
+      expect(data.typesDirectoryName).toBe("foo__bar");
     });
   });
 });

--- a/packages/definitions-parser/test/parse-definitions.test.ts
+++ b/packages/definitions-parser/test/parse-definitions.test.ts
@@ -23,8 +23,8 @@ testo({
     expect(defs.allTypings().length).toBe(6);
     const j = defs.tryGetLatestVersion("jquery");
     expect(j).toBeDefined();
-    expect(j!.fullNpmName).toContain("types");
-    expect(j!.fullNpmName).toContain("jquery");
+    expect(j!.name).toContain("types");
+    expect(j!.name).toContain("jquery");
     expect(defs.allPackages().length).toEqual(defs.allTypings().length + defs.allNotNeeded().length);
   },
 });

--- a/packages/definitions-parser/test/tsconfig.json
+++ b/packages/definitions-parser/test/tsconfig.json
@@ -8,5 +8,6 @@
   "references": [
     { "path": ".." },
     { "path": "../../utils" }
-  ]
+  ],
+  "exclude": ["fixtures"]
 }

--- a/packages/definitions-parser/test/utils.ts
+++ b/packages/definitions-parser/test/utils.ts
@@ -1,4 +1,5 @@
-import { TypingsVersionsRaw, License } from "../src/packages";
+import { scopeName } from "../src/lib/settings";
+import { TypingsVersionsRaw, License, getMangledNameForScopedPackage } from "../src/packages";
 
 export function testo(o: { [s: string]: () => void }) {
   for (const k of Object.keys(o)) {
@@ -7,25 +8,27 @@ export function testo(o: { [s: string]: () => void }) {
 }
 
 export function createTypingsVersionRaw(
-  name: string,
+  libraryName: string,
   dependencies: { readonly [name: string]: string },
   devDependencies: { readonly [name: string]: string }
 ): TypingsVersionsRaw {
   return {
     "1.0": {
-      libraryName: name,
-      typingsPackageName: name,
+      header: {
+        name: `@${scopeName}/${getMangledNameForScopedPackage(libraryName)}`,
+        libraryMajorVersion: 1,
+        libraryMinorVersion: 0,
+        contributors: [{ name: "Bender", url: "futurama.com", githubUsername: "bender" }],
+        typeScriptVersion: "2.3",
+        nonNpm: false,
+        projects: ["zombo.com"],
+      },
       files: ["index.d.ts"],
-      libraryMajorVersion: 1,
-      libraryMinorVersion: 0,
-      contributors: [{ name: "Bender", url: "futurama.com", githubUsername: "bender" }],
-      minTsVersion: "2.3",
       typesVersions: [],
       license: License.MIT,
       packageJsonDependencies: dependencies,
       packageJsonDevDependencies: devDependencies,
       contentHash: "11111111111111",
-      projectName: "zombo.com",
       globals: [],
     },
   };

--- a/packages/header-parser/src/index.ts
+++ b/packages/header-parser/src/index.ts
@@ -21,7 +21,8 @@ import { deepEquals, parsePackageSemver } from "@definitelytyped/utils";
 // used in dts-critic
 export interface Header {
   readonly nonNpm: boolean;
-  readonly libraryName: string;
+  readonly nonNpmDescription?: string;
+  readonly name: string;
   readonly libraryMajorVersion: number;
   readonly libraryMinorVersion: number;
   readonly typeScriptVersion: AllTypeScriptVersion;
@@ -57,7 +58,7 @@ export function makeTypesVersionsForPackageJson(typesVersions: readonly AllTypeS
 }
 
 export function validatePackageJson(
-  packageName: string,
+  typesDirectoryName: string,
   packageJson: Record<string, unknown>,
   typesVersions: readonly AllTypeScriptVersion[]
 ): Header | string[] {
@@ -95,25 +96,25 @@ export function validatePackageJson(
       case "typesVersions":
       case "types":
         if (!needsTypesVersions) {
-          errors.push(`${packageName}'s package.json doesn't need to set "${key}" when no 'ts4.x' directories exist.`);
+          errors.push(`${typesDirectoryName}'s package.json doesn't need to set "${key}" when no 'ts4.x' directories exist.`);
         }
         break;
       default:
-        errors.push(`${packageName}'s package.json should not include property ${key}`);
+        errors.push(`${typesDirectoryName}'s package.json should not include property ${key}`);
     }
   }
   // private
   if (packageJson.private !== true) {
-    errors.push(`${packageName}'s package.json has bad "private": must be \`"private": true\``);
+    errors.push(`${typesDirectoryName}'s package.json has bad "private": must be \`"private": true\``);
   }
   // devDependencies
   if (
     typeof packageJson.devDependencies !== "object" ||
     packageJson.devDependencies === null ||
-    (packageJson.devDependencies as any)["@types/" + packageName] !== "workspace:."
+    (packageJson.devDependencies as any)["@types/" + typesDirectoryName] !== "workspace:."
   ) {
     errors.push(
-      `${packageName}'s package.json has bad "devDependencies": must include \`"@types/${packageName}": "workspace:."\``
+      `${typesDirectoryName}'s package.json has bad "devDependencies": must include \`"@types/${typesDirectoryName}": "workspace:."\``
     );
   }
   // TODO: disallow devDeps from containing dependencies (although this is VERY linty)
@@ -121,18 +122,18 @@ export function validatePackageJson(
 
   // typesVersions
   if (needsTypesVersions) {
-    assert.strictEqual(packageJson.types, "index", `"types" in '${packageName}'s package.json' should be "index".`);
+    assert.strictEqual(packageJson.types, "index", `"types" in '${typesDirectoryName}'s package.json' should be "index".`);
     const expected = makeTypesVersionsForPackageJson(typesVersions) as Record<string, object>;
     if (!deepEquals(packageJson.typesVersions, expected)) {
       errors.push(
-        `'${packageName}'s package.json' has bad "typesVersions". Should be: ${JSON.stringify(expected, undefined, 4)}`
+        `'${typesDirectoryName}'s package.json' has bad "typesVersions". Should be: ${JSON.stringify(expected, undefined, 4)}`
       );
     }
   }
 
   // building the header object uses a monadic error pattern based on the one in the old header parser
   // It's verbose and repetitive, but I didn't feel like writing a monadic `seq` to be used in only one place.
-  let libraryName = "ERROR";
+  let name = "ERROR";
   let libraryMajorVersion = 0;
   let libraryMinorVersion = 0;
   let nonNpm = false;
@@ -148,7 +149,7 @@ export function validatePackageJson(
   if (typeof nameResult === "object") {
     errors.push(...nameResult.errors);
   } else {
-    libraryName = packageName;
+    name = packageJson.name as string;
   }
   if ("errors" in versionResult) {
     errors.push(...versionResult.errors);
@@ -180,7 +181,7 @@ export function validatePackageJson(
     return errors;
   } else {
     return {
-      libraryName,
+      name,
       libraryMajorVersion,
       libraryMinorVersion,
       nonNpm,
@@ -191,22 +192,22 @@ export function validatePackageJson(
   }
 
   function validateName(): string | { errors: string[] } {
-    if (packageJson.name !== "@types/" + packageName) {
-      return { errors: [`${packageName}'s package.json should have \`"name": "@types/${packageName}"\``] };
+    if (packageJson.name !== "@types/" + typesDirectoryName) {
+      return { errors: [`${typesDirectoryName}'s package.json should have \`"name": "@types/${typesDirectoryName}"\``] };
     } else {
-      return packageName;
+      return typesDirectoryName;
     }
   }
   function validateVersion(): { major: number; minor: number } | { errors: string[] } {
     const errors = [];
     if (!packageJson.version || typeof packageJson.version !== "string") {
       errors.push(
-        `${packageName}'s package.json should have \`"version"\` matching the version of the implementation package.`
+        `${typesDirectoryName}'s package.json should have \`"version"\` matching the version of the implementation package.`
       );
     } else if (!/\d+\.\d+\.\d+/.exec(packageJson.version)) {
-      errors.push(`${packageName}'s package.json has bad "version": should look like "NN.NN.99999"`);
+      errors.push(`${typesDirectoryName}'s package.json has bad "version": should look like "NN.NN.99999"`);
     } else if (!packageJson.version.endsWith(".99999")) {
-      errors.push(`${packageName}'s package.json has bad "version": must end with ".99999"`);
+      errors.push(`${typesDirectoryName}'s package.json has bad "version": must end with ".99999"`);
     } else {
       let version: "*" | { major: number; minor?: number } = "*";
       try {
@@ -218,7 +219,7 @@ export function validatePackageJson(
           return { major: version.major, minor: version.minor ?? 0 };
         }
       } catch (e: any) {
-        errors.push(`'${packageName}'s package.json' has bad "version": Semver parsing failed with '${e.message}'`);
+        errors.push(`'${typesDirectoryName}'s package.json' has bad "version": Semver parsing failed with '${e.message}'`);
       }
     }
     return { errors };
@@ -227,19 +228,19 @@ export function validatePackageJson(
     const errors = [];
     if (packageJson.nonNpm !== undefined) {
       if (packageJson.nonNpm !== true) {
-        errors.push(`${packageName}'s package.json has bad "nonNpm": must be true if present.`);
+        errors.push(`${typesDirectoryName}'s package.json has bad "nonNpm": must be true if present.`);
       } else if (!packageJson.nonNpmDescription) {
         errors.push(
-          `${packageName}'s package.json has missing "nonNpmDescription", which is required with "nonNpm": true.`
+          `${typesDirectoryName}'s package.json has missing "nonNpmDescription", which is required with "nonNpm": true.`
         );
       } else if (typeof packageJson.nonNpmDescription !== "string") {
-        errors.push(`${packageName}'s package.json has bad "nonNpmDescription": must be a string if present.`);
+        errors.push(`${typesDirectoryName}'s package.json has bad "nonNpmDescription": must be a string if present.`);
       } else {
         return true;
       }
       return { errors };
     } else if (packageJson.nonNpmDescription !== undefined) {
-      errors.push(`${packageName}'s package.json has "nonNpmDescription" without "nonNpm": true.`);
+      errors.push(`${typesDirectoryName}'s package.json has "nonNpmDescription" without "nonNpm": true.`);
     }
     if (errors.length) {
       return { errors };
@@ -255,7 +256,7 @@ export function validatePackageJson(
       ) {
         return {
           errors: [
-            `${packageName}'s package.json has bad "typeScriptVersion": if present, must be a MAJOR.MINOR semver string up to "${TypeScriptVersion.latest}".
+            `${typesDirectoryName}'s package.json has bad "typeScriptVersion": if present, must be a MAJOR.MINOR semver string up to "${TypeScriptVersion.latest}".
 (Defaults to "${TypeScriptVersion.lowest}" if not provided.)`,
           ],
         };
@@ -273,10 +274,10 @@ export function validatePackageJson(
       !packageJson.projects.every((p) => typeof p === "string")
     ) {
       errors.push(
-        `${packageName}'s package.json has bad "projects": must be an array of strings that point to the project web site(s).`
+        `${typesDirectoryName}'s package.json has bad "projects": must be an array of strings that point to the project web site(s).`
       );
     } else if (packageJson.projects.length === 0) {
-      errors.push(`${packageName}'s package.json has bad "projects": must have at least one project URL.`);
+      errors.push(`${typesDirectoryName}'s package.json has bad "projects": must have at least one project URL.`);
     } else {
       return packageJson.projects;
     }
@@ -286,10 +287,10 @@ export function validatePackageJson(
     const errors: string[] = [];
     if (!packageJson.contributors || !Array.isArray(packageJson.contributors)) {
       errors.push(
-        `${packageName}'s package.json has bad "contributors": must be an array of type Array<{ name: string, url: string, githubUsername: string}>.`
+        `${typesDirectoryName}'s package.json has bad "contributors": must be an array of type Array<{ name: string, url: string, githubUsername: string}>.`
       );
     } else {
-      const es = checkPackageJsonContributors(packageName, packageJson.contributors);
+      const es = checkPackageJsonContributors(typesDirectoryName, packageJson.contributors);
       if (es.length) {
         errors.push(...es);
       } else {

--- a/packages/header-parser/src/index.ts
+++ b/packages/header-parser/src/index.ts
@@ -30,11 +30,17 @@ export interface Header {
   readonly contributors: readonly Author[];
 }
 // used in definitions-parser
-export interface Author {
-  readonly name: string;
-  readonly url: string;
-  readonly githubUsername: string | undefined;
-}
+export type Author =
+  | {
+      readonly name: string;
+      readonly url: string;
+    }
+  | {
+      readonly name: string;
+      readonly githubUsername: string;
+      readonly url?: undefined;
+    };
+
 // used locally
 export interface ParseError {
   readonly index: number;
@@ -96,7 +102,9 @@ export function validatePackageJson(
       case "typesVersions":
       case "types":
         if (!needsTypesVersions) {
-          errors.push(`${typesDirectoryName}'s package.json doesn't need to set "${key}" when no 'ts4.x' directories exist.`);
+          errors.push(
+            `${typesDirectoryName}'s package.json doesn't need to set "${key}" when no 'ts4.x' directories exist.`
+          );
         }
         break;
       default:
@@ -122,11 +130,19 @@ export function validatePackageJson(
 
   // typesVersions
   if (needsTypesVersions) {
-    assert.strictEqual(packageJson.types, "index", `"types" in '${typesDirectoryName}'s package.json' should be "index".`);
+    assert.strictEqual(
+      packageJson.types,
+      "index",
+      `"types" in '${typesDirectoryName}'s package.json' should be "index".`
+    );
     const expected = makeTypesVersionsForPackageJson(typesVersions) as Record<string, object>;
     if (!deepEquals(packageJson.typesVersions, expected)) {
       errors.push(
-        `'${typesDirectoryName}'s package.json' has bad "typesVersions". Should be: ${JSON.stringify(expected, undefined, 4)}`
+        `'${typesDirectoryName}'s package.json' has bad "typesVersions". Should be: ${JSON.stringify(
+          expected,
+          undefined,
+          4
+        )}`
       );
     }
   }
@@ -193,7 +209,9 @@ export function validatePackageJson(
 
   function validateName(): string | { errors: string[] } {
     if (packageJson.name !== "@types/" + typesDirectoryName) {
-      return { errors: [`${typesDirectoryName}'s package.json should have \`"name": "@types/${typesDirectoryName}"\``] };
+      return {
+        errors: [`${typesDirectoryName}'s package.json should have \`"name": "@types/${typesDirectoryName}"\``],
+      };
     } else {
       return typesDirectoryName;
     }
@@ -219,7 +237,9 @@ export function validatePackageJson(
           return { major: version.major, minor: version.minor ?? 0 };
         }
       } catch (e: any) {
-        errors.push(`'${typesDirectoryName}'s package.json' has bad "version": Semver parsing failed with '${e.message}'`);
+        errors.push(
+          `'${typesDirectoryName}'s package.json' has bad "version": Semver parsing failed with '${e.message}'`
+        );
       }
     }
     return { errors };

--- a/packages/publisher/src/generate-packages.ts
+++ b/packages/publisher/src/generate-packages.ts
@@ -3,34 +3,33 @@ import { emptyDir, mkdir, mkdirp, readFileSync } from "fs-extra";
 import path = require("path");
 import yargs = require("yargs");
 
-import { defaultLocalOptions } from "./lib/common";
-import { outputDirPath, sourceBranch } from "./lib/settings";
 import {
+  AllPackages,
+  AnyPackage,
+  License,
+  NotNeededPackage,
+  TypingsData,
+  getDefinitelyTyped
+} from "@definitelytyped/definitions-parser";
+import {
+  FS,
+  Logger,
   assertNever,
+  cacheDir,
   joinPaths,
   logUncaughtErrors,
-  loggerWithErrors,
-  FS,
   logger,
-  writeLog,
+  loggerWithErrors,
   writeFile,
-  Logger,
-  cacheDir,
+  writeLog,
   writeTgz,
 } from "@definitelytyped/utils";
-import {
-  getDefinitelyTyped,
-  AllPackages,
-  TypingsData,
-  NotNeededPackage,
-  AnyPackage,
-  getFullNpmName,
-  License,
-} from "@definitelytyped/definitions-parser";
 import * as pacote from "pacote";
-import { readChangedPackages, ChangedPackages } from "./lib/versions";
-import { outputDirectory } from "./util/util";
+import { defaultLocalOptions } from "./lib/common";
 import { skipBadPublishes } from "./lib/npm";
+import { outputDirPath, sourceBranch } from "./lib/settings";
+import { ChangedPackages, readChangedPackages } from "./lib/versions";
+import { outputDirectory } from "./util/util";
 
 const mitLicense = readFileSync(joinPaths(__dirname, "..", "LICENSE"), "utf-8");
 
@@ -70,7 +69,7 @@ export default async function generatePackages(dt: FS, changedPackages: ChangedP
   await writeLog("package-generator.md", logResult());
 }
 async function generateTypingPackage(typing: TypingsData, version: string, dt: FS): Promise<void> {
-  const typesDirectory = dt.subDir("types").subDir(typing.name);
+  const typesDirectory = dt.subDir("types").subDir(typing.typesDirectoryName);
   const packageFS =
     typing.isLatest || !typing.versionDirectoryName
       ? typesDirectory
@@ -85,8 +84,8 @@ async function generateTypingPackage(typing: TypingsData, version: string, dt: F
 async function generateNotNeededPackage(pkg: NotNeededPackage, log: Logger): Promise<void> {
   pkg = await skipBadPublishes(pkg, log);
   const info = await pacote.manifest(pkg.libraryName, { cache: cacheDir, fullMetadata: true });
-  const readme = `This is a stub types definition for ${getFullNpmName(pkg.name)} (${info.homepage}).\n
-${pkg.libraryName} provides its own type definitions, so you don't need ${getFullNpmName(pkg.name)} installed!`;
+  const readme = `This is a stub types definition for ${pkg.name} (${info.homepage}).\n
+${pkg.libraryName} provides its own type definitions, so you don't need ${pkg.name} installed!`;
   await writeCommonOutputs(pkg, createNotNeededPackageJSON(pkg), readme);
 }
 
@@ -116,11 +115,11 @@ async function outputFilePath(pkg: AnyPackage, filename: string): Promise<string
 export function createPackageJSON(typing: TypingsData, version: string): string {
   // Use the ordering of fields from https://docs.npmjs.com/files/package.json
   const out: {} = {
-    name: typing.fullNpmName,
+    name: typing.name,
     version,
     description: `TypeScript definitions for ${typing.libraryName}`,
     // keywords,
-    homepage: `https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/${typing.name}`,
+    homepage: `https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/${typing.typesDirectoryName}`,
     // bugs,
     license: typing.license,
     contributors: typing.contributors,
@@ -130,7 +129,7 @@ export function createPackageJSON(typing: TypingsData, version: string): string 
     repository: {
       type: "git",
       url: "https://github.com/DefinitelyTyped/DefinitelyTyped.git",
-      directory: `types/${typing.name}`,
+      directory: `types/${typing.typesDirectoryName}`,
     },
     scripts: {},
     dependencies: typing.packageJsonDependencies,
@@ -157,7 +156,7 @@ const definitelyTypedURL = "https://github.com/DefinitelyTyped/DefinitelyTyped";
 
 export function createNotNeededPackageJSON(pkg: NotNeededPackage): string {
   const out = {
-    name: pkg.fullNpmName,
+    name: pkg.name,
     version: String(pkg.version),
     description: `Stub TypeScript definitions entry for ${pkg.libraryName}, which provides its own types definitions`,
     main: "",
@@ -175,7 +174,7 @@ export function createNotNeededPackageJSON(pkg: NotNeededPackage): string {
 export function createReadme(typing: TypingsData, packageFS: FS): string {
   const lines: string[] = [];
   lines.push("# Installation");
-  lines.push(`> \`npm install --save ${typing.fullNpmName}\``);
+  lines.push(`> \`npm install --save ${typing.name}\``);
   lines.push("");
 
   lines.push("# Summary");

--- a/packages/publisher/src/generate-packages.ts
+++ b/packages/publisher/src/generate-packages.ts
@@ -211,7 +211,7 @@ export function createReadme(typing: TypingsData, packageFS: FS): string {
 
   lines.push("# Credits");
   const contributors = typing.contributors
-    .map(({ name, url }) => `[${name}](${url})`)
+    .map((c) => `[${c.name}](${c.url ?? `https://github.com/${c.githubUsername}`})`)
     .join(", ")
     .replace(/, ([^,]+)$/, ", and $1");
   lines.push(`These definitions were written by ${contributors}.`);

--- a/packages/publisher/src/lib/npm.ts
+++ b/packages/publisher/src/lib/npm.ts
@@ -10,7 +10,7 @@ import * as semver from "semver";
  */
 export async function skipBadPublishes(pkg: NotNeededPackage, log: Logger) {
   // because this is called right after isAlreadyDeprecated, we can rely on the cache being up-to-date
-  const info = await pacote.packument(pkg.fullNpmName, { cache: cacheDir });
+  const info = await pacote.packument(pkg.name, { cache: cacheDir });
   const maxVersion = semver.maxSatisfying(Object.keys(info.versions), "*")!;
   if (semver.lte(pkg.version, maxVersion)) {
     const plusOne = semver.inc(maxVersion, "patch")!;

--- a/packages/publisher/src/lib/package-publisher.ts
+++ b/packages/publisher/src/lib/package-publisher.ts
@@ -21,7 +21,7 @@ export async function publishTypingsPackage(
     // If this is an older version of the package, we still update tags for the *latest*.
     // NPM will update "latest" even if we are publishing an older version of a package (https://github.com/npm/npm/issues/6778),
     // so we must undo that by re-tagging latest.
-    await updateLatestTag(pkg.fullNpmName, latestVersion, client, log, dry);
+    await updateLatestTag(pkg.name, latestVersion, client, log, dry);
   }
 }
 

--- a/packages/publisher/src/lib/versions.ts
+++ b/packages/publisher/src/lib/versions.ts
@@ -19,6 +19,7 @@ export interface ChangedTyping {
 
 export interface ChangedPackagesJson {
   readonly changedTypings: readonly ChangedTypingJson[];
+  /** Values are `typesDirectoryName` strings (keys of notNeededPackages.json) */
   readonly changedNotNeededPackages: readonly string[];
 }
 

--- a/packages/publisher/src/publish-packages.ts
+++ b/packages/publisher/src/publish-packages.ts
@@ -95,9 +95,9 @@ export default async function publishPackages(
       log("Current date is " + new Date(Date.now()).toString());
       log("  Merge date is " + new Date(latest.merged_at).toString());
 
-      const published = cp.pkg.fullNpmName + "@" + cp.version;
+      const published = cp.pkg.name + "@" + cp.version;
       const publishNotification =
-        "I just published [`" + published + "` to npm](https://www.npmjs.com/package/" + cp.pkg.fullNpmName + ").";
+        "I just published [`" + published + "` to npm](https://www.npmjs.com/package/" + cp.pkg.name + ").";
       log(publishNotification);
       if (dry) {
         log("(dry) Skip publishing notification to github.");

--- a/packages/publisher/src/publish-registry.ts
+++ b/packages/publisher/src/publish-registry.ts
@@ -168,7 +168,7 @@ async function validateIsSubset(notNeeded: readonly NotNeededPackage[], log: Log
   const actual = (await readJson(joinPaths(validateTypesRegistryPath, indexJson))) as Registry;
   const expected = (await readJson(joinPaths(registryOutputPath, indexJson))) as Registry;
   for (const key of Object.keys(actual.entries)) {
-    if (!(key in expected.entries) && !notNeeded.some((p) => p.name === key)) {
+    if (!(key in expected.entries) && !notNeeded.some((p) => p.typesDirectoryName === key)) {
       throw new Error(`Actual types-registry has unexpected key ${key}`);
     }
   }
@@ -221,7 +221,7 @@ function generatePackageJson(name: string, version: string, typesPublisherConten
 
 interface Registry {
   readonly entries: {
-    readonly [packageName: string]: {
+    readonly [typesDirectoryName: string]: {
       readonly [distTags: string]: string;
     };
   };
@@ -231,8 +231,8 @@ async function generateRegistry(typings: readonly TypingsData[]): Promise<Regist
     entries: Object.fromEntries(
       await Promise.all(
         typings.map(async (typing) => [
-          typing.name,
-          filterTags((await pacote.packument(typing.fullNpmName, { cache: cacheDir }))["dist-tags"]),
+          typing.typesDirectoryName,
+          filterTags((await pacote.packument(typing.name, { cache: cacheDir }))["dist-tags"]),
         ])
       )
     ),

--- a/packages/publisher/src/util/util.ts
+++ b/packages/publisher/src/util/util.ts
@@ -7,5 +7,5 @@ export function currentTimeStamp(): string {
 }
 
 export function outputDirectory(pkg: AnyPackage) {
-  return joinPaths(outputDirPath, pkg.desc);
+  return joinPaths(outputDirPath, pkg.typesDirectoryName + pkg.isLatest ? "" : ` v${pkg.major}.${pkg.minor}`);
 }

--- a/packages/publisher/src/util/util.ts
+++ b/packages/publisher/src/util/util.ts
@@ -7,5 +7,5 @@ export function currentTimeStamp(): string {
 }
 
 export function outputDirectory(pkg: AnyPackage) {
-  return joinPaths(outputDirPath, pkg.typesDirectoryName + pkg.isLatest ? "" : ` v${pkg.major}.${pkg.minor}`);
+  return joinPaths(outputDirPath, pkg.typesDirectoryName + (pkg.isLatest ? "" : ` v${pkg.major}.${pkg.minor}`));
 }

--- a/packages/publisher/test/generate-packages.test.ts
+++ b/packages/publisher/test/generate-packages.test.ts
@@ -10,19 +10,21 @@ import { InMemoryFS, Dir, FS } from "@definitelytyped/utils";
 
 function createRawPackage(license: License): TypingsDataRaw {
   return {
-    libraryName: "jquery",
-    typingsPackageName: "jquery",
-    contributors: [{ name: "A", url: "b@c.d", githubUsername: "e" }],
-    libraryMajorVersion: 1,
-    libraryMinorVersion: 0,
-    minTsVersion: "3.2",
+    header: {
+      name: "@types/jquery",
+      contributors: [{ name: "A", url: "b@c.d", githubUsername: "e" }],
+      libraryMajorVersion: 1,
+      libraryMinorVersion: 0,
+      typeScriptVersion: "3.2",
+      projects: ["jquery.org"],
+      nonNpm: false,
+    },
     typesVersions: [],
     files: ["index.d.ts", "jquery.test.ts"],
     license,
     packageJsonDependencies: { "@types/madeira": "^1", balzac: "~3" },
     packageJsonDevDependencies: { "@types/jquery": "workspace:." },
     contentHash: "11",
-    projectName: "jquery.org",
     globals: [],
   };
 }

--- a/packages/publisher/test/generate-packages.test.ts
+++ b/packages/publisher/test/generate-packages.test.ts
@@ -12,7 +12,7 @@ function createRawPackage(license: License): TypingsDataRaw {
   return {
     header: {
       name: "@types/jquery",
-      contributors: [{ name: "A", url: "b@c.d", githubUsername: "e" }],
+      contributors: [{ name: "A", url: "b@c.d" }, { name: "E", githubUsername: "e" }],
       libraryMajorVersion: 1,
       libraryMinorVersion: 0,
       typeScriptVersion: "3.2",
@@ -60,6 +60,10 @@ testo({
       expect.stringContaining("This package contains type definitions for")
     );
   },
+  readmeContainsContributors() {
+    const typing = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
+    expect(createReadme(typing, defaultFS())).toEqual(expect.stringContaining("written by [A](b@c.d), and [E](https://github.com/e)"));
+  },
   readmeContainsProjectName() {
     const typing = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
     expect(createReadme(typing, defaultFS())).toEqual(expect.stringContaining("jquery.org"));
@@ -105,7 +109,10 @@ testo({
     "contributors": [
         {
             "name": "A",
-            "url": "b@c.d",
+            "url": "b@c.d"
+        },
+        {
+            "name": "E",
             "githubUsername": "e"
         }
     ],

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -33,6 +33,7 @@
     "@types/charm": "^1.0.1",
     "@types/fs-extra": "^8.1.0",
     "@types/semver": "^7.5.3",
+    "@types/tar": "^6.1",
     "@types/tar-stream": "^2.1.0"
   },
   "publishConfig": {

--- a/packages/utils/src/typescript-installer.ts
+++ b/packages/utils/src/typescript-installer.ts
@@ -51,7 +51,7 @@ export function cleanTypeScriptInstalls(): Promise<void> {
   return fs.remove(installsDir);
 }
 
-export function typeScriptPath(version: TsVersion, tsLocal: string | undefined): string {
+export function typeScriptPath(version: TsVersion | "next" | "rc", tsLocal: string | undefined): string {
   if (version === "local") {
     return tsLocal! + "/typescript.js";
   }

--- a/packages/utils/test/io.test.ts
+++ b/packages/utils/test/io.test.ts
@@ -13,14 +13,13 @@ describe("io", () => {
         throw err;
       })
         .pipe(fs.createWriteStream(archivePath))
-        .on("finish", () => {
+        .on("finish", async () => {
           expect(fs.existsSync(archivePath)).toBe(true);
           const entries: string[] = [];
-          list({ file: archivePath, onentry: (e) => entries.push(e.path) }, null, () => {
-            expect(entries[0]).toBe("pack/");
-            expect(entries[1]).toBe("pack/test.txt");
-            done();
-          });
+          await list({ file: archivePath, onentry: (e) => entries.push(e.path) });
+          expect(entries[0]).toBe("pack/");
+          expect(entries[1]).toBe("pack/test.txt");
+          done();
         });
     });
   });

--- a/packages/utils/test/typescript-installer.test.ts
+++ b/packages/utils/test/typescript-installer.test.ts
@@ -5,8 +5,8 @@ import * as path from "path";
 
 describe("typeScriptPath", () => {
   it("maps to temp folder", () => {
-    expect(typeScriptPath("3.4", undefined)).toEqual(
-      path.join(os.homedir(), ".dts", "typescript-installs", "3.4", "node_modules", "typescript")
+    expect(typeScriptPath("5.3", undefined)).toEqual(
+      path.join(os.homedir(), ".dts", "typescript-installs", "5.3", "node_modules", "typescript")
     );
   });
   it("maps next to latest typescript version", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -446,6 +446,9 @@ importers:
       '@types/semver':
         specifier: ^7.5.3
         version: 7.5.3
+      '@types/tar':
+        specifier: ^6.1
+        version: 6.1.6
       '@types/tar-stream':
         specifier: ^2.1.0
         version: 2.2.2
@@ -1138,14 +1141,14 @@ packages:
       '@jest/test-result': 29.5.0
       '@jest/transform': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 18.14.2
+      '@types/node': 14.18.36
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.8.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.5.0
-      jest-config: 29.5.0(@types/node@18.14.2)
+      jest-config: 29.5.0(@types/node@14.18.36)
       jest-haste-map: 29.5.0
       jest-message-util: 29.5.0
       jest-regex-util: 29.4.3
@@ -1320,7 +1323,7 @@ packages:
       '@jest/schemas': 29.4.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 18.14.2
+      '@types/node': 14.18.36
       '@types/yargs': 17.0.23
       chalk: 4.1.2
     dev: true
@@ -1804,7 +1807,7 @@ packages:
   /@types/npm-registry-fetch@8.0.4:
     resolution: {integrity: sha512-R9yEj6+NDmXLpKNS19cIaMyaHfV0aHjy/1qbo8K9jiHyjyaYg0CEmuOV/L0Q91DZDi3SuxlYY+2XYwh9TbB+eQ==}
     dependencies:
-      '@types/node': 18.14.2
+      '@types/node': 14.18.36
       '@types/node-fetch': 2.6.2
       '@types/npm-package-arg': 6.1.1
       '@types/npmlog': 4.1.4
@@ -1863,7 +1866,7 @@ packages:
   /@types/ssri@7.1.1:
     resolution: {integrity: sha512-DPP/jkDaqGiyU75MyMURxLWyYLwKSjnAuGe9ZCsLp9QZOpXmDfuevk769F0BS86TmRuD5krnp06qw9nSoNO+0g==}
     dependencies:
-      '@types/node': 18.14.2
+      '@types/node': 14.18.36
     dev: true
 
   /@types/stack-utils@2.0.1:
@@ -1886,6 +1889,13 @@ packages:
     resolution: {integrity: sha512-1AX+Yt3icFuU6kxwmPakaiGrJUwG44MpuiqPg4dSolRFk6jmvs4b3IbUol9wKDLIgU76gevn3EwE8y/DkSJCZQ==}
     dependencies:
       '@types/node': 18.14.2
+    dev: true
+
+  /@types/tar@6.1.6:
+    resolution: {integrity: sha512-HQ06kiiDXz9uqtmE9ksQUn1ovcPr1gGV9EgaCWo6FGYKD0onNBCetBzL0kfcS8Kbj1EFxJWY9jL2W4ZvvtGI8Q==}
+    dependencies:
+      '@types/node': 14.18.36
+      minipass: 4.2.4
     dev: true
 
   /@types/tmp@0.2.3:
@@ -4546,45 +4556,6 @@ packages:
       - supports-color
     dev: true
 
-  /jest-config@29.5.0(@types/node@18.14.2):
-    resolution: {integrity: sha512-kvDUKBnNJPNBmFFOhDbm59iu1Fii1Q6SxyhXfvylq3UTHbg6o7j/g8k2dZyXWLvfdKB1vAPxNZnMgtKJcmu3kA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    peerDependencies:
-      '@types/node': '*'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      '@babel/core': 7.21.3
-      '@jest/test-sequencer': 29.5.0
-      '@jest/types': 29.5.0
-      '@types/node': 18.14.2
-      babel-jest: 29.5.0(@babel/core@7.21.3)
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      deepmerge: 4.3.0
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.5.0
-      jest-environment-node: 29.5.0
-      jest-get-type: 29.4.3
-      jest-regex-util: 29.4.3
-      jest-resolve: 29.5.0
-      jest-runner: 29.5.0
-      jest-util: 29.5.0
-      jest-validate: 29.5.0
-      micromatch: 4.0.5
-      parse-json: 5.2.0
-      pretty-format: 29.5.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /jest-diff@29.5.0:
     resolution: {integrity: sha512-LtxijLLZBduXnHSniy0WMdaHjmQnt3g5sa16W4p0HqukYTTsyTW3GD1q41TyGl5YFXj/5B2U6dlh5FM1LIMgxw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -4828,7 +4799,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.5.0
-      '@types/node': 18.14.2
+      '@types/node': 14.18.36
       chalk: 4.1.2
       ci-info: 3.8.0
       graceful-fs: 4.2.11
@@ -5313,7 +5284,6 @@ packages:
   /minipass@4.2.4:
     resolution: {integrity: sha512-lwycX3cBMTvcejsHITUgYj6Gy6A7Nh4Q6h9NP4sTHY1ccJlC7yKzDmiShEHsJ16Jf1nKGDEaiHxiltsJEvk0nQ==}
     engines: {node: '>=8'}
-    dev: false
 
   /minizlib@2.1.2:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,11 @@
     { "path": "packages/publisher" },
     { "path": "packages/typescript-versions" },
     { "path": "packages/utils" },
-    { "path": "packages/retag" }
+    { "path": "packages/retag" },
+
+    { "path": "packages/definitions-parser/test" },
+    { "path": "packages/header-parser/test" },
+    { "path": "packages/publisher/test" },
+    { "path": "packages/utils/test" }
   ]
 }


### PR DESCRIPTION
A bunch of renaming, and preserving some more info starting at the header parser. New nomenclature:

- name: `@types/ember__object`
- typesDirectoryName: `ember__object`
- libraryName: `@ember/object` (or `nonNpmDescription` for non-npm packages)
- subDirectoryPath: `ember__object/v2`

