### PR TITLE
Ignore typescript-*.* in pnpm outdated

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "updateConfig": {
       "ignoreDependencies": [
         "@types/strip-json-comments",
-        "strip-json-comments"
+        "strip-json-comments",
+        "typescript-*.*"
       ]
     },
     "patchedDependencies": {


### PR DESCRIPTION
Packages matching this pattern are intentionally outdated but clutter `pnpm outdated -r`.