### PR TITLE
Allow PRs to delete files, fix error passing

### DIFF
--- a/.changeset/gorgeous-colts-prove.md
+++ b/.changeset/gorgeous-colts-prove.md
@@ -1,0 +1,6 @@
+---
+"@definitelytyped/definitions-parser": patch
+"@definitelytyped/dtslint-runner": patch
+---
+
+Allow PRs to delete files

--- a/packages/definitions-parser/src/git.ts
+++ b/packages/definitions-parser/src/git.ts
@@ -56,6 +56,7 @@ export function gitChanges(
   const addedPackages = new Map<string, [PackageId, "A" | "D"]>();
   const errors = [];
   for (const diff of diffs) {
+    if (!/types[\\/]/.test(diff.file)) continue;
     if (diff.status === "M") continue;
     const dep = getDependencyFromFile(diff.file);
     if (dep) {
@@ -95,7 +96,13 @@ export async function getAffectedPackagesFromDiff(
   }
   const affected = await getAffectedPackages(allPackages, diffs, definitelyTypedPath);
   if ("errors" in affected) {
+    errors.push(...affected.errors);
+  }
+  if (errors.length) {
     return errors;
+  }
+  if ("errors" in affected) {
+    throw new Error("unexpected error array");
   }
   console.log(`Testing ${affected.packageNames.size} changed packages: ${inspect(affected.packageNames)}`);
   console.log(`Testing ${affected.dependents.size} dependent packages: ${inspect(affected.dependents)}`);

--- a/packages/definitions-parser/test/git.test.ts
+++ b/packages/definitions-parser/test/git.test.ts
@@ -35,12 +35,7 @@ testo({
     ).toEqual({ errors: ["Please delete all files in jest when adding it to notNeededPackages.json."] });
   },
   async tooManyDeletes() {
-    expect(await getNotNeededPackages(allPackages, [{ status: "D", file: "oops.txt" }])).toEqual({
-      errors: [
-        `Unexpected file deleted: oops.txt
-You should only delete files that are a part of removed packages.`,
-      ],
-    });
+    expect(await getNotNeededPackages(allPackages, [{ status: "D", file: "types/oops/oops.txt" }])).toEqual([]);
   },
   async deleteInOtherPackage() {
     expect(
@@ -53,17 +48,10 @@ You should only delete files that are a part of removed packages.`,
   async extraneousFile() {
     expect(
       await getNotNeededPackages(allPackages, [
-        { status: "A", file: "oooooooooooops.txt" },
-        { status: "M", file: "notNeededPackages.json" },
-        { status: "D", file: "types/jest/index.d.ts" },
-        { status: "D", file: "types/jest/jest-tests.d.ts" },
+        ...deleteJestDiffs,
+        { status: "A", file: "types/oops/oooooooooooops.txt" },
       ])
-    ).toEqual({
-      errors: [
-        `Unexpected file added: oooooooooooops.txt
-You should only add files that are part of packages.`,
-      ],
-    });
+    ).toEqual(jestNotNeeded);
   },
   async scoped() {
     expect(

--- a/packages/dtslint-runner/src/prepareAffectedPackages.ts
+++ b/packages/dtslint-runner/src/prepareAffectedPackages.ts
@@ -21,5 +21,8 @@ export async function prepareAffectedPackages(definitelyTypedPath: string): Prom
   if (errors.length) {
     throw new Error(errors.join("\n"));
   }
-  return result as PreparePackagesResult;
+  if (Array.isArray(result)) {
+    throw new Error(`result should not have been array: ${typeof result}`);
+  }
+  return result;
 }


### PR DESCRIPTION
An effect of #761 was to make PRs fail if they ever deleted a file, no matter where. This means PRs like my PR that deletes scripts fails because deleting files is now banned, which doesn't feel right.

Also, fix a case where errors were not propagated upward, which was the root cause of the tooling hiding the error for the script PR. I think we may want to consider using a real generic result type; working with these error arrays and ensuring they're nonempty is getting a little fickle...