### PR TITLE
Run eslint test using plugin loaded by tests, not built

### DIFF
--- a/.changeset/serious-dots-press.md
+++ b/.changeset/serious-dots-press.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/eslint-plugin": patch
+---
+
+Minor refactor for tests

--- a/packages/eslint-plugin/src/configs/all.ts
+++ b/packages/eslint-plugin/src/configs/all.ts
@@ -1,4 +1,4 @@
-import { rules } from "../rules/index.js";
+import { rules } from "../rules";
 import { Linter } from "eslint";
 
 export const all: Linter.BaseConfig = {

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,5 +1,5 @@
-import { all } from "./configs/all.js";
-export { rules } from "./rules/index.js";
+import { all } from "./configs/all";
+export { rules } from "./rules/index";
 
 export const configs = {
   all,

--- a/packages/eslint-plugin/test/eslint.test.ts
+++ b/packages/eslint-plugin/test/eslint.test.ts
@@ -4,6 +4,7 @@ import stripAnsi from "strip-ansi";
 import { globSync } from "glob";
 import { fixtureRoot } from "./util";
 import { toMatchFile } from "jest-file-snapshot";
+import * as plugin from "../src/index";
 import fs from "fs";
 
 expect.extend({ toMatchFile });
@@ -26,7 +27,10 @@ function getAllExpectedLintSnapshots() {
 let eslint: ESLint;
 
 beforeAll(() => {
-  eslint = new ESLint({ cwd: fixtureRoot });
+  eslint = new ESLint({
+    cwd: fixtureRoot,
+    plugins: { "@definitelytyped/eslint-plugin": plugin as unknown as ESLint.Plugin },
+  });
 });
 
 afterAll(() => {


### PR DESCRIPTION
Previously, this test required a self link and built artifacts. I didn't notice the latter as a problem because I usually run using the Ctrl+Shift+B watch build. But, it's not so good when editing and you aren't using that.

Instead, we can provide the plugin ahead of time, which causes ESLint to not try and find it on disk.

This required some changes to make the plugin's imports resolve when transpiled by ts-jest. Would be nice to get rid of that gotcha at some point but at the moment we're still fully CJS.

Tested by:

```console
$ git clean -fdx -e '/.vscode'
$ pnpm i
$ (cd packages/utils; pnpm build)
$ pnpm test -- eslint-plugin
```