### PR TITLE
Handle `import = require()` in lint rules

### DIFF
--- a/.changeset/sharp-roses-beam.md
+++ b/.changeset/sharp-roses-beam.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/eslint-plugin": patch
+---
+
+Handle `import = require()` in lint rules

--- a/packages/eslint-plugin/src/rules/no-import-of-dev-dependencies.ts
+++ b/packages/eslint-plugin/src/rules/no-import-of-dev-dependencies.ts
@@ -1,5 +1,5 @@
 import { TSESTree } from "@typescript-eslint/utils";
-import { createRule, commentsMatching, findTypesPackage } from "../util";
+import { createRule, commentsMatching, findTypesPackage, getImportSource } from "../util";
 import { isDeclarationPath, isTypesPackageName, typesPackageNameToRealName } from "@definitelytyped/utils";
 
 type MessageId = "noImportOfDevDependencies" | "noReferenceOfDevDependencies";
@@ -47,30 +47,28 @@ const rule = createRule({
       }
     });
 
+    function lint(node: TSESTree.ImportDeclaration | TSESTree.TSImportEqualsDeclaration) {
+      const source = getImportSource(node);
+      if (!source) {
+        return;
+      }
+
+      if (devDeps.includes(source.value)) {
+        context.report({
+          messageId: "noImportOfDevDependencies",
+          node,
+        });
+      }
+    }
+
     return {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       ImportDeclaration(node) {
-        if (devDeps.includes(node.source.value)) {
-          context.report({
-            messageId: "noImportOfDevDependencies",
-            node,
-          });
-        }
+        lint(node);
       },
       // eslint-disable-next-line @typescript-eslint/naming-convention
       TSImportEqualsDeclaration(node) {
-        if (
-          node.moduleReference.type === "TSExternalModuleReference" &&
-          node.moduleReference.expression.type === "Literal" &&
-          typeof node.moduleReference.expression.value === "string"
-        ) {
-          if (devDeps.includes(node.moduleReference.expression.value)) {
-            context.report({
-              messageId: "noImportOfDevDependencies",
-              node,
-            });
-          }
-        }
+        lint(node);
       },
     };
 

