### PR TITLE
Write suggestions to the cache dir instead of home

### DIFF
--- a/.changeset/funny-ravens-carry.md
+++ b/.changeset/funny-ravens-carry.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/utils": patch
+---
+
+Change suggestionsDir to use the user’s cache dir instead of .dts the user’s home dir

--- a/.changeset/tiny-boats-prove.md
+++ b/.changeset/tiny-boats-prove.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/utils": patch
+---
+
+Expose suggestionsDir

--- a/packages/dtslint-runner/src/main.ts
+++ b/packages/dtslint-runner/src/main.ts
@@ -1,16 +1,14 @@
-import os from "os";
 import {
   execAndThrowErrors,
   joinPaths,
   runWithListeningChildProcesses,
+  suggestionsDir,
   CrashRecoveryState,
 } from "@definitelytyped/utils";
 import fs from "fs";
 import { RunDTSLintOptions } from "./types";
 import { prepareAllPackages } from "./prepareAllPackages";
 import { prepareAffectedPackages } from "./prepareAffectedPackages";
-
-const suggestionsDir = joinPaths(os.homedir(), ".dts", "suggestions");
 
 export async function runDTSLint({
   definitelyTypedAcquisition,

--- a/packages/eslint-plugin/src/suggestions.ts
+++ b/packages/eslint-plugin/src/suggestions.ts
@@ -1,8 +1,6 @@
 import fs = require("fs");
-import os = require("os");
 import path = require("path");
-
-const suggestionsDir = path.join(os.homedir(), ".dts", "suggestions");
+import { suggestionsDir } from '@definitelytyped/utils';
 
 interface Suggestion {
   fileName: string;

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -23,6 +23,7 @@
     "@definitelytyped/typescript-versions": "workspace:*",
     "@qiwi/npm-registry-client": "^8.9.1",
     "@types/node": "^18.19.7",
+    "cachedir": "^2.0.0",
     "charm": "^1.0.2",
     "minimatch": "^9.0.3",
     "tar": "^6.2.0",

--- a/packages/utils/src/fs.ts
+++ b/packages/utils/src/fs.ts
@@ -1,8 +1,12 @@
 import assert from "assert";
-import { relative, resolve, isAbsolute } from "path";
+import { join, relative, resolve, isAbsolute } from "path";
+import getCacheDir = require("cachedir");
 import { assertDefined } from "./assertions";
 import fs from "fs";
 import { readFileSync, readJsonSync } from "./io";
+
+/** The directory to read/write suggestsions from */
+export const suggestionsDir = join(getCacheDir("dts"), "suggestions");
 
 /** Convert a path to use "/" instead of "\\" for consistency. (This affects content hash.) */
 export function normalizeSlashes(path: string): string {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -419,6 +419,9 @@ importers:
       '@types/node':
         specifier: ^18.19.7
         version: 18.19.7
+      cachedir:
+        specifier: ^2.0.0
+        version: 2.4.0
       charm:
         specifier: ^1.0.2
         version: 1.0.2
@@ -2654,6 +2657,11 @@ packages:
       ssri: 10.0.5
       tar: 6.2.0
       unique-filename: 3.0.0
+    dev: false
+
+  /cachedir@2.4.0:
+    resolution: {integrity: sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==}
+    engines: {node: '>=6'}
     dev: false
 
   /call-bind@1.0.5:


### PR DESCRIPTION
This prevents DefinitelyTyped tools from polluting the user’s home directory.

Also the `suggestionsDir` is defined and exported once, so it can be reused.

Closes #387