### PR TITLE
Fix dts-critic on Windows, missing `which` calls before exec

### DIFF
--- a/.changeset/plenty-melons-think.md
+++ b/.changeset/plenty-melons-think.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/dts-critic": patch
+---
+
+Call "which" before exec-ing

--- a/packages/dts-critic/develop.ts
+++ b/packages/dts-critic/develop.ts
@@ -3,6 +3,7 @@ import yargs = require("yargs");
 import headerParser = require("@definitelytyped/header-parser");
 import path = require("path");
 import cp = require("child_process");
+import which from "which";
 import {
   dtsCritic,
   dtToNpmName,
@@ -24,7 +25,7 @@ const isNpmPath = path.join(sourcesDir, "dts-critic-internal/npm.json");
 function getPackageDownloads(dtName: string): number {
   const npmName = dtToNpmName(dtName);
   const url = `https://api.npmjs.org/downloads/point/last-month/${npmName}`;
-  const result = JSON.parse(cp.execFileSync("curl", ["--silent", "-L", url], { encoding: "utf8" })) as {
+  const result = JSON.parse(cp.execFileSync(which.sync("curl"), ["--silent", "-L", url], { encoding: "utf8" })) as {
     downloads?: number;
   };
   return result.downloads || 0;

--- a/packages/dts-critic/package.json
+++ b/packages/dts-critic/package.json
@@ -12,6 +12,7 @@
     "semver": "^7.5.4",
     "tmp": "^0.2.1",
     "typescript": "^5.3.3",
+    "which": "^4.0.0",
     "yargs": "^17.7.2"
   },
   "peerDependencies": {
@@ -22,6 +23,7 @@
     "@types/semver": "^7.5.6",
     "@types/strip-json-comments": "^3.0.0",
     "@types/tmp": "^0.2.6",
+    "@types/which": "^3.0.3",
     "strip-json-comments": "^3.1.1"
   },
   "main": "dist/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
+      which:
+        specifier: ^4.0.0
+        version: 4.0.0
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
@@ -125,6 +128,9 @@ importers:
       '@types/tmp':
         specifier: ^0.2.6
         version: 0.2.6
+      '@types/which':
+        specifier: ^3.0.3
+        version: 3.0.3
       strip-json-comments:
         specifier: ^3.1.1
         version: 3.1.1
@@ -2770,6 +2776,7 @@ packages:
   /clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
+    requiresBuild: true
     dev: true
 
   /co@4.6.0:
@@ -3002,6 +3009,7 @@ packages:
 
   /defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
+    requiresBuild: true
     dependencies:
       clone: 1.0.4
     dev: true


### PR DESCRIPTION
This should address https://github.com/DefinitelyTyped/DefinitelyTyped/issues/67921.

On Windows, `npm` can actually be `npm.cmd` or `npm.ps1` or similar, especially in the world of corepack. If we're using `child_process` directly and not though a helper or lib like `execa`, we need to call `which` on the command name.

Every other package goes through `@definitelytyped/utils`' `exec` helper, but dts-critic does not as it needs to be synchronous. I could go and extract a helper to make a sync variant, if that's more desirable, but I wasn't sure I wouldn't accidentally cause a behavior change.