### PR TITLE
eslint-plugin: Require eslint ^8.40.0 as peerDependency

### DIFF
--- a/.changeset/curly-starfishes-check.md
+++ b/.changeset/curly-starfishes-check.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/eslint-plugin": patch
+---
+
+Require eslint ^8.40.0 as peerDependency

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.11.0",
     "@typescript-eslint/parser": "^6.11.0",
-    "eslint": "^8.0.0",
+    "eslint": "^8.40.0",
     "eslint-plugin-jsdoc": "^44.0.0",
     "typescript": ">= 3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.7.0-dev || >= 3.8.0-dev || >= 3.9.0-dev || >= 4.0.0-dev || >=5.0.0-dev"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,7 +242,7 @@ importers:
         specifier: ^6.11.0
         version: 6.11.0(eslint@8.53.0)(typescript@5.2.2)
       eslint:
-        specifier: ^8.0.0
+        specifier: ^8.40.0
         version: 8.53.0
       eslint-plugin-jsdoc:
         specifier: ^44.0.0


### PR DESCRIPTION
Commit 6da1cb1bfb3e787122536ff14fd09194c8b55cbe started to use `context.sourceCode` property, which is introduced in ESlint v8.40.0.[^eslint-8.40.0]

This patch updates the peerDependency for `eslint` to require that version or later. The change will help users using `@definitelytyped/eslint-plugin` outside of DefinitelyTyped properly manage their dependencies.

[^eslint-8.40.0]: https://eslint.org/blog/2023/05/eslint-v8.40.0-released/