### PR TITLE
Use a direct require when finding estree import

### DIFF
--- a/.changeset/flat-eagles-build.md
+++ b/.changeset/flat-eagles-build.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/dtslint": patch
+---
+
+Use a direct require when finding estree import

--- a/packages/dtslint/src/lint.ts
+++ b/packages/dtslint/src/lint.ts
@@ -20,7 +20,9 @@ export async function lint(
   tsLocal: string | undefined,
 ): Promise<string | undefined> {
   const tsconfigPath = joinPaths(dirPath, "tsconfig.json");
-  const estree = await import(require.resolve("@typescript-eslint/typescript-estree", { paths: [dirPath] }));
+  const estree = require(
+    require.resolve("@typescript-eslint/typescript-estree", { paths: [dirPath] }),
+  ) as typeof import("@typescript-eslint/typescript-estree");
   process.env.TSESTREE_SINGLE_RUN = "true";
   // TODO: To remove tslint, replace this with a ts.createProgram (probably)
   const lintProgram = Linter.createProgram(tsconfigPath);


### PR DESCRIPTION
I believe that this would fix https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/67600

When you use a dynamic import, a path like `c:/blah` is assumed to be a URL, not a file path, and so throws. This could be fixed by using `pathToFileURL`, but I think that this code could actually just be a direct require. The indirection was only needed to emulate `require` relative to the DT root (since that's where imports are resolved from).