### PR TITLE
Fix dependent packages showing up as changed in getAffectedPackages

### DIFF
--- a/.changeset/nervous-dancers-argue.md
+++ b/.changeset/nervous-dancers-argue.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/definitions-parser": patch
+---
+
+Fix dependent packages showing up as changed in getAffectedPackages

--- a/packages/definitions-parser/src/get-affected-packages.ts
+++ b/packages/definitions-parser/src/get-affected-packages.ts
@@ -56,7 +56,6 @@ export async function getAffectedPackages(
       )
     );
   }
-
   return getAffectedPackagesWorker(
     allPackages,
     changedPackageDirectories,

--- a/packages/definitions-parser/src/get-affected-packages.ts
+++ b/packages/definitions-parser/src/get-affected-packages.ts
@@ -16,8 +16,9 @@ export async function getAffectedPackages(
   definitelyTypedPath: string
 ): Promise<{ errors: string[] } | PreparePackagesResult> {
   const errors = [];
+  // No ... prefix; we only want packages that were actually edited.
   const changedPackageDirectories = await execAndThrowErrors(
-    `pnpm ls -r --depth -1 --parseable --filter '...@types/**[${sourceRemote}/${sourceBranch}]'`,
+    `pnpm ls -r --depth -1 --parseable --filter '@types/**[${sourceRemote}/${sourceBranch}]'`,
     definitelyTypedPath
   );
 
@@ -29,7 +30,10 @@ export async function getAffectedPackages(
   const { additions, deletions } = git;
   const addedPackageDirectories = mapDefined(additions, (id) => id.typesDirectoryName);
   const allDependentDirectories = [];
-  const filters = [`--filter '...[${sourceRemote}/${sourceBranch}]'`];
+  // Start the filter off with all packages that were touched along with those that depend on them.
+  const filters = [`--filter '...@types/**[${sourceRemote}/${sourceBranch}]'`];
+  // For packages that have been deleted, they won't appear in the graph anymore; look for packages
+  // that still depend on the package (but via npm) and manually add them.
   for (const d of deletions) {
     for (const dep of await allPackages.allTypings()) {
       for (const [name, version] of dep.allPackageJsonDependencies()) {
@@ -52,6 +56,11 @@ export async function getAffectedPackages(
       )
     );
   }
+
+  console.log("changedPackageDirectories", changedPackageDirectories);
+  console.log("addedPackageDirectories", addedPackageDirectories);
+  console.log("allDependentDirectories", allDependentDirectories);
+
   return getAffectedPackagesWorker(
     allPackages,
     changedPackageDirectories,

--- a/packages/definitions-parser/src/get-affected-packages.ts
+++ b/packages/definitions-parser/src/get-affected-packages.ts
@@ -57,10 +57,6 @@ export async function getAffectedPackages(
     );
   }
 
-  console.log("changedPackageDirectories", changedPackageDirectories);
-  console.log("addedPackageDirectories", addedPackageDirectories);
-  console.log("allDependentDirectories", allDependentDirectories);
-
   return getAffectedPackagesWorker(
     allPackages,
     changedPackageDirectories,


### PR DESCRIPTION
Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/67205

I think I probably incorrectly suggested the bad code in a change, not understanding what this code did. This just removes `...` which gives the right answer on DT:

```
dtslint-runner@0.0.188
Node version:  v20.9.0
Using local DefinitelyTyped at .
Running: git rev-parse --verify master
d0df83268470773861ff1bd2a6a9520b8c247d3d
Running: git diff master --name-status
M       types/node/v18/child_process.d.ts
M       types/node/v18/test/child_process.ts
Testing 1 changed packages: Set(1) { 'node/v18' }
Testing 9 dependent packages: Set(9) {
  'ssh2',
  'docker-modem',
  'dockerode',
  'docker-events',
  'node-ssh',
  'promise-sftp',
  'ssh2-sftp-client',
  'ssh2-sftp-client/v7',
  'tunnel-ssh'
}
```