### PR TITLE
Fix changeset check failure on versioning PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,15 @@ jobs:
     - run: pnpm install
     - name: Check for missing changesets
       run: |
+        PR_CHANGESETS=$(ls .changeset | grep -v -E 'README\.md|config\.json' | wc -l)
+        MASTER_CHANGESETS=$(git ls-tree -r origin/master .changeset | grep -v -E 'README\.md|config\.json' | wc -l)
+
+        # If the PR has no changesets, but master has changesets, assume this is PR is a versioning PR and exit
+        if [[ $PR_CHANGESETS -eq 0 && $MASTER_CHANGESETS -gt 0 ]]; then
+          echo "This PR is a versioning PR, exiting"
+          exit 0
+        fi
+
         git switch -c changesets-temp
         git checkout origin/master -- packages/definitions-parser/allowedPackageJsonDependencies.txt
         pnpm changeset status --since=origin/master


### PR DESCRIPTION
This unblocks #804. It's technically feasible that someone reverts a changeset in a PR (bringing the count to zero) but also changes a package intentionally, but that is nearly indistinguishable from the versioning PR.