### PR TITLE
Add react-native to allowedPackageJsonDependencies.txt

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -801,6 +801,7 @@ react-draggable
 react-final-form
 react-intl
 react-map-gl
+react-native
 react-native-fs
 react-native-gesture-handler
 react-native-maps


### PR DESCRIPTION
So we can deprecate react-native https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67459