### PR TITLE
ship ts5.3, remove ts4.5

### DIFF
--- a/packages/typescript-versions/src/index.ts
+++ b/packages/typescript-versions/src/index.ts
@@ -53,20 +53,21 @@ export type UnsupportedTypeScriptVersion =
   | "4.1"
   | "4.2"
   | "4.3"
-  | "4.4";
+  | "4.4"
+  | "4.5";
 /**
  * Parseable and supported TypeScript versions.
  * Only add to this list if we will support this version on Definitely Typed.
  */
-export type TypeScriptVersion = "4.5" | "4.6" | "4.7" | "4.8" | "4.9" | "5.0" | "5.1" | "5.2" | "5.3" | "5.4";
+export type TypeScriptVersion = "4.6" | "4.7" | "4.8" | "4.9" | "5.0" | "5.1" | "5.2" | "5.3" | "5.4";
 
 export type AllTypeScriptVersion = UnsupportedTypeScriptVersion | TypeScriptVersion;
 
 export namespace TypeScriptVersion {
   /** Add to this list when a version actually ships.  */
-  export const shipped: readonly TypeScriptVersion[] = ["4.5", "4.6", "4.7", "4.8", "4.9", "5.0", "5.1", "5.2"];
+  export const shipped: readonly TypeScriptVersion[] = ["4.6", "4.7", "4.8", "4.9", "5.0", "5.1", "5.2", "5.3"];
   /** Add to this list when a version is available as typescript@next */
-  export const supported: readonly TypeScriptVersion[] = [...shipped, "5.3", "5.4"];
+  export const supported: readonly TypeScriptVersion[] = [...shipped, "5.4"];
   /** Add to this list when it will no longer be supported on Definitely Typed */
   export const unsupported: readonly UnsupportedTypeScriptVersion[] = [
     "2.0",
@@ -94,6 +95,7 @@ export namespace TypeScriptVersion {
     "4.2",
     "4.3",
     "4.4",
+    "4.5",
   ];
   export const all: readonly AllTypeScriptVersion[] = [...unsupported, ...supported];
   export const lowest = supported[0];

--- a/packages/typescript-versions/test/index.test.ts
+++ b/packages/typescript-versions/test/index.test.ts
@@ -20,11 +20,11 @@ describe("isSupported", () => {
   it("works", () => {
     expect(TypeScriptVersion.isSupported("5.1")).toBeTruthy();
   });
-  it("supports 4.5", () => {
-    expect(TypeScriptVersion.isSupported("4.5")).toBeTruthy();
+  it("supports 4.6", () => {
+    expect(TypeScriptVersion.isSupported("4.6")).toBeTruthy();
   });
-  it("does not support 4.4", () => {
-    expect(!TypeScriptVersion.isSupported("4.4")).toBeTruthy();
+  it("does not support 4.5", () => {
+    expect(!TypeScriptVersion.isSupported("4.5")).toBeTruthy();
   });
 });
 
@@ -44,8 +44,8 @@ describe("range", () => {
   it("works", () => {
     expect(TypeScriptVersion.range("4.9")).toEqual(["4.9", "5.0", "5.1", "5.2", "5.3", "5.4"]);
   });
-  it("includes 4.5 onwards", () => {
-    expect(TypeScriptVersion.range("4.5")).toEqual(TypeScriptVersion.supported);
+  it("includes 4.6 onwards", () => {
+    expect(TypeScriptVersion.range("4.6")).toEqual(TypeScriptVersion.supported);
   });
 });
 
@@ -53,8 +53,8 @@ describe("tagsToUpdate", () => {
   it("works", () => {
     expect(TypeScriptVersion.tagsToUpdate("5.0")).toEqual(["ts5.0", "ts5.1", "ts5.2", "ts5.3", "ts5.4", "latest"]);
   });
-  it("allows 4.5 onwards", () => {
-    expect(TypeScriptVersion.tagsToUpdate("4.5")).toEqual(
+  it("allows 4.6 onwards", () => {
+    expect(TypeScriptVersion.tagsToUpdate("4.6")).toEqual(
       TypeScriptVersion.supported.map((s) => "ts" + s).concat("latest"),
     );
   });


### PR DESCRIPTION
There are no ts4.5/ typesVersions on DT, so nothing to do there.