### PR TITLE
Ignore non-types packages returned by pnpm

### DIFF
--- a/.changeset/strange-eagles-hope.md
+++ b/.changeset/strange-eagles-hope.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/definitions-parser": patch
+---
+
+Ignore non-types packages returned by pnpm


### PR DESCRIPTION
This unblocks https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67259. See https://github.com/DefinitelyTyped/DefinitelyTyped/actions/runs/6708512678/job/18229483924?pr=67259

```
M	types/node/v18/ts4.8/test/stream.ts
AssertionError [ERR_ASSERTION]: bad path scripts
    at assertDefined (/home/runner/work/DefinitelyTyped/DefinitelyTyped/node_modules/.pnpm/@definitelytyped+utils@0.0.182/node_modules/@definitelytyped/utils/src/assertions.ts:7:9)
    at <anonymous> (/home/runner/work/DefinitelyTyped/DefinitelyTyped/node_modules/.pnpm/@definitelytyped+definitions-parser@0.0.186_typescript@5.3.0-dev.202[31](https://github.com/DefinitelyTyped/DefinitelyTyped/actions/runs/6708512678/job/18229483924?pr=67259#step:7:32)031/node_modules/@definitelytyped/definitions-parser/src/get-affected-packages.ts:99:30)
    at Array.map (<anonymous>)
```

This happens because I added a `scripts` package to the DT repo in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67128 which depended on `@types/node`, but we didn't fully ignore non-`@types` packages (since such a thing didn't exist until now).