--- a/packages/eslint-plugin/src/rules/no-import-of-dev-dependencies.ts
+++ b/packages/eslint-plugin/src/rules/no-import-of-dev-dependencies.ts
@@ -57,6 +57,21 @@ const rule = createRule({
           });
         }
       },
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      TSImportEqualsDeclaration(node) {
+        if (
+          node.moduleReference.type === "TSExternalModuleReference" &&
+          node.moduleReference.expression.type === "Literal" &&
+          typeof node.moduleReference.expression.value === "string"
+        ) {
+          if (devDeps.includes(node.moduleReference.expression.value)) {
+            context.report({
+              messageId: "noImportOfDevDependencies",
+              node,
+            });
+          }
+        }
+      },
     };
 
     function report(comment: TSESTree.Comment, messageId: MessageId) {

--- a/packages/eslint-plugin/src/rules/no-self-import.ts
+++ b/packages/eslint-plugin/src/rules/no-self-import.ts
@@ -30,12 +30,12 @@ const rule = createRule({
       if (source.value === packageName || source.value.startsWith(packageName + "/")) {
         context.report({
           messageId: "useRelativeImport",
-          node: source,
+          node,
         });
       } else if (source.value.match(/^\.\/v\d+(?:\.\d+)?(?:\/.*)?$/)) {
         context.report({
           messageId: "useOnlyCurrentVersion",
-          node: source,
+          node,
         });
       }
     }

--- a/packages/eslint-plugin/src/rules/no-self-import.ts
+++ b/packages/eslint-plugin/src/rules/no-self-import.ts
@@ -1,4 +1,5 @@
-import { createRule, getTypesPackageForDeclarationFile } from "../util";
+import { TSESTree } from "@typescript-eslint/utils";
+import { createRule, getImportSource, getTypesPackageForDeclarationFile } from "../util";
 const rule = createRule({
   name: "no-self-import",
   defaultOptions: [],
@@ -20,20 +21,33 @@ const rule = createRule({
       return {};
     }
 
+    function lint(node: TSESTree.ImportDeclaration | TSESTree.TSImportEqualsDeclaration) {
+      const source = getImportSource(node);
+      if (!source) {
+        return;
+      }
+
+      if (source.value === packageName || source.value.startsWith(packageName + "/")) {
+        context.report({
+          messageId: "useRelativeImport",
+          node: source,
+        });
+      } else if (source.value.match(/^\.\/v\d+(?:\.\d+)?(?:\/.*)?$/)) {
+        context.report({
+          messageId: "useOnlyCurrentVersion",
+          node: source,
+        });
+      }
+    }
+
     return {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       ImportDeclaration(node) {
-        if (node.source.value === packageName || node.source.value.startsWith(packageName + "/")) {
-          context.report({
-            messageId: "useRelativeImport",
-            node,
-          });
-        } else if (node.source.value.match(/^\.\/v\d+(?:\.\d+)?(?:\/.*)?$/)) {
-          context.report({
-            messageId: "useOnlyCurrentVersion",
-            node,
-          });
-        }
+        lint(node);
+      },
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      TSImportEqualsDeclaration(node) {
+        lint(node);
       },
     };
   },

--- a/packages/eslint-plugin/src/util.ts
+++ b/packages/eslint-plugin/src/util.ts
@@ -98,3 +98,21 @@ export function findTypesPackage(file: string): TypesPackageInfo | undefined {
     };
   });
 }
+
+export function getImportSource(
+  node: TSESTree.ImportDeclaration | TSESTree.TSImportEqualsDeclaration,
+): TSESTree.StringLiteral | undefined {
+  if (node.type === "ImportDeclaration") {
+    return node.source;
+  }
+
+  if (
+    node.moduleReference.type === "TSExternalModuleReference" &&
+    node.moduleReference.expression.type === "Literal" &&
+    typeof node.moduleReference.expression.value === "string"
+  ) {
+    return node.moduleReference.expression;
+  }
+
+  return undefined;
+}

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-import-of-dev-dependencies/bad.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-import-of-dev-dependencies/bad.d.ts.lint
@@ -1,21 +1,29 @@
 types/no-import-of-dev-dependencies/bad.d.ts
   1:1   error  Do not use a triple slash reference for devdep, use `import` style instead       @typescript-eslint/triple-slash-reference
+  1:1   error  Do not use a triple slash reference for devdep, use `import` style instead       @typescript-eslint/triple-slash-reference
   1:21  error  .d.ts files may not triple-slash reference packages in devDependencies           @definitelytyped/no-import-of-dev-dependencies
+  2:1   error  Do not use a triple slash reference for otherdevdep, use `import` style instead  @typescript-eslint/triple-slash-reference
   2:1   error  Do not use a triple slash reference for otherdevdep, use `import` style instead  @typescript-eslint/triple-slash-reference
   2:21  error  .d.ts files may not triple-slash reference packages in devDependencies           @definitelytyped/no-import-of-dev-dependencies
   4:1   error  .d.ts files may not import packages in devDependencies                           @definitelytyped/no-import-of-dev-dependencies
   5:1   error  .d.ts files may not import packages in devDependencies                           @definitelytyped/no-import-of-dev-dependencies
+  7:1   error  .d.ts files may not import packages in devDependencies                           @definitelytyped/no-import-of-dev-dependencies
+  8:1   error  .d.ts files may not import packages in devDependencies                           @definitelytyped/no-import-of-dev-dependencies
 
-✖ 6 problems (6 errors, 0 warnings)
+✖ 10 problems (10 errors, 0 warnings)
 
 ==== types/no-import-of-dev-dependencies/bad.d.ts ====
 
     /// <reference types="devdep"/>
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @typescript-eslint/triple-slash-reference: Do not use a triple slash reference for devdep, use `import` style instead.
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! @typescript-eslint/triple-slash-reference: Do not use a triple slash reference for devdep, use `import` style instead.
                         ~~~~~~
 !!! @definitelytyped/no-import-of-dev-dependencies: .d.ts files may not triple-slash reference packages in devDependencies.
     /// <reference types="otherdevdep"/>
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! @typescript-eslint/triple-slash-reference: Do not use a triple slash reference for otherdevdep, use `import` style instead.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @typescript-eslint/triple-slash-reference: Do not use a triple slash reference for otherdevdep, use `import` style instead.
                         ~~~~~~~~~~~
@@ -29,4 +37,8 @@ types/no-import-of-dev-dependencies/bad.d.ts
 !!! @definitelytyped/no-import-of-dev-dependencies: .d.ts files may not import packages in devDependencies.
     
     import devdep2 = require("devdep");
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! @definitelytyped/no-import-of-dev-dependencies: .d.ts files may not import packages in devDependencies.
     import otherdevdep2 = require("otherdevdep");
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! @definitelytyped/no-import-of-dev-dependencies: .d.ts files may not import packages in devDependencies.

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-import-of-dev-dependencies/bad.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-import-of-dev-dependencies/bad.d.ts.lint
@@ -27,3 +27,6 @@ types/no-import-of-dev-dependencies/bad.d.ts
     import * as otherdevdep from "otherdevdep";
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-import-of-dev-dependencies: .d.ts files may not import packages in devDependencies.
+    
+    import devdep2 = require("devdep");
+    import otherdevdep2 = require("otherdevdep");

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-import-of-dev-dependencies/index.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-import-of-dev-dependencies/index.d.ts.lint
@@ -1,8 +1,8 @@
 types/no-import-of-dev-dependencies/index.d.ts
-  1:1   error  Do not use a triple slash reference for other, use `import` style instead         @typescript-eslint/triple-slash-reference
-  1:1   error  Do not use a triple slash reference for other, use `import` style instead         @typescript-eslint/triple-slash-reference
-  4:18  error  Declaration file should not use a global import of itself. Use a relative import  @definitelytyped/no-self-import
-  7:24  error  Declaration file should not use a global import of itself. Use a relative import  @definitelytyped/no-self-import
+  1:1  error  Do not use a triple slash reference for other, use `import` style instead         @typescript-eslint/triple-slash-reference
+  1:1  error  Do not use a triple slash reference for other, use `import` style instead         @typescript-eslint/triple-slash-reference
+  4:1  error  Declaration file should not use a global import of itself. Use a relative import  @definitelytyped/no-self-import
+  7:1  error  Declaration file should not use a global import of itself. Use a relative import  @definitelytyped/no-self-import
 
 ✖ 4 problems (4 errors, 0 warnings)
 
@@ -16,10 +16,10 @@ types/no-import-of-dev-dependencies/index.d.ts
     
     import other from "other";
     import self from "no-import-of-dev-dependencies";
-                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
     
     import other2 = require("other");
     import self2 = require("no-import-of-dev-dependencies");
-                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-import-of-dev-dependencies/index.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-import-of-dev-dependencies/index.d.ts.lint
@@ -14,3 +14,6 @@ types/no-import-of-dev-dependencies/index.d.ts
     import self from "no-import-of-dev-dependencies";
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
+    
+    import other2 = require("other");
+    import self2 = require("no-import-of-dev-dependencies");

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-import-of-dev-dependencies/index.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-import-of-dev-dependencies/index.d.ts.lint
@@ -1,12 +1,15 @@
 types/no-import-of-dev-dependencies/index.d.ts
   1:1  error  Do not use a triple slash reference for other, use `import` style instead         @typescript-eslint/triple-slash-reference
+  1:1  error  Do not use a triple slash reference for other, use `import` style instead         @typescript-eslint/triple-slash-reference
   4:1  error  Declaration file should not use a global import of itself. Use a relative import  @definitelytyped/no-self-import
 
-✖ 2 problems (2 errors, 0 warnings)
+✖ 3 problems (3 errors, 0 warnings)
 
 ==== types/no-import-of-dev-dependencies/index.d.ts ====
 
     /// <reference types="other"/>
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! @typescript-eslint/triple-slash-reference: Do not use a triple slash reference for other, use `import` style instead.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @typescript-eslint/triple-slash-reference: Do not use a triple slash reference for other, use `import` style instead.
     

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-import-of-dev-dependencies/index.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-import-of-dev-dependencies/index.d.ts.lint
@@ -1,9 +1,10 @@
 types/no-import-of-dev-dependencies/index.d.ts
-  1:1  error  Do not use a triple slash reference for other, use `import` style instead         @typescript-eslint/triple-slash-reference
-  1:1  error  Do not use a triple slash reference for other, use `import` style instead         @typescript-eslint/triple-slash-reference
-  4:1  error  Declaration file should not use a global import of itself. Use a relative import  @definitelytyped/no-self-import
+  1:1   error  Do not use a triple slash reference for other, use `import` style instead         @typescript-eslint/triple-slash-reference
+  1:1   error  Do not use a triple slash reference for other, use `import` style instead         @typescript-eslint/triple-slash-reference
+  4:18  error  Declaration file should not use a global import of itself. Use a relative import  @definitelytyped/no-self-import
+  7:24  error  Declaration file should not use a global import of itself. Use a relative import  @definitelytyped/no-self-import
 
-✖ 3 problems (3 errors, 0 warnings)
+✖ 4 problems (4 errors, 0 warnings)
 
 ==== types/no-import-of-dev-dependencies/index.d.ts ====
 
@@ -15,8 +16,10 @@ types/no-import-of-dev-dependencies/index.d.ts
     
     import other from "other";
     import self from "no-import-of-dev-dependencies";
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
     
     import other2 = require("other");
     import self2 = require("no-import-of-dev-dependencies");
+                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-import-of-dev-dependencies/no-import-of-dev-dependencies-tests.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-import-of-dev-dependencies/no-import-of-dev-dependencies-tests.ts.lint
@@ -22,3 +22,9 @@ types/no-import-of-dev-dependencies/no-import-of-dev-dependencies-tests.ts
     
     import devdep from "devdep";
     import * as otherdevdep from "otherdevdep";
+    
+    import other2 = require("other");
+    import self2 = require("no-import-of-dev-dependencies");
+    
+    import devdep2 = require("devdep");
+    import otherdevdep2 = require("otherdevdep");

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-import-of-dev-dependencies/no-import-of-dev-dependencies-tests.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-import-of-dev-dependencies/no-import-of-dev-dependencies-tests.ts.lint
@@ -1,19 +1,28 @@
 types/no-import-of-dev-dependencies/no-import-of-dev-dependencies-tests.ts
   1:1  error  Do not use a triple slash reference for devdep, use `import` style instead       @typescript-eslint/triple-slash-reference
+  1:1  error  Do not use a triple slash reference for devdep, use `import` style instead       @typescript-eslint/triple-slash-reference
+  2:1  error  Do not use a triple slash reference for otherdevdep, use `import` style instead  @typescript-eslint/triple-slash-reference
   2:1  error  Do not use a triple slash reference for otherdevdep, use `import` style instead  @typescript-eslint/triple-slash-reference
   3:1  error  Do not use a triple slash reference for other, use `import` style instead        @typescript-eslint/triple-slash-reference
+  3:1  error  Do not use a triple slash reference for other, use `import` style instead        @typescript-eslint/triple-slash-reference
 
-✖ 3 problems (3 errors, 0 warnings)
+✖ 6 problems (6 errors, 0 warnings)
 
 ==== types/no-import-of-dev-dependencies/no-import-of-dev-dependencies-tests.ts ====
 
     /// <reference types="devdep"/>
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @typescript-eslint/triple-slash-reference: Do not use a triple slash reference for devdep, use `import` style instead.
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! @typescript-eslint/triple-slash-reference: Do not use a triple slash reference for devdep, use `import` style instead.
     /// <reference types="otherdevdep"/>
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @typescript-eslint/triple-slash-reference: Do not use a triple slash reference for otherdevdep, use `import` style instead.
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! @typescript-eslint/triple-slash-reference: Do not use a triple slash reference for otherdevdep, use `import` style instead.
     /// <reference types="other"/>
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! @typescript-eslint/triple-slash-reference: Do not use a triple slash reference for other, use `import` style instead.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @typescript-eslint/triple-slash-reference: Do not use a triple slash reference for other, use `import` style instead.
     

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-relative-import-in-test/index.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-relative-import-in-test/index.d.ts.lint
@@ -1,10 +1,5 @@
-types/no-relative-import-in-test/index.d.ts
-  1:1  error  File has no content  @definitelytyped/no-useless-files
-
-✖ 1 problem (1 error, 0 warnings)
+No errors
 
 ==== types/no-relative-import-in-test/index.d.ts ====
 
-    
-    ~
-!!! @definitelytyped/no-useless-files: File has no content.
+    export function getFoo(): "foo";

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-relative-import-in-test/no-relative-import-in-test-tests3.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-relative-import-in-test/no-relative-import-in-test-tests3.ts.lint
@@ -1,5 +1,10 @@
-No errors
+types/no-relative-import-in-test/no-relative-import-in-test-tests3.ts
+  1:23  error  Test file should not use a relative import. Use a global import as if this were a user of the package  @definitelytyped/no-relative-import-in-test
+
+✖ 1 problem (1 error, 0 warnings)
 
 ==== types/no-relative-import-in-test/no-relative-import-in-test-tests3.ts ====
 
     import util = require('./');
+                          ~~~~
+!!! @definitelytyped/no-relative-import-in-test: Test file should not use a relative import. Use a global import as if this were a user of the package.

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-relative-import-in-test/no-relative-import-in-test-tests3.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-relative-import-in-test/no-relative-import-in-test-tests3.ts.lint
@@ -1,0 +1,5 @@
+No errors
+
+==== types/no-relative-import-in-test/no-relative-import-in-test-tests3.ts ====
+
+    import util = require('./');

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-relative-references/index.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-relative-references/index.d.ts.lint
@@ -3,13 +3,13 @@ types/no-relative-references/index.d.ts
    2:22  error  The reference "./v1/index.d.ts" resolves outside of the package. Use a global reference to reference other packages           @definitelytyped/no-bad-reference
    3:22  error  The reference "../foo/v1/index.d.ts" resolves outside of the package. Use a global reference to reference other packages      @definitelytyped/no-bad-reference
    5:22  error  The import "../foo" resolves outside of the package. Use a bare import to reference other packages                            @definitelytyped/no-bad-reference
+   6:1   error  Don't import an old version of the current package                                                                            @definitelytyped/no-self-import
    6:23  error  The import "./v1" resolves outside of the package. Use a bare import to reference other packages                              @definitelytyped/no-bad-reference
-   6:23  error  Don't import an old version of the current package                                                                            @definitelytyped/no-self-import
    7:23  error  The import "../foo/v1" resolves outside of the package. Use a bare import to reference other packages                         @definitelytyped/no-bad-reference
    9:16  error  Instead of declaring a module with `declare module "no-relative-references"`, write its contents in directly in "index.d.ts"  @definitelytyped/no-declare-current-package
-  10:22  error  Declaration file should not use a global import of itself. Use a relative import                                              @definitelytyped/no-self-import
+  10:3   error  Declaration file should not use a global import of itself. Use a relative import                                              @definitelytyped/no-self-import
+  11:3   error  Declaration file should not use a global import of itself. Use a relative import                                              @definitelytyped/no-self-import
   11:22  error  The import "no-relative-references/v1" resolves outside of the package. Use a bare import to reference other packages         @definitelytyped/no-bad-reference
-  11:22  error  Declaration file should not use a global import of itself. Use a relative import                                              @definitelytyped/no-self-import
 
 ✖ 11 problems (11 errors, 0 warnings)
 
@@ -29,10 +29,10 @@ types/no-relative-references/index.d.ts
                          ~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../foo" resolves outside of the package. Use a bare import to reference other packages.
     import * as foo2 from "./v1";
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! @definitelytyped/no-self-import: Don't import an old version of the current package.
                           ~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "./v1" resolves outside of the package. Use a bare import to reference other packages.
-                          ~~~~~~
-!!! @definitelytyped/no-self-import: Don't import an old version of the current package.
     import * as foo3 from "../foo/v1";
                           ~~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../foo/v1" resolves outside of the package. Use a bare import to reference other packages.
@@ -41,11 +41,11 @@ types/no-relative-references/index.d.ts
                    ~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-declare-current-package: Instead of declaring a module with `declare module "no-relative-references"`, write its contents in directly in "index.d.ts".
       import A = require("no-relative-references/blah"); // Okay; relative
-                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
       import B = require("no-relative-references/v1"); // Bad; versioned subdir
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "no-relative-references/v1" resolves outside of the package. Use a bare import to reference other packages.
-                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
     }

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-relative-references/index.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-relative-references/index.d.ts.lint
@@ -3,13 +3,15 @@ types/no-relative-references/index.d.ts
    2:22  error  The reference "./v1/index.d.ts" resolves outside of the package. Use a global reference to reference other packages           @definitelytyped/no-bad-reference
    3:22  error  The reference "../foo/v1/index.d.ts" resolves outside of the package. Use a global reference to reference other packages      @definitelytyped/no-bad-reference
    5:22  error  The import "../foo" resolves outside of the package. Use a bare import to reference other packages                            @definitelytyped/no-bad-reference
