### PR TITLE
Don't look for dependents of packages with deleted files if those packages were not fully deleted

### DIFF
--- a/.changeset/cold-kiwis-relate.md
+++ b/.changeset/cold-kiwis-relate.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/definitions-parser": patch
+---
+
+Don't look for dependents of packages with deleted files if those packages were not fully deleted

--- a/packages/definitions-parser/src/get-affected-packages.ts
+++ b/packages/definitions-parser/src/get-affected-packages.ts
@@ -31,6 +31,11 @@ export async function getAffectedPackages(
   // For packages that have been deleted, they won't appear in the graph anymore; look for packages
   // that still depend on the package (but via npm) and manually add them.
   for (const d of git.deletions) {
+    if (await allPackages.tryGetTypingsData(d)) {
+      // The package actually wasn't deleted.
+      continue;
+    }
+
     for (const dep of await allPackages.allTypings()) {
       for (const [name, version] of dep.allPackageJsonDependencies()) {
         if (

--- a/packages/definitions-parser/src/get-affected-packages.ts
+++ b/packages/definitions-parser/src/get-affected-packages.ts
@@ -32,7 +32,7 @@ export async function getAffectedPackages(
   // that still depend on the package (but via npm) and manually add them.
   for (const d of git.deletions) {
     if (await allPackages.tryGetTypingsData(d)) {
-      // The package actually wasn't deleted.
+      // The package wasn't actually deleted.
       continue;
     }
 


### PR DESCRIPTION
This should unblock https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68392 and maybe https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68356

This code is in the untested part of our code, so, no test :(