### PR TITLE
fix: position of reporting ESLint rule no-unnecessary-generics

### DIFF
--- a/.changeset/forty-teachers-push.md
+++ b/.changeset/forty-teachers-push.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/eslint-plugin": patch
+---
+
+fix: position of reporting ESLint rule no-unnecessary-generics

--- a/packages/eslint-plugin/src/rules/no-unnecessary-generics.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-generics.ts
@@ -47,16 +47,15 @@ const rule = createRule({
         const checker = parserServices.program.getTypeChecker();
 
         for (const typeParameter of tsNode.typeParameters) {
-          const name = typeParameter.name.text;
-          const res = getSoleUse(tsNode, assertDefined(checker.getSymbolAtLocation(typeParameter.name)), checker);
-          
-          if (res.type === "ok") {
+          const result = getSoleUse(tsNode, assertDefined(checker.getSymbolAtLocation(typeParameter.name)), checker);
+
+          if (result === "ok") {
             continue;
           }
 
           context.report({
-            data: { name },
-            messageId: res.type,
+            data: { name: typeParameter.name.text },
+            messageId: result,
             node: parserServices.tsNodeToESTreeNodeMap.get(typeParameter),
           });
         }
@@ -65,7 +64,8 @@ const rule = createRule({
   },
 });
 
-interface Result { type: "ok" | "never" | "sole"; }
+type Result = "ok" | "never" | "sole";
+
 function getSoleUse(sig: ts.SignatureDeclaration, typeParameterSymbol: ts.Symbol, checker: ts.TypeChecker): Result {
   const exit = {};
   let soleUse: ts.Identifier | undefined;
@@ -88,12 +88,12 @@ function getSoleUse(sig: ts.SignatureDeclaration, typeParameterSymbol: ts.Symbol
     }
   } catch (err) {
     if (err === exit) {
-      return { type: "ok" };
+      return "ok";
     }
     throw err;
   }
 
-  return soleUse ? { type: "sole" } : { type: "never" };
+  return soleUse ? "sole" : "never";
 
   function recur(node: ts.Node): void {
     if (ts.isIdentifier(node)) {

--- a/packages/eslint-plugin/src/rules/no-unnecessary-generics.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-generics.ts
@@ -1,6 +1,24 @@
 import { ESLintUtils, TSESTree } from "@typescript-eslint/utils";
 import * as ts from "typescript";
 
+
+/*
+BAD - what we have now
+    <TElement extends HTMLElement = HTMLElement>(
+      html: JQuery.htmlString,
+      ownerDocument_attributes?: Document | JQuery.PlainObject,
+      // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+    ): JQuery<TElement>;
+
+GOOD - what we want to have
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+    <TElement extends HTMLElement = HTMLElement>(
+      html: JQuery.htmlString,
+      ownerDocument_attributes?: Document | JQuery.PlainObject,
+    ): JQuery<TElement>; 
+*/
+
+
 import { createRule } from "../util";
 
 type ESTreeFunctionLikeWithTypeParameters = TSESTree.FunctionLike & {
@@ -54,7 +72,7 @@ const rule = createRule({
               context.report({
                 data: { name },
                 messageId: "sole",
-                node: parserServices.tsNodeToESTreeNodeMap.get(res.soleUse),
+                node: parserServices.tsNodeToESTreeNodeMap.get(typeParameter),
               });
               break;
             case "never":

--- a/packages/eslint-plugin/src/rules/no-unnecessary-generics.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-generics.ts
@@ -1,24 +1,6 @@
 import { ESLintUtils, TSESTree } from "@typescript-eslint/utils";
 import * as ts from "typescript";
 
-
-/*
-BAD - what we have now
-    <TElement extends HTMLElement = HTMLElement>(
-      html: JQuery.htmlString,
-      ownerDocument_attributes?: Document | JQuery.PlainObject,
-      // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-    ): JQuery<TElement>;
-
-GOOD - what we want to have
-    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-    <TElement extends HTMLElement = HTMLElement>(
-      html: JQuery.htmlString,
-      ownerDocument_attributes?: Document | JQuery.PlainObject,
-    ): JQuery<TElement>; 
-*/
-
-
 import { createRule } from "../util";
 
 type ESTreeFunctionLikeWithTypeParameters = TSESTree.FunctionLike & {

--- a/packages/eslint-plugin/test/no-unnecessary-generics.test.ts
+++ b/packages/eslint-plugin/test/no-unnecessary-generics.test.ts
@@ -20,7 +20,7 @@ const f2 = <T>(): T => {};
       errors: [
         {
           line: 2,
-          column: 19,
+          column: 13,
           messageId: "sole",
         },
       ],
@@ -34,7 +34,7 @@ class C {
       errors: [
         {
           line: 3,
-          column: 21,
+          column: 15,
           messageId: "sole",
         },
       ],
@@ -46,7 +46,7 @@ function f<T>(): T { }
       errors: [
         {
           line: 2,
-          column: 18,
+          column: 12,
           messageId: "sole",
         },
       ],
@@ -70,7 +70,7 @@ function f<T, U extends T>(u: U): U;
       errors: [
         {
           line: 2,
-          column: 25,
+          column: 12,
           messageId: "sole",
         },
       ],
@@ -82,7 +82,7 @@ const f = function<T>(): T {};
       errors: [
         {
           line: 2,
-          column: 26,
+          column: 20,
           messageId: "sole",
         },
       ],
@@ -96,7 +96,7 @@ interface I {
       errors: [
         {
           line: 3,
-          column: 14,
+          column: 4,
           messageId: "sole",
         },
       ],
@@ -110,7 +110,7 @@ interface I {
       errors: [
         {
           line: 3,
-          column: 11,
+          column: 5,
           messageId: "sole",
         },
       ],
@@ -122,7 +122,7 @@ type Fn = <T>() => T;
       errors: [
         {
           line: 2,
-          column: 20,
+          column: 12,
           messageId: "sole",
         },
       ],
@@ -134,7 +134,7 @@ type Ctr = new<T>() => T;
       errors: [
         {
           line: 2,
-          column: 24,
+          column: 16,
           messageId: "sole",
         },
       ],


### PR DESCRIPTION
This PR addresses https://github.com/microsoft/DefinitelyTyped-tools/issues/734 and is a result of pairing with the ever kind and generous @joshuakgoldberg.

When working on the formatting of Definitely Typed, we happened upon some surprising behaviour around the `no-unnecessary-generics` rule. In the words of George Bernard Shaw: "I often quote myself. It adds spice to my conversation."  Let me quote me now:

> You'll note that we have an `eslint-disable-next-line` just before the last line; the ReturnType of the method.  Without this in place the red squigglies would be under:
> 
> ```ts
> JQuery<TElement>
>        ~~~~~~~~
> ```
> 
> This isn't the useful place to have this report.  Perhaps the better place would be the first mention of `TElement`, like so:
> 
> ```ts
>     <TElement extends HTMLElement = HTMLElement>(
>      ~~~~~~~~
> ```

This PR implements the suggested change; moving the position of the report to the type parameter position.

What do you think?