### PR TITLE
Disable corepack when we run npm

### DIFF
--- a/.changeset/mighty-falcons-matter.md
+++ b/.changeset/mighty-falcons-matter.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/dts-critic": patch
+---
+
+Disable corepack when we run npm

--- a/packages/dts-critic/index.ts
+++ b/packages/dts-critic/index.ts
@@ -191,6 +191,7 @@ export function getNpmInfo(name: string): NpmInfo {
   const npmName = dtToNpmName(name);
   const infoResult = cp.spawnSync("npm", ["info", npmName, "--json", "--silent", "versions", "dist-tags"], {
     encoding: "utf8",
+    env: { ...process.env, COREPACK_ENABLE_STRICT: "0" },
   });
   const info = JSON.parse(infoResult.stdout || infoResult.stderr);
   if (info.error !== undefined) {
@@ -298,7 +299,7 @@ export function findDtsName(dtsPath: string) {
 function downloadNpmPackage(name: string, version: string, outDir: string): string {
   const npmName = dtToNpmName(name);
   const fullName = `${npmName}@${version}`;
-  const cpOpts = { encoding: "utf8", maxBuffer: 100 * 1024 * 1024 } as const;
+  const cpOpts = { encoding: "utf8", maxBuffer: 100 * 1024 * 1024, env: { ...process.env, COREPACK_ENABLE_STRICT: "0" } } as const;
   const npmPack = cp.execFileSync("npm", ["pack", fullName, "--json", "--silent"], cpOpts).trim();
   // https://github.com/npm/cli/issues/3405
   const tarballName = (npmPack.endsWith(".tgz") ? npmPack : (JSON.parse(npmPack)[0].filename as string))


### PR DESCRIPTION
This would unblock https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67120, but I actually think these two uses could just be `pacote` + https://www.npmjs.com/package/@andrewbranch/untar.js or something.