-   6:1   error  Don't import an old version of the current package                                                                            @definitelytyped/no-self-import
    6:23  error  The import "./v1" resolves outside of the package. Use a bare import to reference other packages                              @definitelytyped/no-bad-reference
+   6:23  error  Don't import an old version of the current package                                                                            @definitelytyped/no-self-import
    7:23  error  The import "../foo/v1" resolves outside of the package. Use a bare import to reference other packages                         @definitelytyped/no-bad-reference
    9:16  error  Instead of declaring a module with `declare module "no-relative-references"`, write its contents in directly in "index.d.ts"  @definitelytyped/no-declare-current-package
+  10:22  error  Declaration file should not use a global import of itself. Use a relative import                                              @definitelytyped/no-self-import
   11:22  error  The import "no-relative-references/v1" resolves outside of the package. Use a bare import to reference other packages         @definitelytyped/no-bad-reference
+  11:22  error  Declaration file should not use a global import of itself. Use a relative import                                              @definitelytyped/no-self-import
 
-✖ 9 problems (9 errors, 0 warnings)
+✖ 11 problems (11 errors, 0 warnings)
 
 ==== types/no-relative-references/index.d.ts ====
 
@@ -27,10 +29,10 @@ types/no-relative-references/index.d.ts
                          ~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../foo" resolves outside of the package. Use a bare import to reference other packages.
     import * as foo2 from "./v1";
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! @definitelytyped/no-self-import: Don't import an old version of the current package.
                           ~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "./v1" resolves outside of the package. Use a bare import to reference other packages.
