### PR TITLE
Remove more tslint code to make dtslint work again

### DIFF
--- a/.changeset/thirty-cows-think.md
+++ b/.changeset/thirty-cows-think.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/dtslint": patch
+---
+
+Remove more tslint code to make dtslint work again


### PR DESCRIPTION
Things were only working on my machine because my build output dir wasn't clean and so tslint was able to find rules.

Just remove the code that fails due to there being no rules. Not a full removal of tslint at all, just enough to make it work.