### PR TITLE
Don't error when scripts are modified

### DIFF
--- a/.changeset/gorgeous-scissors-sell.md
+++ b/.changeset/gorgeous-scissors-sell.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/definitions-parser": patch
+---
+
+Don't error when scripts are modified

--- a/packages/definitions-parser/src/get-affected-packages.ts
+++ b/packages/definitions-parser/src/get-affected-packages.ts
@@ -83,7 +83,7 @@ export async function getAffectedPackagesWorker(
 
   async function tryGetTypingsData(d: string) {
     const dep = getDependencyFromFile(normalizeSlashes(d + "/index.d.ts"));
-    if (!dep) return undefined;
+    if (typeof dep !== "object") return undefined;
     const data = await allPackages.tryGetTypingsData(dep);
     if (!data) return undefined;
     return data.subDirectoryPath;

--- a/packages/definitions-parser/src/git.ts
+++ b/packages/definitions-parser/src/git.ts
@@ -73,20 +73,20 @@ export function gitChanges(
     if (!/types[\\/]/.test(diff.file)) continue;
     if (diff.status === "M") continue;
     const dep = getDependencyFromFile(diff.file);
-    if (dep) {
+    if (typeof dep === "object") {
       const key = `${dep.typesDirectoryName}/v${dep.version === "*" ? "*" : formatTypingVersion(dep.version)}`;
       (diff.status === "D" ? deletions : additions).set(key, dep);
       if (diff.status === "R") {
         // add the source of moves to deletions (the destination was just added to additions)
         const srcDep = getDependencyFromFile(diff.source);
-        if (srcDep) {
+        if (typeof srcDep === "object") {
           const srcKey = `${srcDep.typesDirectoryName}/v${
             srcDep.version === "*" ? "*" : formatTypingVersion(srcDep.version)
           }`;
           deletions.set(srcKey, srcDep);
         }
       }
-    } else {
+    } else if (dep === undefined) {
       const status = diff.status === "A" || diff.status === "R" ? "add" : "delete";
       errors.push(
         `Unexpected file ${status === "add" ? "added" : "deleted"}: ${diff.file}

--- a/packages/definitions-parser/src/packages.ts
+++ b/packages/definitions-parser/src/packages.ts
@@ -595,11 +595,12 @@ export function readNotNeededPackages(dt: FS): readonly NotNeededPackage[] {
 /**
  * For "types/a/b/c", returns { name: "a", version: "*" }.
  * For "types/a/v3/c", returns { name: "a", version: 3 }.
+ * for "types/a/scripts/...", returns "scripts".
  * For "x", returns undefined.
  */
 export function getDependencyFromFile(
   file: string,
-): { typesDirectoryName: string; version: DirectoryParsedTypingVersion | "*" } | undefined {
+): { typesDirectoryName: string; version: DirectoryParsedTypingVersion | "*" } | "scripts" | undefined {
   const parts = file.split("/");
   if (parts.length <= 2) {
     // It's not in a typings directory at all.
@@ -625,7 +626,7 @@ export function getDependencyFromFile(
     // is root package's scripts folder with overridden packageVersion and tsVersion
     (version !== "*" && /^ts\d+\.\d$/.test(tsVersion) && scripts === "scripts")
   ) {
-    return undefined;
+    return "scripts";
   }
 
   return { typesDirectoryName: name, version };

--- a/packages/definitions-parser/src/packages.ts
+++ b/packages/definitions-parser/src/packages.ts
@@ -616,7 +616,11 @@ export function getDependencyFromFile(
   const version = parseVersionFromDirectoryName(packageVersion) ?? "*";
   if (
     // package is not in types directory
-    typesDirName !== typesDirectoryName ||
+    typesDirName !== typesDirectoryName
+  ) {
+    return undefined;
+  }
+  if (
     // is root package's scripts folder
     packageVersion === "scripts" ||
     // is root package's scripts folder with overridden tsVersion

--- a/packages/definitions-parser/test/packages.test.ts
+++ b/packages/definitions-parser/test/packages.test.ts
@@ -285,18 +285,18 @@ describe(getDependencyFromFile, () => {
   });
 
   it("returns undefined on package's scripts directory", () => {
-    expect(getDependencyFromFile("types/a/scripts")).toBe(undefined);
+    expect(getDependencyFromFile("types/a/scripts")).toBe("scripts");
   });
 
   it("returns undefined on package's scripts directory with overridden tsVersion", () => {
-    expect(getDependencyFromFile("types/a/ts4.8/scripts")).toBe(undefined);
+    expect(getDependencyFromFile("types/a/ts4.8/scripts")).toBe("scripts");
   });
 
   it("returns undefined on package's scripts directory with overridden packageVersion", () => {
-    expect(getDependencyFromFile("types/a/v18/scripts")).toBe(undefined);
+    expect(getDependencyFromFile("types/a/v18/scripts")).toBe("scripts");
   });
 
   it("returns undefined on package's scripts directory with overridden packageVersion and tsVersion", () => {
-    expect(getDependencyFromFile("types/a/v18/ts4.8/scripts")).toBe(undefined);
+    expect(getDependencyFromFile("types/a/v18/ts4.8/scripts")).toBe("scripts");
   });
 });


### PR DESCRIPTION
Proposed fix for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68392#issuecomment-1918387474:

```
Error: Unexpected file added: types/node/ts4.8/scripts/html-doc-processing.ts
You should only add files that are part of packages.
    at prepareAffectedPackages (/home/runner/work/DefinitelyTyped/DefinitelyTyped/node_modules/.pnpm/@definitelytyped+dtslint-runner@0.1.5_typescript@5.4.0-dev.20240130/node_modules/@definitelytyped/dtslint-runner/src/prepareAffectedPackages.ts:24:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at runDTSLint (/home/runner/work/DefinitelyTyped/DefinitelyTyped/node_modules/.pnpm/@definitelytyped+dtslint-runner@0.1.5_typescript@5.4.0-dev.20240130/node_modules/@definitelytyped/dtslint-runner/src/main.ts:45:7)
    at <anonymous> (/home/runner/work/DefinitelyTyped/DefinitelyTyped/node_modules/.pnpm/@definitelytyped+dtslint-runner@0.1.5_typescript@5.4.0-dev.20240130/node_modules/@definitelytyped/dtslint-runner/src/index.ts:119:22)
 ELIFECYCLE  Command failed with exit code 1.
```

Which is due to a bad interplay with https://github.com/microsoft/DefinitelyTyped-tools/pull/812.

Maybe this fix is too gross, though. Weird to mix types IMO...