+                          ~~~~~~
+!!! @definitelytyped/no-self-import: Don't import an old version of the current package.
     import * as foo3 from "../foo/v1";
                           ~~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../foo/v1" resolves outside of the package. Use a bare import to reference other packages.
@@ -39,7 +41,11 @@ types/no-relative-references/index.d.ts
                    ~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-declare-current-package: Instead of declaring a module with `declare module "no-relative-references"`, write its contents in directly in "index.d.ts".
       import A = require("no-relative-references/blah"); // Okay; relative
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
       import B = require("no-relative-references/v1"); // Bad; versioned subdir
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "no-relative-references/v1" resolves outside of the package. Use a bare import to reference other packages.
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
     }

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-relative-references/v1/index.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-relative-references/v1/index.d.ts.lint
@@ -8,9 +8,11 @@ types/no-relative-references/v1/index.d.ts
    8:23  error  The import "../../foo/v1" resolves outside of the package. Use a bare import to reference other packages                      @definitelytyped/no-bad-reference
    9:22  error  The import "../index" resolves outside of the package. Use a bare import to reference other packages                          @definitelytyped/no-bad-reference
   11:16  error  Instead of declaring a module with `declare module "no-relative-references"`, write its contents in directly in "index.d.ts"  @definitelytyped/no-declare-current-package
+  12:22  error  Declaration file should not use a global import of itself. Use a relative import                                              @definitelytyped/no-self-import
+  13:22  error  Declaration file should not use a global import of itself. Use a relative import                                              @definitelytyped/no-self-import
   14:22  error  The import "../index" resolves outside of the package. Use a bare import to reference other packages                          @definitelytyped/no-bad-reference
 
-✖ 10 problems (10 errors, 0 warnings)
+✖ 12 problems (12 errors, 0 warnings)
 
 ==== types/no-relative-references/v1/index.d.ts ====
 
@@ -44,7 +46,11 @@ types/no-relative-references/v1/index.d.ts
                    ~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-declare-current-package: Instead of declaring a module with `declare module "no-relative-references"`, write its contents in directly in "index.d.ts".
       import A = require("no-relative-references/blah"); // Okay; relative
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
       import B = require("no-relative-references/v1"); // Okay; no versioned dir here
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
       import C = require("../index"); // Bad; parent dir
                          ~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../index" resolves outside of the package. Use a bare import to reference other packages.

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-relative-references/v1/index.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-relative-references/v1/index.d.ts.lint
@@ -8,8 +8,8 @@ types/no-relative-references/v1/index.d.ts
    8:23  error  The import "../../foo/v1" resolves outside of the package. Use a bare import to reference other packages                      @definitelytyped/no-bad-reference
    9:22  error  The import "../index" resolves outside of the package. Use a bare import to reference other packages                          @definitelytyped/no-bad-reference
   11:16  error  Instead of declaring a module with `declare module "no-relative-references"`, write its contents in directly in "index.d.ts"  @definitelytyped/no-declare-current-package
