### PR TITLE
Remove pnpm validation from header-parser

### DIFF
--- a/.changeset/forty-houses-grow.md
+++ b/.changeset/forty-houses-grow.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/header-parser": patch
+---
+
+Remove validation of `"pnpm"` field

--- a/packages/header-parser/src/index.ts
+++ b/packages/header-parser/src/index.ts
@@ -129,7 +129,6 @@ export function validatePackageJson(
   const typeScriptVersionResult = validateTypeScriptVersion();
   const projectsResult = validateProjects();
   const ownersResult = validateOwners();
-  const pnpmResult = validatePnpm();
   const licenseResult = getLicenseFromPackageJson(packageJson.license);
   if (typeof nameResult === "object") {
     errors.push(...nameResult.errors);
@@ -161,9 +160,6 @@ export function validatePackageJson(
     errors.push(...ownersResult.errors);
   } else {
     owners = ownersResult;
-  }
-  if (typeof pnpmResult === "object") {
-    errors.push(...pnpmResult.errors);
   }
   if (Array.isArray(licenseResult)) {
     errors.push(...licenseResult);
@@ -287,40 +283,6 @@ export function validatePackageJson(
       }
     }
     return { errors };
-  }
-  function validatePnpm(): undefined | { errors: string[] } {
-    const errors = [];
-    if (packageJson.pnpm) {
-      if (typeof packageJson.pnpm !== "object" || packageJson.pnpm === null) {
-        errors.push(
-          `${typesDirectoryName}'s package.json has bad "pnpm": must be an object like { "overrides": { "@types/react": "^16" } }`
-        );
-      } else {
-        for (const key in packageJson.pnpm) {
-          if (key !== "overrides") {
-            errors.push(
-              `${typesDirectoryName}'s package.json has bad "pnpm": it should not include property "${key}", only "overrides".`
-            );
-          }
-        }
-        const overrides = (packageJson.pnpm as Record<string, unknown>).overrides;
-        if (overrides && typeof overrides === "object" && overrides !== null) {
-          for (const key in overrides) {
-            if (!key.startsWith("@types/")) {
-              errors.push(
-                `${typesDirectoryName}'s package.json has bad "pnpm": pnpm overrides may only override @types/ packages.`
-              );
-            }
-          }
-        } else {
-          errors.push(`${typesDirectoryName}'s package.json has bad "pnpm": it must contain an "overrides" object.`);
-        }
-      }
-    }
-    if (errors.length) {
-      return { errors };
-    }
-    return undefined;
   }
 }
 

--- a/packages/header-parser/test/index.test.ts
+++ b/packages/header-parser/test/index.test.ts
@@ -98,27 +98,6 @@ describe("validatePackageJson", () => {
   it("works with old-version packages", () => {
     expect(Array.isArray(validatePackageJson("hapi", { ...pkgJson, version: "16.6.9999" }, []))).toBeFalsy();
   });
-  it("requires pnpm to be an object", () => {
-    expect(validatePackageJson("hapi", { ...pkgJson, pnpm: "not an object" }, [])).toEqual([
-      `hapi's package.json has bad "pnpm": must be an object like { "overrides": { "@types/react": "^16" } }`,
-    ]);
-  });
-  it("requires pnpm to contain exactly overrides", () => {
-    expect(validatePackageJson("hapi", { ...pkgJson, pnpm: { unexpected: true } }, [])).toEqual([
-      `hapi's package.json has bad "pnpm": it should not include property "unexpected", only "overrides".`,
-      `hapi's package.json has bad "pnpm": it must contain an "overrides" object.`,
-    ]);
-  });
-  it("pnpm may only override types packages", () => {
-    expect(validatePackageJson("hapi", { ...pkgJson, pnpm: { overrides: { vinland: "^1" } } }, [])).toEqual([
-      `hapi's package.json has bad "pnpm": pnpm overrides may only override @types/ packages.`,
-    ]);
-  });
-  it("pnpm overrides work", () => {
-    expect(validatePackageJson("hapi", { ...pkgJson, pnpm: { overrides: { "@types/react": "^16" } } }, [])).toEqual(
-      header
-    );
-  });
 });
 
 describe("makeTypesVersionsForPackageJson", () => {


### PR DESCRIPTION
Required for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67090 to pull in a specific version of `marked` for testing, while allowing a wide dependency range for publishing