### PR TITLE
Prevent a crash on an empty commit

### DIFF
--- a/.changeset/empty-cups-invent.md
+++ b/.changeset/empty-cups-invent.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/definitions-parser": patch
+---
+
+Prevent crash on an empty commit


### PR DESCRIPTION
I'm effectively proposing we drop this code in #933, but this is a bug in the current code if we happen to merge an empty commit (which can happen if two identical PRs are merged, like the ghostbuster).