### PR TITLE
Fix writeJson helper after incorrect refactor

### DIFF
--- a/.changeset/tiny-pens-rush.md
+++ b/.changeset/tiny-pens-rush.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/utils": patch
+---
+
+Fix writeJson helper, path and contents swapped

--- a/packages/utils/src/io.ts
+++ b/packages/utils/src/io.ts
@@ -61,7 +61,7 @@ export function writeFile(path: string, content: string): Promise<void> {
 }
 
 export function writeJson(path: string, content: unknown, formatted = true): Promise<void> {
-  return fs.promises.writeFile(JSON.stringify(content, undefined, formatted ? 4 : undefined), path);
+  return fs.promises.writeFile(path, JSON.stringify(content, undefined, formatted ? 4 : undefined));
 }
 
 export function streamOfString(text: string): NodeJS.ReadableStream {


### PR DESCRIPTION
I broke this in #818.

Old code:

```ts
export function writeJson(path: string, content: unknown, formatted = true): Promise<void> {
  return writeJsonRaw(path, content, { spaces: formatted ? 4 : 0 });
}
```

What I replaced it with:

```ts
export function writeJson(path: string, content: unknown, formatted = true): Promise<void> {
  return fs.promises.writeFile(JSON.stringify(content, undefined, formatted ? 4 : undefined), path);
}
```

Sigh