### PR TITLE
Generate module=node16 in dts-gen

### DIFF
--- a/.changeset/great-garlics-flash.md
+++ b/.changeset/great-garlics-flash.md
@@ -1,0 +1,5 @@
+---
+"dts-gen": minor
+---
+
+Generate module=node16 instead of commonjs

--- a/packages/dts-gen/src/definitely-typed.ts
+++ b/packages/dts-gen/src/definitely-typed.ts
@@ -50,7 +50,7 @@ async function run(indexDtsContent: string, packageName: string, dtName: string,
 function getTSConfig(dtName: string): {} {
   return {
     compilerOptions: {
-      module: "commonjs",
+      module: "node16",
       lib: ["es6"],
       noImplicitAny: true,
       noImplicitThis: true,


### PR DESCRIPTION
More or less goes with https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68529. Would be nice for people generating packages to start with node16.