### PR TITLE
Add ` vscode-languageserver-types` to allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -868,6 +868,7 @@ vega-typings
 vfile-message
 victory
 vite
+vscode-languageserver-types
 vue
 vue-router
 vuex


### PR DESCRIPTION
Just what it says on the tin. In support of DefinitelyTyped/DefinitelyTyped#67144.