### PR TITLE
Add semver types to dependencies in definitions-parser

### DIFF
--- a/.changeset/dirty-walls-drum.md
+++ b/.changeset/dirty-walls-drum.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/definitions-parser": patch
+---
+
+Add semver types to dependencies in definitions-parser

--- a/packages/definitions-parser/package.json
+++ b/packages/definitions-parser/package.json
@@ -23,14 +23,14 @@
     "@definitelytyped/typescript-versions": "workspace:*",
     "@definitelytyped/utils": "workspace:*",
     "@types/node": "^14.14.35",
+    "@types/semver": "^7.5.2",
     "fs-extra": "^9.1.0",
     "pacote": "^13.6.1",
     "semver": "^7.3.7"
   },
   "devDependencies": {
     "@types/fs-extra": "^9.0.8",
-    "@types/pacote": "^11.1.5",
-    "@types/semver": "^7.5.2"
+    "@types/pacote": "^11.1.5"
   },
   "peerDependencies": {
     "typescript": "*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
       '@types/node':
         specifier: ^14.14.35
         version: 14.18.36
+      '@types/semver':
+        specifier: ^7.5.2
+        version: 7.5.2
       fs-extra:
         specifier: ^9.1.0
         version: 9.1.0
@@ -92,9 +95,6 @@ importers:
       '@types/pacote':
         specifier: ^11.1.5
         version: 11.1.5
-      '@types/semver':
-        specifier: ^7.5.2
-        version: 7.5.2
 
   packages/dts-critic:
     dependencies:
@@ -155,19 +155,19 @@ importers:
         version: link:../utils
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.55.0
-        version: 5.55.0(@typescript-eslint/parser@5.55.0)(eslint@8.35.0)(typescript@5.3.0-dev.20230927)
+        version: 5.55.0(@typescript-eslint/parser@5.55.0)(eslint@8.35.0)(typescript@5.3.0-dev.20231018)
       '@typescript-eslint/parser':
         specifier: ^5.55.0
-        version: 5.55.0(eslint@8.35.0)(typescript@5.3.0-dev.20230927)
+        version: 5.55.0(eslint@8.35.0)(typescript@5.3.0-dev.20231018)
       '@typescript-eslint/types':
         specifier: ^5.56.0
         version: 5.56.0
       '@typescript-eslint/typescript-estree':
         specifier: ^5.55.0
-        version: 5.55.0(typescript@5.3.0-dev.20230927)
+        version: 5.55.0(typescript@5.3.0-dev.20231018)
       '@typescript-eslint/utils':
         specifier: ^5.55.0
-        version: 5.55.0(eslint@8.35.0)(typescript@5.3.0-dev.20230927)
+        version: 5.55.0(eslint@8.35.0)(typescript@5.3.0-dev.20231018)
       eslint:
         specifier: ^8.17.0
         version: 8.35.0
@@ -185,7 +185,7 @@ importers:
         version: 2.0.1
       tslint:
         specifier: 5.14.0
-        version: 5.14.0(typescript@5.3.0-dev.20230927)
+        version: 5.14.0(typescript@5.3.0-dev.20231018)
       yargs:
         specifier: ^15.1.0
         version: 15.3.1
@@ -204,7 +204,7 @@ importers:
         version: 0.0.28
       typescript:
         specifier: next
-        version: 5.3.0-dev.20230927
+        version: 5.3.0-dev.20231018
 
   packages/dtslint-runner:
     dependencies:
@@ -348,7 +348,7 @@ importers:
         version: 0.4.18
       typescript:
         specifier: next
-        version: 5.3.0-dev.20230927
+        version: 5.3.0-dev.20231018
       yargs:
         specifier: 15.3.1
         version: 15.3.1
@@ -1957,7 +1957,7 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/eslint-plugin@5.55.0(@typescript-eslint/parser@5.55.0)(eslint@8.35.0)(typescript@5.3.0-dev.20230927):
+  /@typescript-eslint/eslint-plugin@5.55.0(@typescript-eslint/parser@5.55.0)(eslint@8.35.0)(typescript@5.3.0-dev.20231018):
     resolution: {integrity: sha512-IZGc50rtbjk+xp5YQoJvmMPmJEYoC53SiKPXyqWfv15XoD2Y5Kju6zN0DwlmaGJp1Iw33JsWJcQ7nw0lGCGjVg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1969,18 +1969,18 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.4.0
-      '@typescript-eslint/parser': 5.55.0(eslint@8.35.0)(typescript@5.3.0-dev.20230927)
+      '@typescript-eslint/parser': 5.55.0(eslint@8.35.0)(typescript@5.3.0-dev.20231018)
       '@typescript-eslint/scope-manager': 5.55.0
-      '@typescript-eslint/type-utils': 5.55.0(eslint@8.35.0)(typescript@5.3.0-dev.20230927)
-      '@typescript-eslint/utils': 5.55.0(eslint@8.35.0)(typescript@5.3.0-dev.20230927)
+      '@typescript-eslint/type-utils': 5.55.0(eslint@8.35.0)(typescript@5.3.0-dev.20231018)
+      '@typescript-eslint/utils': 5.55.0(eslint@8.35.0)(typescript@5.3.0-dev.20231018)
       debug: 4.3.4
       eslint: 8.35.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
       natural-compare-lite: 1.4.0
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.3.0-dev.20230927)
-      typescript: 5.3.0-dev.20230927
+      tsutils: 3.21.0(typescript@5.3.0-dev.20231018)
+      typescript: 5.3.0-dev.20231018
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -2025,7 +2025,7 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/parser@5.55.0(eslint@8.35.0)(typescript@5.3.0-dev.20230927):
+  /@typescript-eslint/parser@5.55.0(eslint@8.35.0)(typescript@5.3.0-dev.20231018):
     resolution: {integrity: sha512-ppvmeF7hvdhUUZWSd2EEWfzcFkjJzgNQzVST22nzg958CR+sphy8A6K7LXQZd6V75m1VKjp+J4g/PCEfSCmzhw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2037,10 +2037,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.55.0
       '@typescript-eslint/types': 5.55.0
-      '@typescript-eslint/typescript-estree': 5.55.0(typescript@5.3.0-dev.20230927)
+      '@typescript-eslint/typescript-estree': 5.55.0(typescript@5.3.0-dev.20231018)
       debug: 4.3.4
       eslint: 8.35.0
-      typescript: 5.3.0-dev.20230927
+      typescript: 5.3.0-dev.20231018
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -2092,7 +2092,7 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/type-utils@5.55.0(eslint@8.35.0)(typescript@5.3.0-dev.20230927):
+  /@typescript-eslint/type-utils@5.55.0(eslint@8.35.0)(typescript@5.3.0-dev.20231018):
     resolution: {integrity: sha512-ObqxBgHIXj8rBNm0yh8oORFrICcJuZPZTqtAFh0oZQyr5DnAHZWfyw54RwpEEH+fD8suZaI0YxvWu5tYE/WswA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2102,12 +2102,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.55.0(typescript@5.3.0-dev.20230927)
-      '@typescript-eslint/utils': 5.55.0(eslint@8.35.0)(typescript@5.3.0-dev.20230927)
+      '@typescript-eslint/typescript-estree': 5.55.0(typescript@5.3.0-dev.20231018)
+      '@typescript-eslint/utils': 5.55.0(eslint@8.35.0)(typescript@5.3.0-dev.20231018)
       debug: 4.3.4
       eslint: 8.35.0
-      tsutils: 3.21.0(typescript@5.3.0-dev.20230927)
-      typescript: 5.3.0-dev.20230927
+      tsutils: 3.21.0(typescript@5.3.0-dev.20231018)
+      typescript: 5.3.0-dev.20231018
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -2141,7 +2141,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/typescript-estree@5.55.0(typescript@5.3.0-dev.20230927):
+  /@typescript-eslint/typescript-estree@5.55.0(typescript@5.3.0-dev.20231018):
     resolution: {integrity: sha512-I7X4A9ovA8gdpWMpr7b1BN9eEbvlEtWhQvpxp/yogt48fy9Lj3iE3ild/1H3jKBBIYj5YYJmS2+9ystVhC7eaQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2156,8 +2156,8 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.3.0-dev.20230927)
-      typescript: 5.3.0-dev.20230927
+      tsutils: 3.21.0(typescript@5.3.0-dev.20231018)
+      typescript: 5.3.0-dev.20231018
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -2202,7 +2202,7 @@ packages:
       - typescript
     dev: false
 
-  /@typescript-eslint/utils@5.55.0(eslint@8.35.0)(typescript@5.3.0-dev.20230927):
+  /@typescript-eslint/utils@5.55.0(eslint@8.35.0)(typescript@5.3.0-dev.20231018):
     resolution: {integrity: sha512-FkW+i2pQKcpDC3AY6DU54yl8Lfl14FVGYDgBTyGKB75cCwV3KpkpTMFi9d9j2WAJ4271LR2HeC5SEWF/CZmmfw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2213,7 +2213,7 @@ packages:
       '@types/semver': 7.5.2
       '@typescript-eslint/scope-manager': 5.55.0
       '@typescript-eslint/types': 5.55.0
-      '@typescript-eslint/typescript-estree': 5.55.0(typescript@5.3.0-dev.20230927)
+      '@typescript-eslint/typescript-estree': 5.55.0(typescript@5.3.0-dev.20231018)
       eslint: 8.35.0
       eslint-scope: 5.1.1
       semver: 7.5.4
@@ -3267,7 +3267,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.55.0(eslint@8.35.0)(typescript@5.3.0-dev.20230927)
+      '@typescript-eslint/parser': 5.55.0(eslint@8.35.0)(typescript@5.3.0-dev.20231018)
       debug: 3.2.7
       eslint: 8.35.0
       eslint-import-resolver-node: 0.3.7
@@ -3318,7 +3318,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.55.0(eslint@8.35.0)(typescript@5.3.0-dev.20230927)
+      '@typescript-eslint/parser': 5.55.0(eslint@8.35.0)(typescript@5.3.0-dev.20231018)
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
@@ -6584,7 +6584,7 @@ packages:
       typescript: 5.2.2
     dev: true
 
-  /tslint@5.14.0(typescript@5.3.0-dev.20230927):
+  /tslint@5.14.0(typescript@5.3.0-dev.20231018):
     resolution: {integrity: sha512-IUla/ieHVnB8Le7LdQFRGlVJid2T/gaJe5VkjzRVSRR6pA2ODYrnfR1hmxi+5+au9l50jBwpbBL34txgv4NnTQ==}
     engines: {node: '>=4.8.0'}
     hasBin: true
@@ -6603,8 +6603,8 @@ packages:
       resolve: 1.22.1
       semver: 7.5.4
       tslib: 1.14.1
-      tsutils: 2.29.0(typescript@5.3.0-dev.20230927)
-      typescript: 5.3.0-dev.20230927
+      tsutils: 2.29.0(typescript@5.3.0-dev.20231018)
+      typescript: 5.3.0-dev.20231018
     dev: false
 
   /tslint@6.1.3(typescript@5.2.2):
@@ -6649,13 +6649,13 @@ packages:
       typescript: 5.2.2
     dev: true
 
-  /tsutils@2.29.0(typescript@5.3.0-dev.20230927):
+  /tsutils@2.29.0(typescript@5.3.0-dev.20231018):
     resolution: {integrity: sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==}
     peerDependencies:
       typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.3.0-dev.20230927
+      typescript: 5.3.0-dev.20231018
     dev: false
 
   /tsutils@3.21.0(typescript@5.2.2):
@@ -6667,14 +6667,14 @@ packages:
       tslib: 1.14.1
       typescript: 5.2.2
 
-  /tsutils@3.21.0(typescript@5.3.0-dev.20230927):
+  /tsutils@3.21.0(typescript@5.3.0-dev.20231018):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.3.0-dev.20230927
+      typescript: 5.3.0-dev.20231018
     dev: false
 
   /tty-table@4.2.1:
@@ -6758,8 +6758,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /typescript@5.3.0-dev.20230927:
-    resolution: {integrity: sha512-FHoT/nbOZjlXfK1yYTtCVT6yOp7Y9Vab/8Do4KiEGl3jI6rxPD7d1ssB/5vlH4ZXZ//0DW96vsvp/OUyjxCqgA==}
+  /typescript@5.3.0-dev.20231018:
+    resolution: {integrity: sha512-qBPaVi+ntB9Ys4T3uP1ZYCtxFWIV/1ieooBDhFEd8nw4IqAoB/Us7XobF3xb756bnX8cS/zIt9fgukde4MG4bA==}
     engines: {node: '>=14.17'}
     hasBin: true
 


### PR DESCRIPTION
Otherwise you get:

```
node_modules/.pnpm/@definitelytyped+definitions-parser@0.0.179_typescript@5.3.0-dev.20231018/node_modules/@definitelytyped/definitions-parser/dist/packages.d.ts:4:25 - error TS7016: Could not find a declaration file for module 'semver'. '/home/jabaile/work/DefinitelyTyped/node_modules/.pnpm/semver@7.5.4/node_modules/semver/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/semver` if it exists or add a new declaration (.d.ts) file containing `declare module 'semver';`

4 import * as semver from "semver";
```