-  12:22  error  Declaration file should not use a global import of itself. Use a relative import                                              @definitelytyped/no-self-import
-  13:22  error  Declaration file should not use a global import of itself. Use a relative import                                              @definitelytyped/no-self-import
+  12:3   error  Declaration file should not use a global import of itself. Use a relative import                                              @definitelytyped/no-self-import
+  13:3   error  Declaration file should not use a global import of itself. Use a relative import                                              @definitelytyped/no-self-import
   14:22  error  The import "../index" resolves outside of the package. Use a bare import to reference other packages                          @definitelytyped/no-bad-reference
 
 ✖ 12 problems (12 errors, 0 warnings)
@@ -46,10 +46,10 @@ types/no-relative-references/v1/index.d.ts
                    ~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-declare-current-package: Instead of declaring a module with `declare module "no-relative-references"`, write its contents in directly in "index.d.ts".
       import A = require("no-relative-references/blah"); // Okay; relative
-                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
       import B = require("no-relative-references/v1"); // Okay; no versioned dir here
-                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
       import C = require("../index"); // Bad; parent dir
                          ~~~~~~~~~~

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-self-import/bad.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-self-import/bad.d.ts.lint
@@ -1,65 +1,65 @@
 types/no-self-import/bad.d.ts
-   1:20  error  Declaration file should not use a global import of itself. Use a relative import  @definitelytyped/no-self-import
-   2:17  error  Declaration file should not use a global import of itself. Use a relative import  @definitelytyped/no-self-import
-   4:18  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
-   5:18  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
-   6:18  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
-   7:18  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
-   8:18  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
-  10:33  error  Declaration file should not use a global import of itself. Use a relative import  @definitelytyped/no-self-import
-  11:30  error  Declaration file should not use a global import of itself. Use a relative import  @definitelytyped/no-self-import
-  13:31  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
-  14:31  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
-  15:31  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
-  16:31  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
-  17:31  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
+   1:1  error  Declaration file should not use a global import of itself. Use a relative import  @definitelytyped/no-self-import
+   2:1  error  Declaration file should not use a global import of itself. Use a relative import  @definitelytyped/no-self-import
+   4:1  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
+   5:1  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
+   6:1  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
+   7:1  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
+   8:1  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
+  10:1  error  Declaration file should not use a global import of itself. Use a relative import  @definitelytyped/no-self-import
+  11:1  error  Declaration file should not use a global import of itself. Use a relative import  @definitelytyped/no-self-import
+  13:1  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
+  14:1  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
+  15:1  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
+  16:1  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
+  17:1  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
 
 ✖ 14 problems (14 errors, 0 warnings)
 
 ==== types/no-self-import/bad.d.ts ====
 
     import myself from "no-self-import";
-                       ~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
     import abc from "no-self-import/abc.d.ts"
-                    ~~~~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
     
     import old1 from "./v11";
-                     ~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Don't import an old version of the current package.
     import old2 from "./v11/index";
-                     ~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Don't import an old version of the current package.
     import old3 from "./v11/subdir/file";
-                     ~~~~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Don't import an old version of the current package.
     import old4 from "./v0.1"
-                     ~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Don't import an old version of the current package.
     import old5 from "./v0.1/index"
-                     ~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Don't import an old version of the current package.
     
     import myselfRequired = require("no-self-import");
-                                    ~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
     import abcRequired = require("no-self-import/abc.d.ts");
-                                 ~~~~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
     
     import old1Required = require("./v11");
-                                  ~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Don't import an old version of the current package.
     import old2Required = require("./v11/index");
-                                  ~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Don't import an old version of the current package.
     import old3Required = require("./v11/subdir/file");
-                                  ~~~~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Don't import an old version of the current package.
     import old4Required = require("./v0.1");
-                                  ~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Don't import an old version of the current package.
     import old5Required = require("./v0.1/index");
-                                  ~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Don't import an old version of the current package.

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-self-import/bad.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-self-import/bad.d.ts.lint
@@ -1,44 +1,65 @@
 types/no-self-import/bad.d.ts
-  1:1  error  Declaration file should not use a global import of itself. Use a relative import  @definitelytyped/no-self-import
-  2:1  error  Declaration file should not use a global import of itself. Use a relative import  @definitelytyped/no-self-import
-  4:1  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
-  5:1  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
-  6:1  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
-  7:1  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
-  8:1  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
+   1:20  error  Declaration file should not use a global import of itself. Use a relative import  @definitelytyped/no-self-import
+   2:17  error  Declaration file should not use a global import of itself. Use a relative import  @definitelytyped/no-self-import
+   4:18  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
+   5:18  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
+   6:18  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
+   7:18  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
+   8:18  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
+  10:33  error  Declaration file should not use a global import of itself. Use a relative import  @definitelytyped/no-self-import
+  11:30  error  Declaration file should not use a global import of itself. Use a relative import  @definitelytyped/no-self-import
+  13:31  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
+  14:31  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
+  15:31  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
+  16:31  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
+  17:31  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
 
-✖ 7 problems (7 errors, 0 warnings)
+✖ 14 problems (14 errors, 0 warnings)
 
 ==== types/no-self-import/bad.d.ts ====
 
     import myself from "no-self-import";
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                       ~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
     import abc from "no-self-import/abc.d.ts"
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                    ~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
     
     import old1 from "./v11";
-    ~~~~~~~~~~~~~~~~~~~~~~~~~
+                     ~~~~~~~
 !!! @definitelytyped/no-self-import: Don't import an old version of the current package.
     import old2 from "./v11/index";
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                     ~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Don't import an old version of the current package.
     import old3 from "./v11/subdir/file";
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                     ~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Don't import an old version of the current package.
     import old4 from "./v0.1"
