### PR TITLE
Ignore non-types packages when checking for changed packages

### DIFF
--- a/.changeset/neat-countries-retire.md
+++ b/.changeset/neat-countries-retire.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/definitions-parser": patch
+---
+
+Ignore non-types packages when checking for changed packages

--- a/packages/definitions-parser/src/get-affected-packages.ts
+++ b/packages/definitions-parser/src/get-affected-packages.ts
@@ -17,7 +17,7 @@ export async function getAffectedPackages(
 ): Promise<{ errors: string[] } | PreparePackagesResult> {
   const errors = [];
   const changedPackageDirectories = await execAndThrowErrors(
-    `pnpm ls -r --depth -1 --parseable --filter '[${sourceRemote}/${sourceBranch}]'`,
+    `pnpm ls -r --depth -1 --parseable --filter '...@types/**[${sourceRemote}/${sourceBranch}]'`,
     definitelyTypedPath
   );
 


### PR DESCRIPTION
This should unblock https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67128; we only want to be collecting info on changed `@types/` packages here.