### PR TITLE
Remove performance logging

### DIFF
--- a/.changeset/fuzzy-ducks-knock.md
+++ b/.changeset/fuzzy-ducks-knock.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/dtslint-runner": patch
+---
+
+Remove performance logging

--- a/packages/dtslint-runner/package.json
+++ b/packages/dtslint-runner/package.json
@@ -28,12 +28,10 @@
     "@definitelytyped/utils": "workspace:*",
     "@octokit/rest": "^19.0.13",
     "semver": "^7.5.4",
-    "stats-lite": "^2.2.0",
     "yargs": "^17.7.2"
   },
   "devDependencies": {
     "@types/semver": "^7.5.5",
-    "@types/stats-lite": "^2.2.2",
     "glob": "^10.3.10"
   },
   "engines": {

--- a/packages/dtslint-runner/src/main.ts
+++ b/packages/dtslint-runner/src/main.ts
@@ -1,5 +1,4 @@
 import os from "os";
-import { percentile } from "stats-lite";
 import {
   execAndThrowErrors,
   joinPaths,
@@ -13,7 +12,6 @@ import { RunDTSLintOptions } from "./types";
 import { prepareAllPackages } from "./prepareAllPackages";
 import { prepareAffectedPackages } from "./prepareAffectedPackages";
 
-const perfDir = joinPaths(os.homedir(), ".dts", "perf");
 const suggestionsDir = joinPaths(os.homedir(), ".dts", "suggestions");
 
 export async function runDTSLint({
@@ -154,8 +152,6 @@ export async function runDTSLint({
   }
   console.log(`{${suggestionLines.join(",")}}`);
 
-  logPerformance();
-
   if (writeFailures) {
     fs.writeFileSync(writeFailures, JSON.stringify(allFailures.map(([path, error]) => ({ path, error }))), "utf8");
   }
@@ -202,29 +198,5 @@ async function cloneDefinitelyTyped(cwd: string, sha: string | undefined): Promi
     const cmd: Command = ["git", ["clone", "https://github.com/DefinitelyTyped/DefinitelyTyped.git", "--depth", "1"]];
     console.log(`${cmd[0]} ${cmd[1].join(" ")}`);
     await execAndThrowErrors(cmd[0], cmd[1], cwd);
-  }
-}
-
-function logPerformance() {
-  const big: [string, number][] = [];
-  const types: number[] = [];
-  if (fs.existsSync(perfDir)) {
-    console.log("\n\n=== PERFORMANCE ===\n");
-    for (const filename of fs.readdirSync(perfDir, { encoding: "utf8" })) {
-      const x = JSON.parse(fs.readFileSync(joinPaths(perfDir, filename), { encoding: "utf8" })) as {
-        [s: string]: { types: number; memory: number };
-      };
-      for (const k of Object.keys(x)) {
-        big.push([k, x[k].types]);
-        types.push(x[k].types);
-      }
-    }
-
-    console.log("  * Percentiles: ");
-    console.log("99:", percentile(types, 0.99));
-    console.log("95:", percentile(types, 0.95));
-    console.log("90:", percentile(types, 0.9));
-    console.log("70:", percentile(types, 0.7));
-    console.log("50:", percentile(types, 0.5));
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,9 +204,6 @@ importers:
       semver:
         specifier: ^7.5.4
         version: 7.5.4
-      stats-lite:
-        specifier: ^2.2.0
-        version: 2.2.0
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
@@ -214,9 +211,6 @@ importers:
       '@types/semver':
         specifier: ^7.5.5
         version: 7.5.5
-      '@types/stats-lite':
-        specifier: ^2.2.2
-        version: 2.2.2
       glob:
         specifier: ^10.3.10
         version: 10.3.10
@@ -1940,10 +1934,6 @@ packages:
 
   /@types/stack-utils@2.0.3:
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
-    dev: true
-
-  /@types/stats-lite@2.2.2:
-    resolution: {integrity: sha512-T+bzT53cbPbE0hMlCNZux1QuH6hQFNHIwRMTQCu3YPG0W7XUfeoULHl+TehJCjaxQx8cz4wlg5oQsOyG9LvZmA==}
     dev: true
 
   /@types/strip-json-comments@3.0.0:
@@ -4193,10 +4183,6 @@ packages:
     engines: {node: '>=16'}
     dev: false
 
-  /isnumber@1.0.0:
-    resolution: {integrity: sha512-JLiSz/zsZcGFXPrB4I/AGBvtStkt+8QmksyZBZnVXnnK9XdTEyz0tX8CRYljtwYDuIuZzih6DpHQdi+3Q6zHPw==}
-    dev: false
-
   /isstream@0.1.2:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
     dev: false
@@ -6276,13 +6262,6 @@ packages:
     dependencies:
       escape-string-regexp: 2.0.0
     dev: true
-
-  /stats-lite@2.2.0:
-    resolution: {integrity: sha512-/Kz55rgUIv2KP2MKphwYT/NCuSfAlbbMRv2ZWw7wyXayu230zdtzhxxuXXcvsc6EmmhS8bSJl3uS1wmMHFumbA==}
-    engines: {node: '>=2.0.0'}
-    dependencies:
-      isnumber: 1.0.0
-    dev: false
 
   /stream-transform@2.1.3:
     resolution: {integrity: sha512-9GHUiM5hMiCi6Y03jD2ARC1ettBXkQBoQAe7nJsPknnI0ow10aXjTnew8QtYQmLjzn974BnmWEAJgCY6ZP1DeQ==}


### PR DESCRIPTION
I removed the code that generated these files in #843; maybe I should restore it, but it's not super clear to me we can do so now that we're in eslint and running per-file and not a full compilation.