-    ~~~~~~~~~~~~~~~~~~~~~~~~~
+                     ~~~~~~~~
 !!! @definitelytyped/no-self-import: Don't import an old version of the current package.
     import old5 from "./v0.1/index"
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                     ~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Don't import an old version of the current package.
     
     import myselfRequired = require("no-self-import");
+                                    ~~~~~~~~~~~~~~~~
+!!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
     import abcRequired = require("no-self-import/abc.d.ts");
+                                 ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
     
     import old1Required = require("./v11");
+                                  ~~~~~~~
+!!! @definitelytyped/no-self-import: Don't import an old version of the current package.
     import old2Required = require("./v11/index");
+                                  ~~~~~~~~~~~~~
+!!! @definitelytyped/no-self-import: Don't import an old version of the current package.
     import old3Required = require("./v11/subdir/file");
+                                  ~~~~~~~~~~~~~~~~~~~
+!!! @definitelytyped/no-self-import: Don't import an old version of the current package.
     import old4Required = require("./v0.1");
+                                  ~~~~~~~~
+!!! @definitelytyped/no-self-import: Don't import an old version of the current package.
     import old5Required = require("./v0.1/index");
+                                  ~~~~~~~~~~~~~~
+!!! @definitelytyped/no-self-import: Don't import an old version of the current package.

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-self-import/bad.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-self-import/bad.d.ts.lint
@@ -33,3 +33,12 @@ types/no-self-import/bad.d.ts
     import old5 from "./v0.1/index"
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Don't import an old version of the current package.
+    
+    import myselfRequired = require("no-self-import");
+    import abcRequired = require("no-self-import/abc.d.ts");
+    
+    import old1Required = require("./v11");
+    import old2Required = require("./v11/index");
+    import old3Required = require("./v11/subdir/file");
+    import old4Required = require("./v0.1");
+    import old5Required = require("./v0.1/index");

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-self-import/index.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-self-import/index.d.ts.lint
@@ -9,3 +9,11 @@ No errors
     import old from "./v1gardenpath"
     
     import old from "./v1verb/other"
+    
+    import otherRequired = require("other-package");
+    
+    import otherRequired = require("other-package/this-package");
+    
+    import oldRequired = require("./v1gardenpath");
+    
+    import oldRequired = require("./v1verb/other");

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-self-import/no-self-import-tests.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-self-import/no-self-import-tests.ts.lint
@@ -1,19 +1,28 @@
 types/no-self-import/no-self-import-tests.ts
   1:1  error  Do not use a triple slash reference for devdep, use `import` style instead       @typescript-eslint/triple-slash-reference
+  1:1  error  Do not use a triple slash reference for devdep, use `import` style instead       @typescript-eslint/triple-slash-reference
+  2:1  error  Do not use a triple slash reference for otherdevdep, use `import` style instead  @typescript-eslint/triple-slash-reference
   2:1  error  Do not use a triple slash reference for otherdevdep, use `import` style instead  @typescript-eslint/triple-slash-reference
   3:1  error  Do not use a triple slash reference for other, use `import` style instead        @typescript-eslint/triple-slash-reference
+  3:1  error  Do not use a triple slash reference for other, use `import` style instead        @typescript-eslint/triple-slash-reference
 
-✖ 3 problems (3 errors, 0 warnings)
+✖ 6 problems (6 errors, 0 warnings)
 
 ==== types/no-self-import/no-self-import-tests.ts ====
 
     /// <reference types="devdep"/>
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @typescript-eslint/triple-slash-reference: Do not use a triple slash reference for devdep, use `import` style instead.
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! @typescript-eslint/triple-slash-reference: Do not use a triple slash reference for devdep, use `import` style instead.
     /// <reference types="otherdevdep"/>
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @typescript-eslint/triple-slash-reference: Do not use a triple slash reference for otherdevdep, use `import` style instead.
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! @typescript-eslint/triple-slash-reference: Do not use a triple slash reference for otherdevdep, use `import` style instead.
     /// <reference types="other"/>
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! @typescript-eslint/triple-slash-reference: Do not use a triple slash reference for other, use `import` style instead.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @typescript-eslint/triple-slash-reference: Do not use a triple slash reference for other, use `import` style instead.
     

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-self-import/no-self-import-tests.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-self-import/no-self-import-tests.ts.lint
@@ -22,3 +22,9 @@ types/no-self-import/no-self-import-tests.ts
     
     import devdep from "devdep";
     import * as otherdevdep from "otherdevdep";
+    
+    import otherRequired = require("other");
+    import selfRequired = require("no-import-of-dev-dependencies");
+    
+    import devdepRequired = require("devdep");
+    import otherdevdepRequired = require("otherdevdep");

--- a/packages/eslint-plugin/test/__file_snapshots__/types/scoped__no-relative-references/index.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/scoped__no-relative-references/index.d.ts.lint
@@ -3,13 +3,13 @@ types/scoped__no-relative-references/index.d.ts
    2:22  error  The reference "./v1/index.d.ts" resolves outside of the package. Use a global reference to reference other packages                   @definitelytyped/no-bad-reference
    3:22  error  The reference "../foo/v1/index.d.ts" resolves outside of the package. Use a global reference to reference other packages              @definitelytyped/no-bad-reference
    5:22  error  The import "../foo" resolves outside of the package. Use a bare import to reference other packages                                    @definitelytyped/no-bad-reference
+   6:1   error  Don't import an old version of the current package                                                                                    @definitelytyped/no-self-import
    6:23  error  The import "./v1" resolves outside of the package. Use a bare import to reference other packages                                      @definitelytyped/no-bad-reference
-   6:23  error  Don't import an old version of the current package                                                                                    @definitelytyped/no-self-import
    7:23  error  The import "../foo/v1" resolves outside of the package. Use a bare import to reference other packages                                 @definitelytyped/no-bad-reference
    9:16  error  Instead of declaring a module with `declare module "@scoped/no-relative-references"`, write its contents in directly in "index.d.ts"  @definitelytyped/no-declare-current-package
-  10:22  error  Declaration file should not use a global import of itself. Use a relative import                                                      @definitelytyped/no-self-import
+  10:3   error  Declaration file should not use a global import of itself. Use a relative import                                                      @definitelytyped/no-self-import
+  11:3   error  Declaration file should not use a global import of itself. Use a relative import                                                      @definitelytyped/no-self-import
   11:22  error  The import "@scoped/no-relative-references/v1" resolves outside of the package. Use a bare import to reference other packages         @definitelytyped/no-bad-reference
