### PR TITLE
Fully type eslint plugin export and add metadata

### DIFF
--- a/.changeset/popular-starfishes-listen.md
+++ b/.changeset/popular-starfishes-listen.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/eslint-plugin": patch
+---
+
+Fully type eslint plugin export and add metadata

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -4,7 +4,7 @@ import { rules } from "./rules/index";
 
 const packageJson = require("../package.json");
 
-const plugin: ESLint.Plugin = {
+const plugin = {
   meta: {
     name: packageJson.name,
     version: packageJson.version,
@@ -13,6 +13,6 @@ const plugin: ESLint.Plugin = {
     all,
   },
   rules: rules as any,
-};
+} satisfies ESLint.Plugin;
 
 export = plugin;

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,6 +1,16 @@
+import { ESLint } from "eslint";
 import { all } from "./configs/all";
-export { rules } from "./rules/index";
+import { rules } from "./rules/index";
 
-export const configs = {
-  all,
+const plugin: ESLint.Plugin = {
+  meta: {
+    name: "@definitelytyped/eslint-plugin",
+    version: require("../package.json").version,
+  },
+  configs: {
+    all,
+  },
+  rules: rules as any,
 };
+
+export = plugin;

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -2,10 +2,12 @@ import { ESLint } from "eslint";
 import { all } from "./configs/all";
 import { rules } from "./rules/index";
 
+const packageJson = require("../package.json");
+
 const plugin: ESLint.Plugin = {
   meta: {
-    name: "@definitelytyped/eslint-plugin",
-    version: require("../package.json").version,
+    name: packageJson.name,
+    version: packageJson.version,
   },
   configs: {
     all,

--- a/packages/eslint-plugin/test/eslint.test.ts
+++ b/packages/eslint-plugin/test/eslint.test.ts
@@ -29,7 +29,7 @@ let eslint: ESLint;
 beforeAll(() => {
   eslint = new ESLint({
     cwd: fixtureRoot,
-    plugins: { [plugin.meta!.name!]: plugin },
+    plugins: { [plugin.meta.name]: plugin },
   });
 });
 

--- a/packages/eslint-plugin/test/eslint.test.ts
+++ b/packages/eslint-plugin/test/eslint.test.ts
@@ -29,7 +29,7 @@ let eslint: ESLint;
 beforeAll(() => {
   eslint = new ESLint({
     cwd: fixtureRoot,
-    plugins: { "@definitelytyped/eslint-plugin": plugin as unknown as ESLint.Plugin },
+    plugins: { "@definitelytyped/eslint-plugin": plugin },
   });
 });
 

--- a/packages/eslint-plugin/test/eslint.test.ts
+++ b/packages/eslint-plugin/test/eslint.test.ts
@@ -29,7 +29,7 @@ let eslint: ESLint;
 beforeAll(() => {
   eslint = new ESLint({
     cwd: fixtureRoot,
-    plugins: { "@definitelytyped/eslint-plugin": plugin },
+    plugins: { [plugin.meta!.name!]: plugin },
   });
 });
 


### PR DESCRIPTION
See: https://eslint.org/docs/latest/extend/plugins#meta-data-in-plugins

I'm still unclear why ts-eslint's rule creator is incompatible with ESLint's rule types, but this PR only moves the cast.