### PR TITLE
Require index.d.ts

### DIFF
--- a/.changeset/chilly-ears-allow.md
+++ b/.changeset/chilly-ears-allow.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/dtslint": patch
+---
+
+Require index.d.ts

--- a/packages/dtslint/src/index.ts
+++ b/packages/dtslint/src/index.ts
@@ -186,6 +186,7 @@ async function testTypesVersion(
   tsLocal: string | undefined,
   isLatest: boolean,
 ): Promise<void> {
+  assertIndexdts(dirPath);
   const tsconfigErrors = checkTsconfig(dirPath, getCompilerOptions(dirPath));
   if (tsconfigErrors.length > 0) {
     throw new Error("\n\t* " + tsconfigErrors.join("\n\t* "));
@@ -284,7 +285,13 @@ async function assertNpmIgnoreExpected(dirPath: string) {
 function assertNoOtherFiles(dirPath: string) {
   if (fs.existsSync(joinPaths(dirPath, "OTHER_FILES.txt"))) {
     throw new Error(
-      `${dirPath}: Should not contain 'OTHER_FILES.txt"'. All files matching "**/*.d.{ts,cts,mts,*.ts}" are automatically included.`,
+      `${dirPath}: Should not contain 'OTHER_FILES.txt'. All files matching "**/*.d.{ts,cts,mts,*.ts}" are automatically included.`,
     );
+  }
+}
+
+function assertIndexdts(dirPath: string) {
+  if (!fs.existsSync(joinPaths(dirPath, "index.d.ts"))) {
+    throw new Error(`${dirPath}: Must contain 'index.d.ts'.`);
   }
 }


### PR DESCRIPTION
Add a throw early on in dtslint. This isn't testable and stops linting, but is simple and obvious, making it easy to remove when we stop requiring index.d.ts.