-  11:22  error  Declaration file should not use a global import of itself. Use a relative import                                                      @definitelytyped/no-self-import
 
 ✖ 11 problems (11 errors, 0 warnings)
 
@@ -29,10 +29,10 @@ types/scoped__no-relative-references/index.d.ts
                          ~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../foo" resolves outside of the package. Use a bare import to reference other packages.
     import * as foo2 from "./v1";
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! @definitelytyped/no-self-import: Don't import an old version of the current package.
                           ~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "./v1" resolves outside of the package. Use a bare import to reference other packages.
-                          ~~~~~~
-!!! @definitelytyped/no-self-import: Don't import an old version of the current package.
     import * as foo3 from "../foo/v1";
                           ~~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../foo/v1" resolves outside of the package. Use a bare import to reference other packages.
@@ -41,11 +41,11 @@ types/scoped__no-relative-references/index.d.ts
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-declare-current-package: Instead of declaring a module with `declare module "@scoped/no-relative-references"`, write its contents in directly in "index.d.ts".
       import A = require("@scoped/no-relative-references/blah"); // Okay; relative
-                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
       import B = require("@scoped/no-relative-references/v1"); // Bad; versioned subdir
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "@scoped/no-relative-references/v1" resolves outside of the package. Use a bare import to reference other packages.
-                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
     }

--- a/packages/eslint-plugin/test/__file_snapshots__/types/scoped__no-relative-references/index.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/scoped__no-relative-references/index.d.ts.lint
@@ -3,13 +3,15 @@ types/scoped__no-relative-references/index.d.ts
    2:22  error  The reference "./v1/index.d.ts" resolves outside of the package. Use a global reference to reference other packages                   @definitelytyped/no-bad-reference
    3:22  error  The reference "../foo/v1/index.d.ts" resolves outside of the package. Use a global reference to reference other packages              @definitelytyped/no-bad-reference
    5:22  error  The import "../foo" resolves outside of the package. Use a bare import to reference other packages                                    @definitelytyped/no-bad-reference
-   6:1   error  Don't import an old version of the current package                                                                                    @definitelytyped/no-self-import
    6:23  error  The import "./v1" resolves outside of the package. Use a bare import to reference other packages                                      @definitelytyped/no-bad-reference
+   6:23  error  Don't import an old version of the current package                                                                                    @definitelytyped/no-self-import
    7:23  error  The import "../foo/v1" resolves outside of the package. Use a bare import to reference other packages                                 @definitelytyped/no-bad-reference
    9:16  error  Instead of declaring a module with `declare module "@scoped/no-relative-references"`, write its contents in directly in "index.d.ts"  @definitelytyped/no-declare-current-package
+  10:22  error  Declaration file should not use a global import of itself. Use a relative import                                                      @definitelytyped/no-self-import
   11:22  error  The import "@scoped/no-relative-references/v1" resolves outside of the package. Use a bare import to reference other packages         @definitelytyped/no-bad-reference
+  11:22  error  Declaration file should not use a global import of itself. Use a relative import                                                      @definitelytyped/no-self-import
 
-✖ 9 problems (9 errors, 0 warnings)
+✖ 11 problems (11 errors, 0 warnings)
 
 ==== types/scoped__no-relative-references/index.d.ts ====
 
@@ -27,10 +29,10 @@ types/scoped__no-relative-references/index.d.ts
                          ~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../foo" resolves outside of the package. Use a bare import to reference other packages.
     import * as foo2 from "./v1";
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! @definitelytyped/no-self-import: Don't import an old version of the current package.
                           ~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "./v1" resolves outside of the package. Use a bare import to reference other packages.
+                          ~~~~~~
+!!! @definitelytyped/no-self-import: Don't import an old version of the current package.
     import * as foo3 from "../foo/v1";
                           ~~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../foo/v1" resolves outside of the package. Use a bare import to reference other packages.
@@ -39,7 +41,11 @@ types/scoped__no-relative-references/index.d.ts
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-declare-current-package: Instead of declaring a module with `declare module "@scoped/no-relative-references"`, write its contents in directly in "index.d.ts".
       import A = require("@scoped/no-relative-references/blah"); // Okay; relative
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
       import B = require("@scoped/no-relative-references/v1"); // Bad; versioned subdir
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "@scoped/no-relative-references/v1" resolves outside of the package. Use a bare import to reference other packages.
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
     }

--- a/packages/eslint-plugin/test/__file_snapshots__/types/scoped__no-relative-references/v1/index.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/scoped__no-relative-references/v1/index.d.ts.lint
@@ -8,9 +8,11 @@ types/scoped__no-relative-references/v1/index.d.ts
    8:23  error  The import "../../foo/v1" resolves outside of the package. Use a bare import to reference other packages                              @definitelytyped/no-bad-reference
    9:22  error  The import "../index" resolves outside of the package. Use a bare import to reference other packages                                  @definitelytyped/no-bad-reference
   11:16  error  Instead of declaring a module with `declare module "@scoped/no-relative-references"`, write its contents in directly in "index.d.ts"  @definitelytyped/no-declare-current-package
+  12:22  error  Declaration file should not use a global import of itself. Use a relative import                                                      @definitelytyped/no-self-import
+  13:22  error  Declaration file should not use a global import of itself. Use a relative import                                                      @definitelytyped/no-self-import
   14:22  error  The import "../index" resolves outside of the package. Use a bare import to reference other packages                                  @definitelytyped/no-bad-reference
 
-✖ 10 problems (10 errors, 0 warnings)
+✖ 12 problems (12 errors, 0 warnings)
 
 ==== types/scoped__no-relative-references/v1/index.d.ts ====
 
@@ -44,7 +46,11 @@ types/scoped__no-relative-references/v1/index.d.ts
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-declare-current-package: Instead of declaring a module with `declare module "@scoped/no-relative-references"`, write its contents in directly in "index.d.ts".
       import A = require("@scoped/no-relative-references/blah"); // Okay; relative
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
       import B = require("@scoped/no-relative-references/v1"); // Okay; no versioned dir here
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
       import C = require("../index"); // Bad; parent dir
                          ~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../index" resolves outside of the package. Use a bare import to reference other packages.

