### PR TITLE
Add missing warning logging to dtslint/dtslint-runner

### DIFF
--- a/.changeset/metal-geckos-worry.md
+++ b/.changeset/metal-geckos-worry.md
@@ -1,0 +1,6 @@
+---
+"@definitelytyped/dtslint-runner": patch
+"@definitelytyped/dtslint": patch
+---
+
+Add missing warning logging

--- a/packages/dtslint/src/index.ts
+++ b/packages/dtslint/src/index.ts
@@ -87,7 +87,11 @@ async function main(): Promise<void> {
   if (shouldListen) {
     listen(dirPath, tsLocal);
   } else {
-    await runTests(dirPath, onlyTestTsNext, expectOnly, skipNpmChecks, tsLocal);
+    const warnings = await runTests(dirPath, onlyTestTsNext, expectOnly, skipNpmChecks, tsLocal);
+    if (warnings) {
+      console.log("\nWarnings:\n");
+      console.log(warnings);
+    }
   }
 }
 
@@ -115,7 +119,7 @@ function listen(dirPath: string, tsLocal: string | undefined): void {
 
     runTests(joinPaths(dirPath, path), onlyTestTsNext, !!expectOnly, !!skipNpmChecks, tsLocal)
       .then(
-        () => process.send!({ path, status: "OK" }),
+        (warnings) => process.send!({ path, status: "OK", warnings }),
         (e) => process.send!({ path, status: e.stack }),
       )
       .catch((e) => console.error(e.stack));


### PR DESCRIPTION
This got dropped from #811 somewhere during merge conflict resolution.

Example output:

```
❯ pnpm test-all                                                        

> definitely-typed@0.0.3 test-all /Users/andrew/Developer/microsoft/DefinitelyTyped
> node --enable-source-maps node_modules/@definitelytyped/dtslint-runner/ --path .

dtslint-runner@0.1.5
Node version:  v21.6.1
Using local DefinitelyTyped at .
Running: git rev-parse --verify master
124c5f37d0e894d6fd10f832ffc4dd426a2c0fa5
Running: git diff master --name-status
M       types/xrm/index.d.ts
M       types/xrm/xrm-tests.ts
Testing 1 changed packages: Set(1) { 'xrm' }
Testing 0 dependent packages: Set(0) {}
1> xrm START
dtslint@0.2.5
1> xrm OK (with warnings)


=== SUGGESTIONS ===

{}


=== WARNINGS ===



Warnings in xrm
Ignoring npm version error because xrm was failing when the check was added. If you are making changes to this package, please fix this error:
> Cannot find a version of xrm on npm that matches the types version 9.0. The closest match found was xrm@0.0.1-beta. If these types are for the existing npm package xrm, change the xrm/package.json major and minor version to match an existing version of the npm package. If these types are unrelated to the npm package xrm, add `"nonNpm": true` to the package.json and choose a different name that does not conflict with an existing npm package.
```

```
❯ pnpm test xrm

> definitely-typed@0.0.3 test /Users/andrew/Developer/microsoft/DefinitelyTyped
> node --enable-source-maps node_modules/@definitelytyped/dtslint/ types "xrm"

dtslint@0.2.5

Warnings:

Ignoring npm version error because xrm was failing when the check was added. If you are making changes to this package, please fix this error:
> Cannot find a version of xrm on npm that matches the types version 9.0. The closest match found was xrm@0.0.1-beta. If these types are for the existing npm package xrm, change the xrm/package.json major and minor version to match an existing version of the npm package. If these types are unrelated to the npm package xrm, add `"nonNpm": true` to the package.json and choose a different name that does not conflict with an existing npm package.
```