### PR TITLE
Useful error on `pnpm test` without arguments

### DIFF
--- a/.changeset/khaki-eggs-jam.md
+++ b/.changeset/khaki-eggs-jam.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/dtslint": patch
+---
+
+Special-case a useful error for `pnpm test` without arguments

--- a/packages/dtslint/src/index.ts
+++ b/packages/dtslint/src/index.ts
@@ -26,6 +26,10 @@ async function main(): Promise<void> {
   let tsLocal: string | undefined;
 
   console.log(`dtslint@${require("../package.json").version}`);
+  if (args.length === 1 && args[0] === "types") {
+    console.log("Please provide a package name to test.\nTo test all changed packages at once, run `pnpm run test-all`.");
+    process.exit(1);
+  }
 
   for (const arg of args) {
     if (lookingForTsLocal) {


### PR DESCRIPTION
Special-cased for the way `pnpm test` will invoke dtslint on DT.