### PR TITLE
Fix retag CI job by restoring clone

### DIFF
--- a/.github/workflows/update-ts-version-tags.yml
+++ b/.github/workflows/update-ts-version-tags.yml
@@ -39,8 +39,11 @@ jobs:
           ${{ runner.os }}-pnpm-store-cache-
     - run: pnpm install
     - run: pnpm build
+    - run: git clone --depth 1 https://github.com/DefinitelyTyped/DefinitelyTyped ../DefinitelyTyped
+    - run: pnpm install
+      working-directory: ../DefinitelyTyped
     - name: retag
-      run: node packages/retag/dist/index.js
+      run: node packages/retag/dist/index.js --path ../DefinitelyTyped
       env:
         NPM_TOKEN: ${{ secrets.NPM_RETAG_TOKEN }}
         GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}


### PR DESCRIPTION
I removed this in my PR which got rid of cloning, but I didn't realized that this CI job _never_ worked without a full clone. So, restore it until we can determine if we can avoid a clone.