### PR TITLE
Add --diffBase to configure diffing, stop fetching, other git improvements

### DIFF
--- a/.changeset/brave-deers-share.md
+++ b/.changeset/brave-deers-share.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/dtslint-runner": patch
+---
+
+Switch to blobless clone in cloneDefinitelyTyped

--- a/.changeset/mean-readers-lay.md
+++ b/.changeset/mean-readers-lay.md
@@ -1,0 +1,6 @@
+---
+"@definitelytyped/definitions-parser": patch
+"@definitelytyped/dtslint-runner": patch
+---
+
+Add --noFetch and --diffBase to configure diffing

--- a/.changeset/red-carrots-yell.md
+++ b/.changeset/red-carrots-yell.md
@@ -3,4 +3,4 @@
 "@definitelytyped/dtslint-runner": patch
 ---
 
-Add --diffBase to configure diffing
+Do not fetch automatically fetch master on run

--- a/packages/definitions-parser/src/git.ts
+++ b/packages/definitions-parser/src/git.ts
@@ -30,21 +30,9 @@ If editing this code, be sure to test on both full and shallow clones.
 export async function gitDiff(
   log: Logger,
   definitelyTypedPath: string,
-  noFetch: boolean,
   diffBase: string,
 ): Promise<GitDiff[]> {
-  if (!noFetch) {
-    const remotes = (await run("git", ["remote"])).trim().split(/\r?\n/);
-    if (remotes.some((r) => diffBase.startsWith(r + "/"))) {
-      await run("git", ["fetch", ...diffBase.split("/", 2)]);
-    }
-  } else {
-    try {
-      await run("git", ["rev-parse", "--verify", diffBase]);
-    } catch {
-      throw new Error(`The base commit ${diffBase} does not exist in this repository.`);
-    }
-  }
+  await run("git", ["rev-parse", "--verify", diffBase]);
 
   let diff = (await run("git", ["diff", diffBase, "--name-status"])).trim();
   if (diff === "") {
@@ -117,11 +105,10 @@ You should ` +
 export async function getAffectedPackagesFromDiff(
   allPackages: AllPackages,
   definitelyTypedPath: string,
-  noFetch: boolean,
   diffBase: string,
 ): Promise<string[] | PreparePackagesResult> {
   const errors = [];
-  const diffs = await gitDiff(consoleLogger.info, definitelyTypedPath, noFetch, diffBase);
+  const diffs = await gitDiff(consoleLogger.info, definitelyTypedPath, diffBase);
   const git = gitChanges(diffs);
   if ("errors" in git) {
     return git.errors;

--- a/packages/definitions-parser/src/git.ts
+++ b/packages/definitions-parser/src/git.ts
@@ -34,13 +34,7 @@ export async function gitDiff(
 ): Promise<GitDiff[]> {
   await run("git", ["rev-parse", "--verify", diffBase]);
 
-  let diff = (await run("git", ["diff", diffBase, "--name-status"])).trim();
-  if (diff === "") {
-    // We are probably already on master, so compare to the last commit.
-    log("No diff found, comparing to last commit");
-    diff = (await run("git", ["diff", `HEAD^1`, "--name-status"])).trim();
-    throw new Error("No diff found");
-  }
+  const diff = (await run("git", ["diff", diffBase, "--name-status"])).trim();
   if (diff === "") {
     // Must have been an empty commit; just return no diffs.
     return [];

--- a/packages/definitions-parser/src/git.ts
+++ b/packages/definitions-parser/src/git.ts
@@ -27,11 +27,7 @@ Actions runs:
 
 If editing this code, be sure to test on both full and shallow clones.
 */
-export async function gitDiff(
-  log: Logger,
-  definitelyTypedPath: string,
-  diffBase: string,
-): Promise<GitDiff[]> {
+export async function gitDiff(log: Logger, definitelyTypedPath: string, diffBase: string): Promise<GitDiff[]> {
   await run("git", ["rev-parse", "--verify", diffBase]);
 
   const diff = (await run("git", ["diff", diffBase, "--name-status"])).trim();

--- a/packages/definitions-parser/src/index.ts
+++ b/packages/definitions-parser/src/index.ts
@@ -5,4 +5,4 @@ export * from "./get-definitely-typed";
 export * from "./git";
 export * from "./mocks";
 export * from "./packages";
-export { getAllowedPackageJsonDependencies } from "./lib/settings";
+export { getAllowedPackageJsonDependencies, defaultSourceRef } from "./lib/settings";

--- a/packages/definitions-parser/src/index.ts
+++ b/packages/definitions-parser/src/index.ts
@@ -5,4 +5,4 @@ export * from "./get-definitely-typed";
 export * from "./git";
 export * from "./mocks";
 export * from "./packages";
-export { getAllowedPackageJsonDependencies, defaultSourceRef } from "./lib/settings";
+export { getAllowedPackageJsonDependencies, sourceBranch } from "./lib/settings";

--- a/packages/definitions-parser/src/lib/settings.ts
+++ b/packages/definitions-parser/src/lib/settings.ts
@@ -4,13 +4,11 @@ import { getUrlContentsAsString, withCache } from "./utils";
 const root = joinPaths(__dirname, "..", "..");
 const storageDirPath = process.env.STORAGE_DIR || root;
 export const dataDirPath = joinPaths(storageDirPath, "data");
-export const defaultSourceBranch = "master";
-export const defaultSourceRemote = "origin";
-export const defaultSourceRef = `${defaultSourceRemote}/${defaultSourceBranch}`;
+export const sourceBranch = "master";
 export const typesDirectoryName = "types";
 
 /** URL to download the repository from. */
-export const definitelyTypedZipUrl = `https://codeload.github.com/DefinitelyTyped/DefinitelyTyped/tar.gz/${defaultSourceBranch}`;
+export const definitelyTypedZipUrl = `https://codeload.github.com/DefinitelyTyped/DefinitelyTyped/tar.gz/${sourceBranch}`;
 
 const allowedPackageJsonDependenciesUrl =
   "https://raw.githubusercontent.com/microsoft/DefinitelyTyped-tools/main/packages/definitions-parser/allowedPackageJsonDependencies.txt";

--- a/packages/definitions-parser/src/lib/settings.ts
+++ b/packages/definitions-parser/src/lib/settings.ts
@@ -4,12 +4,13 @@ import { getUrlContentsAsString, withCache } from "./utils";
 const root = joinPaths(__dirname, "..", "..");
 const storageDirPath = process.env.STORAGE_DIR || root;
 export const dataDirPath = joinPaths(storageDirPath, "data");
-export const sourceBranch = "master";
-export const sourceRemote = "origin";
+export const defaultSourceBranch = "master";
+export const defaultSourceRemote = "origin";
+export const defaultSourceRef = `${defaultSourceRemote}/${defaultSourceBranch}`;
 export const typesDirectoryName = "types";
 
 /** URL to download the repository from. */
-export const definitelyTypedZipUrl = "https://codeload.github.com/DefinitelyTyped/DefinitelyTyped/tar.gz/master";
+export const definitelyTypedZipUrl = `https://codeload.github.com/DefinitelyTyped/DefinitelyTyped/tar.gz/${defaultSourceBranch}`;
 
 const allowedPackageJsonDependenciesUrl =
   "https://raw.githubusercontent.com/microsoft/DefinitelyTyped-tools/main/packages/definitions-parser/allowedPackageJsonDependencies.txt";

--- a/packages/dtslint-runner/src/index.ts
+++ b/packages/dtslint-runner/src/index.ts
@@ -5,6 +5,7 @@ import yargs from "yargs";
 import { RunDTSLintOptions } from "./types";
 import { runDTSLint } from "./main";
 import { assertDefined, logUncaughtErrors } from "@definitelytyped/utils";
+import { defaultSourceRef } from "@definitelytyped/definitions-parser";
 
 export { runDTSLint, RunDTSLintOptions };
 
@@ -88,6 +89,18 @@ if (require.main === module) {
         description: "Path to which all failures will be written.",
         default: "",
       },
+      noFetch: {
+        group: "git options",
+        description: "Don't fetch from a git remote before running.",
+        type: "boolean",
+        default: false,
+      },
+      diffBase: {
+        group: "git options",
+        description: "The base commit to diff against.",
+        type: "string",
+        default: defaultSourceRef,
+      },
     })
     .wrap(Math.min(yargs.terminalWidth(), 120))
     .parseSync();
