### PR TITLE
Remove knex-cleaner from expected failures

### DIFF
--- a/.changeset/twenty-timers-march.md
+++ b/.changeset/twenty-timers-march.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/dtslint-runner": patch
+---
+
+Remove knex-cleaner from expected failures

--- a/packages/dtslint-runner/expectedFailures.txt
+++ b/packages/dtslint-runner/expectedFailures.txt
@@ -1,4 +1,3 @@
 bookshelf
 graphql-resolvers
 knex-db-manager
-knex-cleaner


### PR DESCRIPTION
`knex` just published a new version that doesn't have the error that caused `knex-cleaner` to fail on 5.4.
`knex-db-manager` will still fail because it depends on and older `knex` version.