### PR TITLE
Fix publish of interdependent packages

### DIFF
--- a/packages/publisher/src/calculate-versions.ts
+++ b/packages/publisher/src/calculate-versions.ts
@@ -59,6 +59,16 @@ async function computeChangedPackages(allPackages: AllPackages, log: LoggerWithE
       for (const name of Object.keys(pkg.dependencies)) {
         // Assert that dependencies exist on npm.
         // Also checked when we install the dependencies, in dtslint-runner.
+
+        // If we're publishing interdependent types packages, this will fail as
+        // we haven't published them yet. Skip for any packages which are
+        // definitely within the repo.
+        // TODO: This could verify the version range is correct, but just checks for existence for now.
+        // TODO: This startsWith/slice could be a helper.
+        if (name.startsWith("@types/") && allPackages.tryGetLatestVersion(name.slice("@types/".length))) {
+          continue;
+        }
+
         await pacote.manifest(name, { cache: cacheDir }).catch((reason) => {
           throw reason.code === "E404"
             ? new Error(


### PR DESCRIPTION
If we're publishing types packages which depend on each other, `pacote` isn't going to resolve to them. I'm not sure how this worked before (this code appears to have existed before the pnpm branch); for now this unblocks publishing by not checking types packages which exist in the repo (albeit without a version check).