### PR TITLE
Check newly added packages

### DIFF
--- a/.changeset/hungry-jeans-love.md
+++ b/.changeset/hungry-jeans-love.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/definitions-parser": patch
+---
+
+dtslint-runner checks new packages, even malformed ones.

--- a/packages/definitions-parser/test/get-affected-packages.test.ts
+++ b/packages/definitions-parser/test/get-affected-packages.test.ts
@@ -28,6 +28,7 @@ testo({
     const { packageNames, dependents } = getAffectedPackagesWorker(
       allPackages,
       packageOutput,
+      [],
       [dependentOutput],
       "/dt"
     );
@@ -40,6 +41,7 @@ testo({
     const { packageNames, dependents } = getAffectedPackagesWorker(
       allPackages,
       packageOutput,
+      [],
       [dependentOutput],
       "/dt"
     );
@@ -55,8 +57,21 @@ testo({
       `/dt/types/has-older-test-dependency
 /dt/types/known`,
     ];
-    const { packageNames } = getAffectedPackagesWorker(allPackages, packageOutput, dependentOutput, "/dt");
+    const { packageNames } = getAffectedPackagesWorker(allPackages, packageOutput, [], dependentOutput, "/dt");
     expect(packageNames).toEqual(new Set(["jquery"]));
+  },
+  newPackage() {
+    const packageOutput = ``;
+    const dependentOutput = ``;
+    const { packageNames, dependents } = getAffectedPackagesWorker(
+      AllPackages.from({ ...typesData, mistake: createTypingsVersionRaw("mistake", {}, {}) }, notNeeded),
+      packageOutput,
+      ["mistake"],
+      [dependentOutput],
+      "/dt"
+    );
+    expect(packageNames).toEqual(new Set(["mistake"]));
+    expect(dependents).toEqual(new Set([]));
   },
   olderVersion() {
     const packageOutput = `/dt/types/jquery`;
@@ -66,6 +81,7 @@ testo({
     const { packageNames, dependents } = getAffectedPackagesWorker(
       allPackages,
       packageOutput,
+      [],
       [dependentOutput],
       "/dt"
     );

--- a/packages/definitions-parser/test/get-affected-packages.test.ts
+++ b/packages/definitions-parser/test/get-affected-packages.test.ts
@@ -64,7 +64,7 @@ testo({
     const packageOutput = ``;
     const dependentOutput = ``;
     const { packageNames, dependents } = getAffectedPackagesWorker(
-      AllPackages.from({ ...typesData, mistake: createTypingsVersionRaw("mistake", {}, {}) }, notNeeded),
+      allPackages,
       packageOutput,
       ["mistake"],
       [dependentOutput],

--- a/packages/definitions-parser/test/git.test.ts
+++ b/packages/definitions-parser/test/git.test.ts
@@ -24,7 +24,7 @@ const deleteJestDiffs: GitDiff[] = [
 
 testo({
   ok() {
-    expect(getNotNeededPackages(allPackages, deleteJestDiffs)).toEqual({ ok: jestNotNeeded });
+    expect(getNotNeededPackages(allPackages, deleteJestDiffs)).toEqual(jestNotNeeded);
   },
   forgotToDeleteFiles() {
     expect(
@@ -38,14 +38,14 @@ testo({
     expect(getNotNeededPackages(allPackages, [{ status: "D", file: "oops.txt" }])).toEqual({
       errors: [
         `Unexpected file deleted: oops.txt
-When removing packages, you should only delete files that are a part of removed packages.`,
+You should only delete files that are a part of removed packages.`,
       ],
     });
   },
   deleteInOtherPackage() {
     expect(
       getNotNeededPackages(allPackages, [...deleteJestDiffs, { status: "D", file: "types/most-recent/extra-tests.ts" }])
-    ).toEqual({ ok: jestNotNeeded });
+    ).toEqual(jestNotNeeded);
   },
   extraneousFile() {
     expect(
@@ -55,7 +55,12 @@ When removing packages, you should only delete files that are a part of removed 
         { status: "D", file: "types/jest/index.d.ts" },
         { status: "D", file: "types/jest/jest-tests.d.ts" },
       ])
-    ).toEqual({ ok: jestNotNeeded });
+    ).toEqual({
+      errors: [
+        `Unexpected file added: oooooooooooops.txt
+You should only add files that are part of packages.`,
+      ],
+    });
   },
   scoped() {
     expect(
@@ -63,7 +68,7 @@ When removing packages, you should only delete files that are a part of removed 
         AllPackages.from(typesData, [new NotNeededPackage("ember__object", "@ember/object", "1.0.0")]),
         [{ status: "D", file: "types/ember__object/index.d.ts" }]
       )
-    ).toEqual({ ok: [new NotNeededPackage("ember__object", "@ember/object", "1.0.0")] });
+    ).toEqual([new NotNeededPackage("ember__object", "@ember/object", "1.0.0")]);
   },
   // TODO: Test npm info (and with scoped names)
   // TODO: Test with dependents, etc etc


### PR DESCRIPTION
even if they're missing package.json

Moves gitDeletions from git.ts to get-affected-packages, sorry for the churn.
Edit: less churn, still churny.