### PR TITLE
Fix getAffectedPackages for PRs which modify only versioned dirs

### DIFF
--- a/.changeset/fifty-flowers-clean.md
+++ b/.changeset/fifty-flowers-clean.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/definitions-parser": patch
+---
+
+Fix getAffectedPackages for PRs which modify only versioned dirs

--- a/packages/definitions-parser/src/get-affected-packages.ts
+++ b/packages/definitions-parser/src/get-affected-packages.ts
@@ -29,7 +29,11 @@ export async function getAffectedPackages(
     return { errors };
   }
   const { additions, deletions } = git;
-  const addedPackageDirectories = mapDefined(additions, (id) => id.typesDirectoryName);
+  const addedPackageDirectories = mapDefined(additions, (pkg) => {
+    if (!pkg.typesDirectoryName) return undefined;
+    if (!pkg.version || pkg.version === "*") return pkg.typesDirectoryName;
+    return `${pkg.typesDirectoryName}/v${formatTypingVersion(pkg.version)}`;
+  });
   const allDependentDirectories = [];
   // Start the filter off with all packages that were touched along with those that depend on them.
   const filters = ["--filter", `...@types/**[${sourceRemote}/${sourceBranch}]`];


### PR DESCRIPTION
Unblocks https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67463

We really need some sort of test suite for this code.

Also, I really am surprised that we don't have this helper somewhere else. That and I'm eternally confused by `typesDirectoryName` versus `subDirectoryPath`, as well as packages which are missing dirs and versions?