### PR TITLE
Handle moves in gitChanges+other cleanup

### DIFF
--- a/.changeset/strange-sheep-ring.md
+++ b/.changeset/strange-sheep-ring.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/definitions-parser": patch
+---
+
+Handle git moves in gitChanges

--- a/packages/definitions-parser/src/git.ts
+++ b/packages/definitions-parser/src/git.ts
@@ -6,10 +6,16 @@ import * as semver from "semver";
 import { inspect } from "util";
 import { PreparePackagesResult, getAffectedPackages } from "./get-affected-packages";
 
-export interface GitDiff {
-  status: "A" | "D" | "M";
-  file: string;
-}
+export type GitDiff =
+  | {
+      status: "A" | "D" | "M";
+      file: string;
+    }
+  | {
+      status: "R";
+      file: string;
+      source: string;
+    };
 
 /*
 We have to be careful about how we get the diff because Actions uses a shallow clone.
@@ -38,7 +44,10 @@ export async function gitDiff(log: Logger, definitelyTypedPath: string): Promise
     diff = (await run("git", ["diff", `${sourceBranch}~1`, "--name-status"])).trim();
   }
   return diff.split("\n").map((line) => {
-    const [status, file] = line.split(/\s+/, 2);
+    const [status, file, destination] = line.split(/\s+/, 3);
+    if (status[0] === "R") {
+      return { status: "R", file: destination.trim(), source: file.trim() };
+    }
     return { status: status.trim(), file: file.trim() } as GitDiff;
   });
 
@@ -50,6 +59,10 @@ export async function gitDiff(log: Logger, definitelyTypedPath: string): Promise
   }
 }
 
+/**
+ * @returns packages with added or removed files, but not packages with only changed files; 
+ * {@link getAffectedPackages | those are found by calling pnpm }.
+ */
 export function gitChanges(
   diffs: GitDiff[],
 ): { errors: string[] } | { deletions: PackageId[]; additions: PackageId[] } {
@@ -61,12 +74,24 @@ export function gitChanges(
     const dep = getDependencyFromFile(diff.file);
     if (dep) {
       const key = `${dep.typesDirectoryName}/v${dep.version === "*" ? "*" : formatTypingVersion(dep.version)}`;
-      addedPackages.set(key, [dep, diff.status]);
+      if (diff.status === "R") {
+        addedPackages.set(key, [dep, "A"]);
+        const srcDep = getDependencyFromFile(diff.source);
+        if (srcDep) {
+          const srcKey = `${srcDep.typesDirectoryName}/v${
+            srcDep.version === "*" ? "*" : formatTypingVersion(srcDep.version)
+          }`;
+          addedPackages.set(srcKey, [srcDep, "D"]);
+        }
+      } else {
+        addedPackages.set(key, [dep, diff.status]);
+      }
     } else {
+      const status = diff.status === "A" || diff.status === "R" ? "add" : "delete";
       errors.push(
-        `Unexpected file ${diff.status === "A" ? "added" : "deleted"}: ${diff.file}
+        `Unexpected file ${status === "add" ? "added" : "deleted"}: ${diff.file}
 You should ` +
-          (diff.status === "A"
+          (status === "add"
             ? `only add files that are part of packages.`
             : "only delete files that are a part of removed packages."),
       );
@@ -86,18 +111,19 @@ export async function getAffectedPackagesFromDiff(
 ): Promise<string[] | PreparePackagesResult> {
   const errors = [];
   const diffs = await gitDiff(consoleLogger.info, definitelyTypedPath);
+  const git = gitChanges(diffs);
+  if ("errors" in git) {
+    return git.errors;
+  }
   if (diffs.find((d) => d.file === "notNeededPackages.json")) {
-    const deleteds = await getNotNeededPackages(allPackages, diffs);
+    const deleteds = await getNotNeededPackages(allPackages, git.deletions);
     if ("errors" in deleteds) errors.push(...deleteds.errors);
     else
       for (const deleted of deleteds) {
         errors.push(...(await checkNotNeededPackage(deleted)));
       }
   }
-  const affected = await getAffectedPackages(allPackages, diffs, definitelyTypedPath);
-  if ("errors" in affected) {
-    errors.push(...affected.errors);
-  }
+  const affected = await getAffectedPackages(allPackages, git, definitelyTypedPath);
   if (errors.length) {
     return errors;
   }
@@ -148,11 +174,8 @@ it is supposed to replace, ${typings.version} of ${unneeded.name}.`);
  */
 export async function getNotNeededPackages(
   allPackages: AllPackages,
-  diffs: GitDiff[],
+  deletions: PackageId[],
 ): Promise<{ errors: string[] } | NotNeededPackage[]> {
-  const changes = gitChanges(diffs);
-  if ("errors" in changes) return changes;
-  const { deletions } = changes;
   const deletedPackages = new Set(deletions.map((p) => assertDefined(p.typesDirectoryName)));
   const notNeededs = [];
   const errors = [];

--- a/packages/definitions-parser/src/git.ts
+++ b/packages/definitions-parser/src/git.ts
@@ -60,7 +60,7 @@ export async function gitDiff(log: Logger, definitelyTypedPath: string): Promise
 }
 
 /**
- * @returns packages with added or removed files, but not packages with only changed files; 
+ * @returns packages with added or removed files, but not packages with only changed files;
  * {@link getAffectedPackages | those are found by calling pnpm }.
  */
 export function gitChanges(

--- a/packages/definitions-parser/test/git.test.ts
+++ b/packages/definitions-parser/test/git.test.ts
@@ -72,19 +72,18 @@ testo({
   },
   async gitMovesConvertedToAddsAndDeletes() {
     expect(gitChanges(moveRdfJSDiffs)).toEqual({
-      // serializer-jsonld-ext has changes, why isn't in the list? I guess we only track dirs with additions and deletions?
       additions: [
         { typesDirectoryName: "rdf-ext", version: "*" },
         { typesDirectoryName: "rdfjs__formats", version: "*" },
         { typesDirectoryName: "rdfjs__serializer-turtle", version: "*" },
       ],
       deletions: [
-        { typesDirectoryName: "rdfjs__environment", version: "*" }, // this still has stuff in it, why is it put in deletions?
+        { typesDirectoryName: "rdf-ext", version: "*" },
+        { typesDirectoryName: "rdfjs__environment", version: "*" },
         { typesDirectoryName: "rdfjs__formats-common", version: "*" },
       ],
     });
-  }, // I think both of these questions are because we are only interested in checking that added and removed *files* are correct.
-  // But this means I might have done the wrong thing with respect to moves. (=even though they're technically an add+remove)
+  },
   async forgotToDeleteFiles() {
     expect(
       await getNotNeededPackages(

--- a/packages/definitions-parser/test/git.test.ts
+++ b/packages/definitions-parser/test/git.test.ts
@@ -1,8 +1,8 @@
 import * as util from "util";
 import * as pacote from "pacote";
 import { createTypingsVersionRaw, testo } from "./utils";
-import { GitDiff, getNotNeededPackages, checkNotNeededPackage } from "../src/git";
-import { NotNeededPackage, AllPackages } from "../src/packages";
+import { GitDiff, getNotNeededPackages, checkNotNeededPackage, gitChanges } from "../src/git";
+import { NotNeededPackage, AllPackages, PackageId } from "../src/packages";
 
 const typesData = {
   jquery: createTypingsVersionRaw("jquery", {}, {}),
@@ -21,43 +21,102 @@ const deleteJestDiffs: GitDiff[] = [
   { status: "D", file: "types/jest/index.d.ts" },
   { status: "D", file: "types/jest/jest-tests.d.ts" },
 ];
+const moveRdfJSDiffs: GitDiff[] = [
+  { status: "D", file: "types/rdf-ext/ClownfaceFactory.d.ts" },
+  { status: "A", file: "types/rdf-ext/FetchFactory.d.ts" },
+  { status: "A", file: "types/rdf-ext/FormatsFactory.d.ts" },
+  { status: "M", file: "types/rdf-ext/index.d.ts" },
+  { status: "M", file: "types/rdf-ext/package.json" },
+  { status: "M", file: "types/rdf-ext/rdf-ext-tests.ts" },
+  { status: "D", file: "types/rdfjs__environment/DataFactory.d.ts" },
+  { status: "D", file: "types/rdfjs__environment/DatasetFactory.d.ts" },
+  { status: "D", file: "types/rdfjs__environment/NamespaceFactory.d.ts" },
+  { status: "D", file: "types/rdfjs__environment/TermMapSetFactory.d.ts" },
+  { status: "M", file: "types/rdfjs__environment/package.json" },
+  { status: "M", file: "types/rdfjs__environment/rdfjs__environment-tests.ts" },
+  { status: "R", source: "types/rdfjs__formats-common/.npmignore", file: "types/rdfjs__formats/.npmignore" },
+  { status: "R", source: "types/rdfjs__environment/FormatsFactory.d.ts", file: "types/rdfjs__formats/Factory.d.ts" },
+  { status: "R", source: "types/rdfjs__formats-common/index.d.ts", file: "types/rdfjs__formats/index.d.ts" },
+  { status: "R", source: "types/rdfjs__environment/lib/Formats.d.ts", file: "types/rdfjs__formats/lib/Formats.d.ts" },
+  { status: "R", source: "types/rdfjs__formats-common/package.json", file: "types/rdfjs__formats/package.json" },
+  { status: "A", file: "types/rdfjs__formats/pretty.d.ts" },
+  {
+    status: "R",
+    source: "types/rdfjs__formats-common/rdfjs__formats-common-tests.ts",
+    file: "types/rdfjs__formats/rdfjs__formats-tests.ts",
+  },
+  { status: "A", file: "types/rdfjs__formats/tsconfig.json" },
+  { status: "M", file: "types/rdfjs__serializer-jsonld-ext/index.d.ts" },
+  { status: "M", file: "types/rdfjs__serializer-jsonld-ext/package.json" },
+  { status: "M", file: "types/rdfjs__serializer-jsonld-ext/rdfjs__serializer-jsonld-ext-tests.ts" },
+  { status: "A", file: "types/rdfjs__serializer-turtle/.npmignore" },
+  { status: "A", file: "types/rdfjs__serializer-turtle/index.d.ts" },
+  { status: "A", file: "types/rdfjs__serializer-turtle/package.json" },
+  { status: "A", file: "types/rdfjs__serializer-turtle/rdfjs__serializer-turtle-tests.ts" },
+  {
+    status: "R",
+    source: "types/rdfjs__formats-common/tsconfig.json",
+    file: "types/rdfjs__serializer-turtle/tsconfig.json",
+  },
+];
+function getDeletions(diffs: GitDiff[]): PackageId[] {
+  const changes = gitChanges(diffs);
+  expect(changes).not.toHaveProperty("error");
+  const { deletions } = changes as { deletions: PackageId[]; additions: PackageId[] };
+  return deletions;
+}
 
 testo({
   async ok() {
-    expect(await getNotNeededPackages(allPackages, deleteJestDiffs)).toEqual(jestNotNeeded);
+    expect(await getNotNeededPackages(allPackages, getDeletions(deleteJestDiffs))).toEqual(jestNotNeeded);
   },
+  async gitMovesConvertedToAddsAndDeletes() {
+    expect(gitChanges(moveRdfJSDiffs)).toEqual({
+      // serializer-jsonld-ext has changes, why isn't in the list? I guess we only track dirs with additions and deletions?
+      additions: [
+        { typesDirectoryName: "rdf-ext", version: "*" },
+        { typesDirectoryName: "rdfjs__formats", version: "*" },
+        { typesDirectoryName: "rdfjs__serializer-turtle", version: "*" },
+      ],
+      deletions: [
+        { typesDirectoryName: "rdfjs__environment", version: "*" }, // this still has stuff in it, why is it put in deletions?
+        { typesDirectoryName: "rdfjs__formats-common", version: "*" },
+      ],
+    });
+  }, // I think both of these questions are because we are only interested in checking that added and removed *files* are correct.
+  // But this means I might have done the wrong thing with respect to moves. (=even though they're technically an add+remove)
   async forgotToDeleteFiles() {
     expect(
       await getNotNeededPackages(
         AllPackages.fromTestData({ jest: createTypingsVersionRaw("jest", {}, {}) }, jestNotNeeded),
-        deleteJestDiffs,
+        getDeletions(deleteJestDiffs),
       ),
     ).toEqual({ errors: ["Please delete all files in jest when adding it to notNeededPackages.json."] });
   },
   async tooManyDeletes() {
-    expect(await getNotNeededPackages(allPackages, [{ status: "D", file: "types/oops/oops.txt" }])).toEqual([]);
+    expect(await getNotNeededPackages(allPackages, getDeletions([{ status: "D", file: "types/oops/oops.txt" }]))).toEqual([]);
   },
   async deleteInOtherPackage() {
     expect(
-      await getNotNeededPackages(allPackages, [
+      await getNotNeededPackages(allPackages, getDeletions([
         ...deleteJestDiffs,
         { status: "D", file: "types/most-recent/extra-tests.ts" },
-      ]),
+      ])),
     ).toEqual(jestNotNeeded);
   },
   async extraneousFile() {
     expect(
-      await getNotNeededPackages(allPackages, [
+      await getNotNeededPackages(allPackages, getDeletions([
         ...deleteJestDiffs,
         { status: "A", file: "types/oops/oooooooooooops.txt" },
-      ]),
+      ])),
     ).toEqual(jestNotNeeded);
   },
   async scoped() {
     expect(
       await getNotNeededPackages(
         AllPackages.fromTestData(typesData, [new NotNeededPackage("ember__object", "@ember/object", "1.0.0")]),
-        [{ status: "D", file: "types/ember__object/index.d.ts" }],
+        getDeletions([{ status: "D", file: "types/ember__object/index.d.ts" }]),
       ),
     ).toEqual([new NotNeededPackage("ember__object", "@ember/object", "1.0.0")]);
   },

--- a/packages/definitions-parser/test/git.test.ts
+++ b/packages/definitions-parser/test/git.test.ts
@@ -94,22 +94,24 @@ testo({
     ).toEqual({ errors: ["Please delete all files in jest when adding it to notNeededPackages.json."] });
   },
   async tooManyDeletes() {
-    expect(await getNotNeededPackages(allPackages, getDeletions([{ status: "D", file: "types/oops/oops.txt" }]))).toEqual([]);
+    expect(
+      await getNotNeededPackages(allPackages, getDeletions([{ status: "D", file: "types/oops/oops.txt" }])),
+    ).toEqual([]);
   },
   async deleteInOtherPackage() {
     expect(
-      await getNotNeededPackages(allPackages, getDeletions([
-        ...deleteJestDiffs,
-        { status: "D", file: "types/most-recent/extra-tests.ts" },
-      ])),
+      await getNotNeededPackages(
+        allPackages,
+        getDeletions([...deleteJestDiffs, { status: "D", file: "types/most-recent/extra-tests.ts" }]),
+      ),
     ).toEqual(jestNotNeeded);
   },
   async extraneousFile() {
     expect(
-      await getNotNeededPackages(allPackages, getDeletions([
-        ...deleteJestDiffs,
-        { status: "A", file: "types/oops/oooooooooooops.txt" },
-      ])),
+      await getNotNeededPackages(
+        allPackages,
+        getDeletions([...deleteJestDiffs, { status: "A", file: "types/oops/oooooooooooops.txt" }]),
+      ),
     ).toEqual(jestNotNeeded);
   },
   async scoped() {


### PR DESCRIPTION
1. gitDiff parses git moves from R*nnn* *from* *to* to `{ status: "R", file: to, source: from }`.
1. gitChanges converts `R` to an add and a remove.
3. Documentation of gitChanges, especially in relation getAffectedPackages.
4. Test of gitChanges!
5. No more circular dependency get-affected-packages.ts <-> git.ts. Now git.ts only depends on get-affected-packages.ts.
6. Dedupe call to (and error logging from!) gitChanges.
7. getAffectedPackages no longer returns any errors, only throws if `pnpm` execs fail.

The test case I added is pretty big, but it is real, and complicated. I can try to minimise it if anybody feels strongly that it should be.