### PR TITLE
[definitions-parser] skip scripts folder

### DIFF
--- a/.changeset/five-bears-tickle.md
+++ b/.changeset/five-bears-tickle.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/definitions-parser": patch
+---
+
+Don't treat script dirs as types packages

--- a/packages/definitions-parser/src/packages.ts
+++ b/packages/definitions-parser/src/packages.ts
@@ -614,20 +614,30 @@ export function getDependencyFromFile(
     return undefined;
   }
 
-  const [typesDirName, name, subDirName] = parts; // Ignore any other parts
+  // types/[packageName]/[scripts]
+  // types/[packageName]/[tsVersion]/[scripts]
+  // types/[packageName]/[packageVersion]/[scripts]
+  // types/[packageName]/[packageVersion]/[tsVersion]/[scripts]
+  const [typesDirName, name, packageVersion, tsVersion, scripts] = parts;
 
-  if (typesDirName !== typesDirectoryName) {
+  const version = parseVersionFromDirectoryName(packageVersion)
+    ?? '*';
+  if (
+    // package is not in types directory
+    typesDirName !== typesDirectoryName
+    // is root package's scripts folder
+    || packageVersion === 'scripts'
+    // is root package's scripts folder with overridden tsVersion
+    || (/^ts\d+\.\d$/.test(packageVersion) && tsVersion === 'scripts')
+    // is root package's scripts folder with overridden packageVersion
+    || (version !== '*' && tsVersion === 'scripts')
+    // is root package's scripts folder with overridden packageVersion and tsVersion
+    || (version !== '*' && /^ts\d+\.\d$/.test(tsVersion) && scripts === 'scripts')
+  ) {
     return undefined;
   }
 
-  if (subDirName) {
-    const version = parseVersionFromDirectoryName(subDirName);
-    if (version !== undefined) {
-      return { typesDirectoryName: name, version };
-    }
-  }
-
-  return { typesDirectoryName: name, version: "*" };
+  return { typesDirectoryName: name, version };
 }
 
 function hash(files: readonly string[], tsconfigPathsForHash: readonly string[], fs: FS): string {

--- a/packages/definitions-parser/test/packages.test.ts
+++ b/packages/definitions-parser/test/packages.test.ts
@@ -283,4 +283,20 @@ describe(getDependencyFromFile, () => {
       version: "*",
     });
   });
+
+  it("returns undefined on package's scripts directory", () => {
+    expect(getDependencyFromFile("types/a/scripts")).toBe(undefined);
+  });
+
+  it("returns undefined on package's scripts directory with overridden tsVersion", () => {
+    expect(getDependencyFromFile("types/a/ts4.8/scripts")).toBe(undefined);
+  });
+
+  it("returns undefined on package's scripts directory with overridden packageVersion", () => {
+    expect(getDependencyFromFile("types/a/v18/scripts")).toBe(undefined);
+  });
+
+  it("returns undefined on package's scripts directory with overridden packageVersion and tsVersion", () => {
+    expect(getDependencyFromFile("types/a/v18/ts4.8/scripts")).toBe(undefined);
+  });
 });


### PR DESCRIPTION
Partially unblocks DefinitelyTyped/DefinitelyTyped#67259 and DefinitelyTyped/DefinitelyTyped#67291

When doing type checking on CI, the package that depends on it might use it in the `scripts` folder while not using it in the `types` folder, causing the CI to fail from missing dependencies due to `pnpm` only installs packages which got affected

In DefinitelyTyped/DefinitelyTyped#67259 case `pnpm` installed packages for
```
es-abstract/scripts
get-intrinsic/scripts
lodash-es/scripts
material-ui/scripts
...
```
While the CI checks typing for
```
es-abstract
get-intrinsic
lodash-es
material-ui
...
```
This PR fixes that issue by skipping type checking for `scripts` folder