### PR TITLE
Make node16 check in expect case insensitive

### DIFF
--- a/.changeset/serious-cougars-judge.md
+++ b/.changeset/serious-cougars-judge.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/eslint-plugin": patch
+---
+
+Fix case sensitivity of node16 backwards compat

--- a/packages/eslint-plugin/src/rules/expect.ts
+++ b/packages/eslint-plugin/src/rules/expect.ts
@@ -175,7 +175,7 @@ function createProgram(configFile: string, ts: TSModule): ts.Program {
     noEmit: true,
   });
 
-  if (config.compilerOptions?.module === "node16" && parsed.options.module === undefined) {
+  if (config.compilerOptions?.module?.toString().toLowerCase() === "node16" && parsed.options.module === undefined) {
     // TypeScript version is too old to handle the "node16" module option,
     // but we can run tests falling back to commonjs/node.
     parsed.options.module = ts.ModuleKind.CommonJS;

--- a/packages/eslint-plugin/src/rules/expect.ts
+++ b/packages/eslint-plugin/src/rules/expect.ts
@@ -175,8 +175,7 @@ function createProgram(configFile: string, ts: TSModule): ts.Program {
     noEmit: true,
   });
 
-  const tsconfigModule = typeof config.compilerOptions?.module;
-  if (tsconfigModule === "string" && tsconfigModule.toLowerCase() === "node16" && parsed.options.module === undefined) {
+  if (config.compilerOptions?.module === "node16" && parsed.options.module === undefined) {
     // TypeScript version is too old to handle the "node16" module option,
     // but we can run tests falling back to commonjs/node.
     parsed.options.module = ts.ModuleKind.CommonJS;

--- a/packages/eslint-plugin/src/rules/expect.ts
+++ b/packages/eslint-plugin/src/rules/expect.ts
@@ -175,7 +175,8 @@ function createProgram(configFile: string, ts: TSModule): ts.Program {
     noEmit: true,
   });
 
-  if (config.compilerOptions?.module === "node16" && parsed.options.module === undefined) {
+  const tsconfigModule = typeof config.compilerOptions?.module;
+  if (tsconfigModule === "string" && tsconfigModule.toLowerCase() === "node16" && parsed.options.module === undefined) {
     // TypeScript version is too old to handle the "node16" module option,
     // but we can run tests falling back to commonjs/node.
     parsed.options.module = ts.ModuleKind.CommonJS;


### PR DESCRIPTION
This was caught on https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68126. Copy the check from https://github.com/microsoft/DefinitelyTyped-tools/blob/4ec06280828fbd22c48008dfbf423585ab8a2d87/packages/dtslint/src/checks.ts#L83.