### PR TITLE
Enforce changesets in PRs (excluding allowedPackageJsonDependencies)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - uses: actions/setup-node@v2
       with:
         node-version: 'lts/*'
     - run: npm install -g pnpm
+    - run: pnpm install
     - name: Check for missing changesets
       run: |
         git switch -c changesets-temp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,5 +53,5 @@ jobs:
     - name: Check for missing changesets
       run: |
         git switch -c changesets-temp
-        git checkout master -- packages/definitions-parser/allowedPackageJsonDependencies.txt
-        pnpm changeset status --since=master
+        git checkout origin/master -- packages/definitions-parser/allowedPackageJsonDependencies.txt
+        pnpm changeset status --since=origin/master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,12 @@ env:
   CI: true
   PNPM_CACHE_FOLDER: .pnpm-store
 
+# Ensure scripts are run with pipefail. See:
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build_and_test:
     name: build and test
@@ -31,3 +37,18 @@ jobs:
   check-parse-results:
     needs: build_and_test
     uses: ./.github/workflows/check-parse-results.yml
+  
+  changesets:
+    name: changesets
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 'lts/*'
+    - run: npm install -g pnpm
+    - name: Check for missing changesets
+      run: |
+        git switch -c changesets-temp
+        git checkout master -- packages/definitions-parser/allowedPackageJsonDependencies.txt
+        pnpm changeset status --since=master

--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -3,7 +3,6 @@
 @azure/functions
 @babel/code-frame
 @babel/core
-@babel/core
 @babel/generator
 @babel/parser
 @babel/template

--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -3,6 +3,7 @@
 @azure/functions
 @babel/code-frame
 @babel/core
+@babel/core
 @babel/generator
 @babel/parser
 @babel/template


### PR DESCRIPTION
This adds a CI check that verifies that PRs contain changesets if they modify packages, ignoring PRs which only modify `allowedPackageJsonDependencies.txt`.

```
🦋  error Some packages have been changed but no changesets were found. Run `changeset add` to resolve this error.
🦋  error If this change doesn't need a release, run `changeset add --empty`.
```
