### PR TITLE
Skip only npm naming in dependents

### DIFF
--- a/.changeset/purple-flies-provide.md
+++ b/.changeset/purple-flies-provide.md
@@ -1,0 +1,6 @@
+---
+"@definitelytyped/dtslint-runner": patch
+"@definitelytyped/dtslint": patch
+---
+
+Skip only npm-naming in dependents

--- a/packages/dtslint-runner/src/index.ts
+++ b/packages/dtslint-runner/src/index.ts
@@ -62,7 +62,13 @@ if (require.main === module) {
       },
       expectOnly: {
         group: "dtslint options",
-        description: "Run only the ExpectType lint rule.",
+        description: "Run only the expect lint rule.",
+        type: "boolean",
+        default: false,
+      },
+      skipNpmNaming: {
+        group: "dtslint options",
+        description: "Skip the npm-naming lint rule.",
         type: "boolean",
         default: false,
       },
@@ -102,6 +108,7 @@ if (require.main === module) {
     localTypeScriptPath: !args.onlyTestTsNext ? args.localTypeScriptPath : undefined,
     onlyTestTsNext: !!args.onlyTestTsNext,
     expectOnly: args.expectOnly,
+    skipNpmNaming: args.skipNpmNaming,
     noInstall: args.noInstall,
     childRestartTaskInterval: args.childRestartTaskInterval,
     writeFailures: args.writeFailures,

--- a/packages/dtslint-runner/src/main.ts
+++ b/packages/dtslint-runner/src/main.ts
@@ -62,7 +62,7 @@ export async function runDTSLint({
   await runWithListeningChildProcesses({
     inputs: testedPackages.map((path) => ({
       path,
-      onlyTestTsNext: onlyTestTsNext || !packageNames.has(path),
+      onlyTestTsNext,
       expectOnly,
       skipNpmNaming: skipNpmNaming || !packageNames.has(path),
     })),

--- a/packages/dtslint-runner/src/main.ts
+++ b/packages/dtslint-runner/src/main.ts
@@ -17,6 +17,7 @@ export async function runDTSLint({
   onlyRunAffectedPackages = false,
   noInstall,
   onlyTestTsNext,
+  skipNpmNaming,
   expectOnly,
   localTypeScriptPath,
   nProcesses,
@@ -62,7 +63,8 @@ export async function runDTSLint({
     inputs: testedPackages.map((path) => ({
       path,
       onlyTestTsNext: onlyTestTsNext || !packageNames.has(path),
-      expectOnly: expectOnly || !packageNames.has(path),
+      expectOnly,
+      skipNpmNaming: skipNpmNaming || !packageNames.has(path),
     })),
     commandLineArgs: dtslintArgs,
     workerFile: require.resolve("@definitelytyped/dtslint"),

--- a/packages/dtslint-runner/src/types.ts
+++ b/packages/dtslint-runner/src/types.ts
@@ -14,6 +14,7 @@ export interface RunDTSLintOptions {
   noInstall: boolean;
   onlyTestTsNext: boolean;
   expectOnly: boolean;
+  skipNpmNaming: boolean;
   localTypeScriptPath?: string;
   nProcesses: number;
   shard?: { id: number; count: number };

--- a/packages/dtslint/src/index.ts
+++ b/packages/dtslint/src/index.ts
@@ -16,6 +16,7 @@ async function main(): Promise<void> {
   let dirPath = process.cwd();
   let onlyTestTsNext = false;
   let expectOnly = false;
+  let skipNpmNaming = false;
   let shouldListen = false;
   let lookingForTsLocal = false;
   let tsLocal: string | undefined;
@@ -46,6 +47,9 @@ async function main(): Promise<void> {
         return;
       case "--expectOnly":
         expectOnly = true;
+        break;
+      case "--skipNpmNaming":
+        skipNpmNaming = true;
         break;
       case "--onlyTestTsNext":
         onlyTestTsNext = true;
@@ -79,7 +83,7 @@ async function main(): Promise<void> {
   if (shouldListen) {
     listen(dirPath, tsLocal);
   } else {
-    await runTests(dirPath, onlyTestTsNext, expectOnly, tsLocal);
+    await runTests(dirPath, onlyTestTsNext, expectOnly, skipNpmNaming, tsLocal);
   }
 }
 
@@ -97,13 +101,13 @@ function usage(): void {
 function listen(dirPath: string, tsLocal: string | undefined): void {
   // Don't await this here to ensure that messages sent during installation aren't dropped.
   process.on("message", async (message: unknown) => {
-    const { path, onlyTestTsNext, expectOnly } = message as {
+    const { path, onlyTestTsNext, expectOnly, skipNpmNaming } = message as {
       path: string;
       onlyTestTsNext: boolean;
       expectOnly?: boolean;
+      skipNpmNaming?: boolean;
     };
-
-    runTests(joinPaths(dirPath, path), onlyTestTsNext, !!expectOnly, tsLocal)
+    runTests(joinPaths(dirPath, path), onlyTestTsNext, !!expectOnly, !!skipNpmNaming, tsLocal)
       .catch((e) => e.stack)
       .then((maybeError) => {
         process.send!({ path, status: maybeError === undefined ? "OK" : maybeError });
@@ -116,6 +120,7 @@ async function runTests(
   dirPath: string,
   onlyTestTsNext: boolean,
   expectOnly: boolean,
+  skipNpmNaming: boolean,
   tsLocal: string | undefined,
 ): Promise<void> {
   // Assert that we're really on DefinitelyTyped.
@@ -140,7 +145,7 @@ async function runTests(
   const minVersion = maxVersion(packageJson.minimumTypeScriptVersion, TypeScriptVersion.lowest);
   if (onlyTestTsNext || tsLocal) {
     const tsVersion = tsLocal ? "local" : TypeScriptVersion.latest;
-    await testTypesVersion(dirPath, tsVersion, tsVersion, expectOnly, tsLocal, /*isLatest*/ true);
+    await testTypesVersion(dirPath, tsVersion, tsVersion, expectOnly, skipNpmNaming, tsLocal, /*isLatest*/ true);
   } else {
     // For example, typesVersions of [3.2, 3.5, 3.6] will have
     // associated ts3.2, ts3.5, ts3.6 directories, for
@@ -161,7 +166,7 @@ async function runTests(
       if (lows.length > 1) {
         console.log("testing from", low, "to", hi, "in", versionPath);
       }
-      await testTypesVersion(versionPath, low, hi, expectOnly, undefined, isLatest);
+      await testTypesVersion(versionPath, low, hi, expectOnly, skipNpmNaming, undefined, isLatest);
     }
   }
 }
@@ -183,6 +188,7 @@ async function testTypesVersion(
   lowVersion: TsVersion,
   hiVersion: TsVersion,
   expectOnly: boolean,
+  skipNpmNaming: boolean,
   tsLocal: string | undefined,
   isLatest: boolean,
 ): Promise<void> {
@@ -191,7 +197,7 @@ async function testTypesVersion(
   if (tsconfigErrors.length > 0) {
     throw new Error("\n\t* " + tsconfigErrors.join("\n\t* "));
   }
-  const err = await lint(dirPath, lowVersion, hiVersion, isLatest, expectOnly, tsLocal);
+  const err = await lint(dirPath, lowVersion, hiVersion, isLatest, expectOnly, skipNpmNaming, tsLocal);
   if (err) {
     throw new Error(err);
   }

--- a/packages/dtslint/src/lint.ts
+++ b/packages/dtslint/src/lint.ts
@@ -13,6 +13,7 @@ export async function lint(
   maxVersion: TsVersion,
   isLatest: boolean,
   expectOnly: boolean,
+  skipNpmNaming: boolean,
   tsLocal: string | undefined,
 ): Promise<string | undefined> {
   const tsconfigPath = joinPaths(dirPath, "tsconfig.json");
@@ -44,8 +45,7 @@ export async function lint(
       files.push(fileName);
     }
   }
-
-  const options = getEslintOptions(expectOnly, minVersion, maxVersion, tsLocal);
+  const options = getEslintOptions(expectOnly, skipNpmNaming, minVersion, maxVersion, tsLocal);
   const eslint = new ESLint(options);
   const formatter = await eslint.loadFormatter("stylish");
   const results = await eslint.lintFiles(files);
@@ -56,6 +56,7 @@ export async function lint(
 
 function getEslintOptions(
   expectOnly: boolean,
+  skipNpmNaming: boolean,
   minVersion: TsVersion,
   maxVersion: TsVersion,
   tsLocal: string | undefined,
@@ -99,9 +100,11 @@ function getEslintOptions(
       overrides: [
         {
           files: allFiles,
-          rules: {
-            "@definitelytyped/npm-naming": "error",
-          },
+          rules: skipNpmNaming
+            ? {}
+            : {
+                "@definitelytyped/npm-naming": "error",
+              },
         },
       ],
     },


### PR DESCRIPTION
Previously, everything was skipped except for expect. This will be
slower, but will catch more errors. Now that we're running only eslint,
it should be fast enough, but I'll test with a node PR after this ships.