@@ -112,6 +125,8 @@ if (require.main === module) {
     noInstall: args.noInstall,
     childRestartTaskInterval: args.childRestartTaskInterval,
     writeFailures: args.writeFailures,
+    noFetch: args.noFetch,
+    diffBase: args.diffBase,
   };
 
   logUncaughtErrors(async () => {

--- a/packages/dtslint-runner/src/index.ts
+++ b/packages/dtslint-runner/src/index.ts
@@ -89,12 +89,6 @@ if (require.main === module) {
         description: "Path to which all failures will be written.",
         default: "",
       },
-      noFetch: {
-        group: "git options",
-        description: "Don't fetch from a git remote before running.",
-        type: "boolean",
-        default: false,
-      },
       diffBase: {
         group: "git options",
         description: "The base commit to diff against.",
@@ -125,7 +119,6 @@ if (require.main === module) {
     noInstall: args.noInstall,
     childRestartTaskInterval: args.childRestartTaskInterval,
     writeFailures: args.writeFailures,
-    noFetch: args.noFetch,
     diffBase: args.diffBase,
   };
 

--- a/packages/dtslint-runner/src/index.ts
+++ b/packages/dtslint-runner/src/index.ts
@@ -5,7 +5,7 @@ import yargs from "yargs";
 import { RunDTSLintOptions } from "./types";
 import { runDTSLint } from "./main";
 import { assertDefined, logUncaughtErrors } from "@definitelytyped/utils";
-import { defaultSourceRef } from "@definitelytyped/definitions-parser";
+import { sourceBranch } from "@definitelytyped/definitions-parser";
 
 export { runDTSLint, RunDTSLintOptions };
 
@@ -91,9 +91,9 @@ if (require.main === module) {
       },
       diffBase: {
         group: "git options",
-        description: "The base commit to diff against.",
+        description: "The base revision to diff against.",
         type: "string",
-        default: defaultSourceRef,
+        default: sourceBranch,
       },
     })
     .wrap(Math.min(yargs.terminalWidth(), 120))

--- a/packages/dtslint-runner/src/main.ts
+++ b/packages/dtslint-runner/src/main.ts
@@ -22,7 +22,6 @@ export async function runDTSLint({
   shard,
   childRestartTaskInterval,
   writeFailures,
-  noFetch,
   diffBase,
 }: RunDTSLintOptions) {
   let definitelyTypedPath;
@@ -44,7 +43,7 @@ export async function runDTSLint({
   const typesPath = joinPaths(definitelyTypedPath, "types");
 
   const { packageNames, dependents } = onlyRunAffectedPackages
-    ? await prepareAffectedPackages(definitelyTypedPath, noFetch, diffBase)
+    ? await prepareAffectedPackages(definitelyTypedPath, diffBase)
     : await prepareAllPackages(definitelyTypedPath, definitelyTypedAcquisition.kind === "clone");
 
   const allFailures: [string, string][] = [];

--- a/packages/dtslint-runner/src/main.ts
+++ b/packages/dtslint-runner/src/main.ts
@@ -22,6 +22,8 @@ export async function runDTSLint({
   shard,
   childRestartTaskInterval,
   writeFailures,
+  noFetch,
+  diffBase,
 }: RunDTSLintOptions) {
   let definitelyTypedPath;
   console.log("Node version: ", process.version);
@@ -42,7 +44,7 @@ export async function runDTSLint({
   const typesPath = joinPaths(definitelyTypedPath, "types");
 
   const { packageNames, dependents } = onlyRunAffectedPackages
-    ? await prepareAffectedPackages(definitelyTypedPath)
+    ? await prepareAffectedPackages(definitelyTypedPath, noFetch, diffBase)
     : await prepareAllPackages(definitelyTypedPath, definitelyTypedAcquisition.kind === "clone");
 
   const allFailures: [string, string][] = [];

--- a/packages/dtslint-runner/src/main.ts
+++ b/packages/dtslint-runner/src/main.ts
@@ -180,23 +180,23 @@ function getExpectedFailures(onlyRunAffectedPackages: boolean, dependents: Set<s
 
 async function cloneDefinitelyTyped(cwd: string, sha: string | undefined): Promise<void> {
   type Command = [string, string[]];
+
+  const cloneCmd: Command = [
+    "git",
+    ["clone", "--filter", "blob:none", "https://github.com/DefinitelyTyped/DefinitelyTyped.git"],
+  ];
+  console.log(`${cloneCmd[0]} ${cloneCmd[1].join(" ")}`);
+  await execAndThrowErrors(cloneCmd[0], cloneCmd[1], cwd);
+
   if (sha) {
-    const cmd: Command = ["git", ["init", "DefinitelyTyped"]];
-    console.log(`${cmd[0]} ${cmd[1].join(" ")}`);
-    await execAndThrowErrors(cmd[0], cmd[1], cwd);
     cwd = `${cwd}/DefinitelyTyped`;
-    const commands: Command[] = [
-      ["git", ["remote", "add", "origin", "https://github.com/DefinitelyTyped/DefinitelyTyped.git"]],
-      ["git", ["fetch", "origin", "master", "--depth", "50"]], // We can't clone the commit directly, so assume the commit is from
-      ["git", ["checkout", sha]], // recent history, pull down some recent commits, then check it out
-    ];
-    for (const cmd of commands) {
-      console.log(`${cmd[0]} ${cmd[1].join(" ")}`);
-      await execAndThrowErrors(cmd[0], cmd[1], cwd);
-    }
-  } else {
-    const cmd: Command = ["git", ["clone", "https://github.com/DefinitelyTyped/DefinitelyTyped.git", "--depth", "1"]];
-    console.log(`${cmd[0]} ${cmd[1].join(" ")}`);
-    await execAndThrowErrors(cmd[0], cmd[1], cwd);
+
+    const fetchCmd: Command = ["git", ["fetch", "origin", sha]];
+    console.log(`${fetchCmd[0]} ${fetchCmd[1].join(" ")}`);
+    await execAndThrowErrors(fetchCmd[0], fetchCmd[1], cwd);
+
+    const switchCmd: Command = ["git", ["switch", "--detach", "FETCH_HEAD"]];
+    console.log(`${switchCmd[0]} ${switchCmd[1].join(" ")}`);
+    await execAndThrowErrors(switchCmd[0], switchCmd[1], cwd);
   }
 }

--- a/packages/dtslint-runner/src/prepareAffectedPackages.ts
+++ b/packages/dtslint-runner/src/prepareAffectedPackages.ts
@@ -7,7 +7,7 @@ import {
 import { loggerWithErrors } from "@definitelytyped/utils";
 import { checkParseResults } from "./check-parse-results";
 
-export async function prepareAffectedPackages(definitelyTypedPath: string, noFetch: boolean, diffBase: string): Promise<PreparePackagesResult> {
+export async function prepareAffectedPackages(definitelyTypedPath: string, diffBase: string): Promise<PreparePackagesResult> {
   const log = loggerWithErrors()[0];
   const options = {
     definitelyTypedPath,
@@ -19,7 +19,7 @@ export async function prepareAffectedPackages(definitelyTypedPath: string, noFet
   if (checkErrors.length) {
     throw new Error(checkErrors.join("\n"));
   }
-  const result = await getAffectedPackagesFromDiff(allPackages, definitelyTypedPath, noFetch, diffBase);
+  const result = await getAffectedPackagesFromDiff(allPackages, definitelyTypedPath, diffBase);
   if (Array.isArray(result)) {
     throw new Error(result.join("\n"));
   }

--- a/packages/dtslint-runner/src/prepareAffectedPackages.ts
+++ b/packages/dtslint-runner/src/prepareAffectedPackages.ts
@@ -7,7 +7,10 @@ import {
 import { loggerWithErrors } from "@definitelytyped/utils";
 import { checkParseResults } from "./check-parse-results";
 
-export async function prepareAffectedPackages(definitelyTypedPath: string, diffBase: string): Promise<PreparePackagesResult> {
+export async function prepareAffectedPackages(
+  definitelyTypedPath: string,
+  diffBase: string,
+): Promise<PreparePackagesResult> {
   const log = loggerWithErrors()[0];
   const options = {
     definitelyTypedPath,

--- a/packages/dtslint-runner/src/prepareAffectedPackages.ts
+++ b/packages/dtslint-runner/src/prepareAffectedPackages.ts
@@ -7,7 +7,7 @@ import {
 import { loggerWithErrors } from "@definitelytyped/utils";
 import { checkParseResults } from "./check-parse-results";
 
-export async function prepareAffectedPackages(definitelyTypedPath: string): Promise<PreparePackagesResult> {
+export async function prepareAffectedPackages(definitelyTypedPath: string, noFetch: boolean, diffBase: string): Promise<PreparePackagesResult> {
   const log = loggerWithErrors()[0];
   const options = {
     definitelyTypedPath,
@@ -19,7 +19,7 @@ export async function prepareAffectedPackages(definitelyTypedPath: string): Prom
   if (checkErrors.length) {
     throw new Error(checkErrors.join("\n"));
   }
-  const result = await getAffectedPackagesFromDiff(allPackages, definitelyTypedPath);
+  const result = await getAffectedPackagesFromDiff(allPackages, definitelyTypedPath, noFetch, diffBase);
   if (Array.isArray(result)) {
     throw new Error(result.join("\n"));
   }

--- a/packages/dtslint-runner/src/types.ts
+++ b/packages/dtslint-runner/src/types.ts
@@ -20,6 +20,5 @@ export interface RunDTSLintOptions {
   shard?: { id: number; count: number };
   childRestartTaskInterval?: number;
   writeFailures?: string;
-  noFetch: boolean;
   diffBase: string;
 }

--- a/packages/dtslint-runner/src/types.ts
+++ b/packages/dtslint-runner/src/types.ts
@@ -20,4 +20,6 @@ export interface RunDTSLintOptions {
   shard?: { id: number; count: number };
   childRestartTaskInterval?: number;
   writeFailures?: string;
+  noFetch: boolean;
+  diffBase: string;
 }


### PR DESCRIPTION
Right now, dtslint-runner always diffs against `master`, fetching if not present. In CI, this causes problems because another user may have merged something to `master` just after the run has started; the view of `master` that CI has may not be the one that the PR's merge commit reflected, and so we'll attempt to run tests of packages that were not affected in the PR.

For `pnpm install`, I've already fixed this race by filtering to `...[HEAD^1]...`. Since PRs run in merge commits, `HEAD^1` (the first parent) is the base branch (master) and `HEAD^2` (the second parent) is the PR code from the user's fork. CI will have fetched these refs, so if we use these and never fetch, CI will always behave deterministically. The same applies to pushes to `master`; we squash commit so `HEAD^1` always points to the previous commit.

But, since these are mismatched, we still are hit by the race condition in dt-tools, which then _looks_ like package install failures because `pnpm` has already been updated to use `HEAD^1` and didn't over-install.

This PR adds a new flag, `--diffBase`, which tells dtslint-runner what to diff against. By default, it's `master`, but we can override it in CI to be `HEAD^1` where needed.

Fetching is removed, under the assumption that CI or a user will do that beforehand. I believe that this is more predictable, but, I'm open to feedback of course.