--- a/packages/eslint-plugin/test/__file_snapshots__/types/scoped__no-relative-references/v1/index.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/scoped__no-relative-references/v1/index.d.ts.lint
@@ -8,8 +8,8 @@ types/scoped__no-relative-references/v1/index.d.ts
    8:23  error  The import "../../foo/v1" resolves outside of the package. Use a bare import to reference other packages                              @definitelytyped/no-bad-reference
    9:22  error  The import "../index" resolves outside of the package. Use a bare import to reference other packages                                  @definitelytyped/no-bad-reference
   11:16  error  Instead of declaring a module with `declare module "@scoped/no-relative-references"`, write its contents in directly in "index.d.ts"  @definitelytyped/no-declare-current-package
-  12:22  error  Declaration file should not use a global import of itself. Use a relative import                                                      @definitelytyped/no-self-import
-  13:22  error  Declaration file should not use a global import of itself. Use a relative import                                                      @definitelytyped/no-self-import
+  12:3   error  Declaration file should not use a global import of itself. Use a relative import                                                      @definitelytyped/no-self-import
+  13:3   error  Declaration file should not use a global import of itself. Use a relative import                                                      @definitelytyped/no-self-import
   14:22  error  The import "../index" resolves outside of the package. Use a bare import to reference other packages                                  @definitelytyped/no-bad-reference
 
 ✖ 12 problems (12 errors, 0 warnings)
@@ -46,10 +46,10 @@ types/scoped__no-relative-references/v1/index.d.ts
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-declare-current-package: Instead of declaring a module with `declare module "@scoped/no-relative-references"`, write its contents in directly in "index.d.ts".
       import A = require("@scoped/no-relative-references/blah"); // Okay; relative
-                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
       import B = require("@scoped/no-relative-references/v1"); // Okay; no versioned dir here
-                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
       import C = require("../index"); // Bad; parent dir
                          ~~~~~~~~~~

--- a/packages/eslint-plugin/test/fixtures/types/no-import-of-dev-dependencies/bad.d.ts
+++ b/packages/eslint-plugin/test/fixtures/types/no-import-of-dev-dependencies/bad.d.ts
@@ -3,3 +3,6 @@
 
 import devdep from "devdep";
 import * as otherdevdep from "otherdevdep";
+
+import devdep2 = require("devdep");
+import otherdevdep2 = require("otherdevdep");

--- a/packages/eslint-plugin/test/fixtures/types/no-import-of-dev-dependencies/index.d.ts
+++ b/packages/eslint-plugin/test/fixtures/types/no-import-of-dev-dependencies/index.d.ts
@@ -2,3 +2,6 @@
 
 import other from "other";
 import self from "no-import-of-dev-dependencies";
+
+import other2 = require("other");
+import self2 = require("no-import-of-dev-dependencies");

--- a/packages/eslint-plugin/test/fixtures/types/no-import-of-dev-dependencies/no-import-of-dev-dependencies-tests.ts
+++ b/packages/eslint-plugin/test/fixtures/types/no-import-of-dev-dependencies/no-import-of-dev-dependencies-tests.ts
@@ -7,3 +7,9 @@ import self from "no-import-of-dev-dependencies";
 
 import devdep from "devdep";
 import * as otherdevdep from "otherdevdep";
+
+import other2 = require("other");
+import self2 = require("no-import-of-dev-dependencies");
+
+import devdep2 = require("devdep");
+import otherdevdep2 = require("otherdevdep");

--- a/packages/eslint-plugin/test/fixtures/types/no-relative-import-in-test/index.d.ts
+++ b/packages/eslint-plugin/test/fixtures/types/no-relative-import-in-test/index.d.ts
@@ -1,0 +1,1 @@
+export function getFoo(): "foo";

--- a/packages/eslint-plugin/test/fixtures/types/no-relative-import-in-test/no-relative-import-in-test-tests3.ts
+++ b/packages/eslint-plugin/test/fixtures/types/no-relative-import-in-test/no-relative-import-in-test-tests3.ts
@@ -1,0 +1,1 @@
+import util = require('./');

--- a/packages/eslint-plugin/test/fixtures/types/no-relative-import-in-test/tsconfig.json
+++ b/packages/eslint-plugin/test/fixtures/types/no-relative-import-in-test/tsconfig.json
@@ -18,6 +18,7 @@
         "bad.d.ts",
         "no-relative-import-in-test-tests.ts",
         "no-relative-import-in-test-tests2.ts",
+        "no-relative-import-in-test-tests3.ts",
         "./abc.d.ts",
         "./no-relative-import-in-test/abc.d.ts"
     ]

--- a/packages/eslint-plugin/test/fixtures/types/no-self-import/bad.d.ts
+++ b/packages/eslint-plugin/test/fixtures/types/no-self-import/bad.d.ts
@@ -6,3 +6,12 @@ import old2 from "./v11/index";
 import old3 from "./v11/subdir/file";
 import old4 from "./v0.1"
 import old5 from "./v0.1/index"
+
+import myselfRequired = require("no-self-import");
+import abcRequired = require("no-self-import/abc.d.ts");
+
+import old1Required = require("./v11");
+import old2Required = require("./v11/index");
+import old3Required = require("./v11/subdir/file");
+import old4Required = require("./v0.1");
+import old5Required = require("./v0.1/index");

--- a/packages/eslint-plugin/test/fixtures/types/no-self-import/index.d.ts
+++ b/packages/eslint-plugin/test/fixtures/types/no-self-import/index.d.ts
@@ -5,3 +5,11 @@ import other from "other-package/this-package";
 import old from "./v1gardenpath"
 
 import old from "./v1verb/other"
+
+import otherRequired = require("other-package");
+
+import otherRequired = require("other-package/this-package");
+
+import oldRequired = require("./v1gardenpath");
+
+import oldRequired = require("./v1verb/other");

--- a/packages/eslint-plugin/test/fixtures/types/no-self-import/no-self-import-tests.ts
+++ b/packages/eslint-plugin/test/fixtures/types/no-self-import/no-self-import-tests.ts
@@ -7,3 +7,9 @@ import self from "no-import-of-dev-dependencies";
 
 import devdep from "devdep";
 import * as otherdevdep from "otherdevdep";
+
+import otherRequired = require("other");
+import selfRequired = require("no-import-of-dev-dependencies");
+
+import devdepRequired = require("devdep");
+import otherdevdepRequired = require("otherdevdep");


### PR DESCRIPTION
This PR didn't fail: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67297/files#r1382334665

It turns out that a number of lint rules did not handle `import =` declarations and so went unchecked