### PR TITLE
Add knex dependents to expected failures

### DIFF
--- a/.changeset/fast-rocks-exist.md
+++ b/.changeset/fast-rocks-exist.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/dtslint-runner": patch
+---
+
+Add knex-\* to expected failures

--- a/packages/dtslint-runner/expectedFailures.txt
+++ b/packages/dtslint-runner/expectedFailures.txt
@@ -1,2 +1,4 @@
 bookshelf
 graphql-resolvers
+knex-db-manager
+knex-cleaner


### PR DESCRIPTION
DT packages that depend on knex (which ships its own types) have started failing on TS 5.4 due to https://github.com/microsoft/TypeScript/pull/56004.