### PR TITLE
Re-allow packages without tests

### DIFF
--- a/.changeset/old-suits-whisper.md
+++ b/.changeset/old-suits-whisper.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/dtslint": patch
+---
+
+Re-allow packages without tests

--- a/.changeset/pink-rules-listen.md
+++ b/.changeset/pink-rules-listen.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/dtslint": patch
+---
+
+Allow ./index.d.ts (with ./ prefix)

--- a/packages/dtslint/src/checks.ts
+++ b/packages/dtslint/src/checks.ts
@@ -49,9 +49,9 @@ export function checkTsconfig(dirPath: string, config: Tsconfig): string[] {
     if (!config.files.includes("index.d.ts")) {
       errors.push('"files" list must include "index.d.ts".');
     }
-    if (!config.files.some((f) => /(?:\.[cm]?ts|\.tsx)$/.test(f) && !isDeclarationPath(f))) {
-      errors.push('"files" list must include at least one ".ts", ".tsx", ".mts" or ".cts" file for testing.');
-    }
+    // if (!config.files.some((f) => /(?:\.[cm]?ts|\.tsx)$/.test(f) && !isDeclarationPath(f))) {
+    //   errors.push('"files" list must include at least one ".ts", ".tsx", ".mts" or ".cts" file for testing.');
+    // }
   }
 
   for (const key of Object.getOwnPropertyNames(mustHave) as (keyof typeof mustHave)[]) {

--- a/packages/dtslint/src/checks.ts
+++ b/packages/dtslint/src/checks.ts
@@ -3,7 +3,7 @@ import { AllTypeScriptVersion } from "@definitelytyped/typescript-versions";
 import fs from "fs";
 import { join as joinPaths } from "path";
 import { CompilerOptions } from "typescript";
-import { deepEquals, isDeclarationPath } from "@definitelytyped/utils";
+import { deepEquals } from "@definitelytyped/utils";
 
 import { readJson, packageNameFromPath } from "./util";
 export function checkPackageJson(
@@ -46,7 +46,7 @@ export function checkTsconfig(dirPath: string, config: Tsconfig): string[] {
   } else if (!config.files) {
     errors.push('Must specify "files".');
   } else {
-    if (!config.files.includes("index.d.ts")) {
+    if (!(config.files.includes("index.d.ts") || config.files.includes("./index.d.ts"))) {
       errors.push('"files" list must include "index.d.ts".');
     }
     // if (!config.files.some((f) => /(?:\.[cm]?ts|\.tsx)$/.test(f) && !isDeclarationPath(f))) {

--- a/packages/dtslint/test/index.test.ts
+++ b/packages/dtslint/test/index.test.ts
@@ -141,6 +141,9 @@ describe("dtslint", () => {
       it("Allows files to contain index.d.ts plus a .cts", () => {
         expect(checkTsconfig("include", { compilerOptions: base, files: ["index.d.ts", "tests.cts"] })).toEqual([]);
       });
+      it("Allows files to contain ./index.d.ts plus a ./.tsx", () => {
+        expect(checkTsconfig("include", { compilerOptions: base, files: ["./index.d.ts", "./tests.tsx"] })).toEqual([]);
+      });
       it("Issues both errors on empty files list", () => {
         expect(checkTsconfig("include", { compilerOptions: base, files: [] })).toEqual([
           `"files" list must include "index.d.ts".`,

--- a/packages/dtslint/test/index.test.ts
+++ b/packages/dtslint/test/index.test.ts
@@ -127,11 +127,11 @@ describe("dtslint", () => {
           checkTsconfig("include", { compilerOptions: base, files: ["package-name.d.ts", "package-name.test.ts"] }),
         ).toEqual([`"files" list must include "index.d.ts".`]);
       });
-      it("Requires files to contain .[mc]ts file", () => {
-        expect(checkTsconfig("include", { compilerOptions: base, files: ["index.d.ts"] })).toEqual([
-          `"files" list must include at least one ".ts", ".tsx", ".mts" or ".cts" file for testing.`,
-        ]);
-      });
+      // it("Requires files to contain .[mc]ts file", () => {
+      //   expect(checkTsconfig("include", { compilerOptions: base, files: ["index.d.ts"] })).toEqual([
+      //     `"files" list must include at least one ".ts", ".tsx", ".mts" or ".cts" file for testing.`,
+      //   ]);
+      // });
       it("Allows files to contain index.d.ts plus a .tsx", () => {
         expect(checkTsconfig("include", { compilerOptions: base, files: ["index.d.ts", "tests.tsx"] })).toEqual([]);
       });
@@ -144,7 +144,7 @@ describe("dtslint", () => {
       it("Issues both errors on empty files list", () => {
         expect(checkTsconfig("include", { compilerOptions: base, files: [] })).toEqual([
           `"files" list must include "index.d.ts".`,
-          `"files" list must include at least one ".ts", ".tsx", ".mts" or ".cts" file for testing.`,
+          // `"files" list must include at least one ".ts", ".tsx", ".mts" or ".cts" file for testing.`,
         ]);
       });
     });


### PR DESCRIPTION
This is awful but 832 packages fail. That's way more than we expected.

The other failures are fixed in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68378.