### PR TITLE
run Expect in all files on CI

### DIFF
--- a/.changeset/khaki-phones-press.md
+++ b/.changeset/khaki-phones-press.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/eslint-plugin": patch
+---
+
+Run Expect on all files in CI

--- a/packages/eslint-plugin/src/rules/expect.ts
+++ b/packages/eslint-plugin/src/rules/expect.ts
@@ -74,7 +74,8 @@ Then re-run.`,
   },
   defaultOptions: [{}],
   create(context) {
-    if (isDeclarationPath(context.filename) || !context.sourceCode.text.includes("$ExpectType")) {
+    const inEditor = !context.options[0]?.versionsToTest?.length
+    if (inEditor && (isDeclarationPath(context.filename) || !context.sourceCode.text.includes("$ExpectType"))) {
       return {};
     }
 


### PR DESCRIPTION
only on .ts files with $ExpectType in the editor.

Previously, this was how it ran in CI too, but Expect is the only compile there, so needs to run on everything.

Note: Code inside the visitor also checks context.options[0].versionsToTest.length, but that check *also* narrows, so I didn't dedupe the calculation. Suggestions welcome.