### PR TITLE
Fix expectOnly enabling npm-naming

### DIFF
--- a/.changeset/moody-geese-stare.md
+++ b/.changeset/moody-geese-stare.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/dtslint": patch
+---
+
+Prevent npm-naming from being enabled in expectOnly

--- a/packages/dtslint/src/lint.ts
+++ b/packages/dtslint/src/lint.ts
@@ -85,6 +85,7 @@ export async function lint(
     // Disable the regular config, instead load only the plugins and use just the rule above.
     // TODO(jakebailey): share this with eslint-plugin
     options.useEslintrc = false;
+    options.baseConfig = undefined;
     options.overrideConfig!.plugins = ["@definitelytyped", "@typescript-eslint", "jsdoc"];
     const override = options.overrideConfig!.overrides![0];
     override.parser = "@typescript-eslint/parser";


### PR DESCRIPTION
When `expectOnly` is on, we force eslint to _only_ load that one rule, no configs, etc.

But, in #681 I forced `npm-naming` on via a base config, but forgot to delete that base config in `expectOnly`. This had the effect of spurious failures when running unrelated packages as `npm-naming` would be enabled while `useEslintrc` was _disabled_, meaning no package's config was being applied.

The fix is to reset the config more.

I want to rewrite this to not be so side-effect-y (e.g. add a `getEslintOptions` function), but that can come later. Right now, this is just breaking people's PRs.