### PR TITLE
Move .vscode/settings.json to template, fix prettier formatting and format repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,10 @@ dist
 *.lerna_backup
 packages/utils/cache
 .pnpm-store
+
+
+**/.vscode/*
+!**/.vscode/tasks.json
+!**/.vscode/settings.template.json
+!**/.vscode/launch.json
+!**/.vscode/extensions.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,10 @@
 node_modules
 dist
 packages/publisher/output
+
+packages/dts-critic/testsource
+
+*.json
+*.yml
+*.yaml
+*.md

--- a/.vscode/settings.template.json
+++ b/.vscode/settings.template.json
@@ -1,0 +1,3 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,9 +4,12 @@ module.exports = {
   modulePathIgnorePatterns: ["packages\\/publisher\\/output"],
   testMatch: ["<rootDir>/packages/*/test/**/*.test.ts", "<rootDir>/packages/dts-critic/index.test.ts"],
   transform: {
-    "^.+\\.tsx?$": ["ts-jest", {
-      tsconfig: "<rootDir>/tsconfig.test.json",
-      diagnostics: false
-    }]
-  }
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      {
+        tsconfig: "<rootDir>/tsconfig.test.json",
+        diagnostics: false,
+      },
+    ],
+  },
 };


### PR DESCRIPTION
Pulled out of #788

I want to auto format, but the settings file is committed and some files aren't formatted. This moves the settings to a template so it can be customized, fixes the ignored files and formats one file such that `prettier -w .` is clean.