### PR TITLE
Add changeset for #757

### DIFF
--- a/.changeset/thick-tigers-cry.md
+++ b/.changeset/thick-tigers-cry.md
@@ -1,0 +1,7 @@
+---
+"@definitelytyped/definitions-parser": patch
+"@definitelytyped/header-parser": patch
+"@definitelytyped/publisher": patch
+---
+
+Always convert contributor githubUsername to url (missing changeset)


### PR DESCRIPTION
#757 was missing changesets, so got partially published breaking downstream importers:

```
node_modules/.pnpm/@definitelytyped+definitions-parser@0.0.180_typescript@5.3.0-dev.20231018/node_modules/@definitelytyped/definitions-parser/dist/packages.d.ts:1:10 - error TS2305: Module '"@definitelytyped/header-parser"' has no exported member 'Contributor'.

1 import { Contributor, Header, License } from "@definitelytyped/header-parser";
           ~~~~~~~~~~~
```