### PR TITLE
Add `@adobe/ccweb-add-on-sdk-types` to allowedPackageJsonDependencies…

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -1,3 +1,4 @@
+@adobe/ccweb-add-on-sdk-types
 @apollo/client
 @aws-sdk/client-s3
 @azure/functions


### PR DESCRIPTION
My build failed on the main DT repo:
PR: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68234

with the error: 
```
Error: adobe__ccweb-add-on-sdk: In package.json: Dependency @adobe/ccweb-add-on-sdk-types not in the allowed dependencies list.
Please make a pull request to microsoft/DefinitelyTyped-tools adding it to `packages/definitions-parser/allowedPackageJsonDependencies.txt.
```
