### PR TITLE
Add `@redux-saga/types` to allowedPackageJsonDependencies.txt

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -478,6 +478,7 @@
 @react-native/virtualized-lists
 @react-navigation/native
 @react-navigation/stack
+@redux-saga/types
 @sentry/browser
 @serverless/typescript
 @sinonjs/fake-timers


### PR DESCRIPTION
redux-saga publishes a separate repo for certain types.