### PR TITLE
Run arethetypeswrong from in-memory tarball data

### DIFF
--- a/.changeset/dull-pets-call.md
+++ b/.changeset/dull-pets-call.md
@@ -1,0 +1,6 @@
+---
+"@definitelytyped/dtslint": patch
+"@definitelytyped/utils": patch
+---
+
+Run arethetypeswrong from in-memory tarball data

--- a/packages/dtslint/package.json
+++ b/packages/dtslint/package.json
@@ -22,7 +22,7 @@
     "test": "../../node_modules/.bin/jest --config ../../jest.config.js packages/dtslint"
   },
   "dependencies": {
-    "@arethetypeswrong/cli": "^0.13.6",
+    "@arethetypeswrong/cli": "^0.13.7",
     "@arethetypeswrong/core": "^0.13.6",
     "@definitelytyped/header-parser": "workspace:*",
     "@definitelytyped/typescript-versions": "workspace:*",
@@ -36,9 +36,7 @@
     "eslint-plugin-import": "^2.29.1",
     "semver": "^7.5.4",
     "strip-json-comments": "^3.1.1",
-    "tar": "^6.2.0",
-    "tmp": "^0.2.1",
-    "which": "^4.0.0"
+    "tar": "^6.2.0"
   },
   "peerDependencies": {
     "typescript": ">= 3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.7.0-dev || >= 3.8.0-dev || >= 3.9.0-dev || >= 4.0.0-dev || >=5.0.0-dev"
@@ -48,8 +46,6 @@
     "@types/semver": "^7.5.5",
     "@types/strip-json-comments": "^3.0.0",
     "@types/tar": "^6.1.9",
-    "@types/tmp": "^0.2.6",
-    "@types/which": "^3.0.3",
     "typescript": "^5.3.3"
   },
   "engines": {

--- a/packages/dtslint/package.json
+++ b/packages/dtslint/package.json
@@ -22,8 +22,8 @@
     "test": "../../node_modules/.bin/jest --config ../../jest.config.js packages/dtslint"
   },
   "dependencies": {
-    "@arethetypeswrong/cli": "^0.13.7",
-    "@arethetypeswrong/core": "^0.13.6",
+    "@arethetypeswrong/cli": "0.13.8",
+    "@arethetypeswrong/core": "0.13.6",
     "@definitelytyped/header-parser": "workspace:*",
     "@definitelytyped/typescript-versions": "workspace:*",
     "@definitelytyped/utils": "workspace:*",

--- a/packages/dtslint/package.json
+++ b/packages/dtslint/package.json
@@ -35,8 +35,7 @@
     "eslint": "^8.56.0",
     "eslint-plugin-import": "^2.29.1",
     "semver": "^7.5.4",
-    "strip-json-comments": "^3.1.1",
-    "tar": "^6.2.0"
+    "strip-json-comments": "^3.1.1"
   },
   "peerDependencies": {
     "typescript": ">= 3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.7.0-dev || >= 3.8.0-dev || >= 3.9.0-dev || >= 4.0.0-dev || >=5.0.0-dev"
@@ -45,7 +44,6 @@
     "@types/eslint": "^8.56.2",
     "@types/semver": "^7.5.5",
     "@types/strip-json-comments": "^3.0.0",
-    "@types/tar": "^6.1.9",
     "typescript": "^5.3.3"
   },
   "engines": {

--- a/packages/dtslint/src/index.ts
+++ b/packages/dtslint/src/index.ts
@@ -200,7 +200,7 @@ async function runTests(
     const failingPackages = ((await readJson(attwJson)) as any).failingPackages;
     const dirName = dirPath.slice(dtRoot.length + "/types/".length);
     const expectError = !!failingPackages?.includes(dirName);
-    const attwResult = runAreTheTypesWrong(dirName, dirPath, implementationPackage.tarballPath, attwJson, expectError);
+    const attwResult = await runAreTheTypesWrong(dirName, dirPath, implementationPackage, attwJson, expectError);
     (warnings ??= []).push(...(attwResult.warnings ?? []));
     (errors ??= []).push(...(attwResult.errors ?? []));
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,10 +141,10 @@ importers:
   packages/dtslint:
     dependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.13.7
-        version: 0.13.7
+        specifier: 0.13.8
+        version: 0.13.8
       '@arethetypeswrong/core':
-        specifier: ^0.13.6
+        specifier: 0.13.6
         version: 0.13.6
       '@definitelytyped/header-parser':
         specifier: workspace:*
@@ -453,8 +453,8 @@ packages:
     resolution: {integrity: sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==}
     dev: false
 
-  /@arethetypeswrong/cli@0.13.7:
-    resolution: {integrity: sha512-zVoNiFfHH4bCHpdE2hZFgR0TNwYCvO8O+JmVL4dHvQfGE6LhsCGG4EnTVEd+7Z2nBBFiCXcCmEQCIiKTAs83bQ==}
+  /@arethetypeswrong/cli@0.13.8:
+    resolution: {integrity: sha512-tQCXVBLuSfFlXdQLl17ZlBuHB1zo03H7uTLDFumoOl/dibXw1osYJ+Fd9Oju34buFDzI1DuFS2vba/Bsk95E5Q==}
     engines: {node: '>=18'}
     hasBin: true
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,8 +141,8 @@ importers:
   packages/dtslint:
     dependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.13.6
-        version: 0.13.6
+        specifier: ^0.13.7
+        version: 0.13.7
       '@arethetypeswrong/core':
         specifier: ^0.13.6
         version: 0.13.6
@@ -185,12 +185,6 @@ importers:
       tar:
         specifier: ^6.2.0
         version: 6.2.0
-      tmp:
-        specifier: ^0.2.1
-        version: 0.2.1
-      which:
-        specifier: ^4.0.0
-        version: 4.0.0
     devDependencies:
       '@types/eslint':
         specifier: ^8.56.2
@@ -204,12 +198,6 @@ importers:
       '@types/tar':
         specifier: ^6.1.9
         version: 6.1.9
-      '@types/tmp':
-        specifier: ^0.2.6
-        version: 0.2.6
-      '@types/which':
-        specifier: ^3.0.3
-        version: 3.0.3
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
@@ -471,8 +459,8 @@ packages:
     resolution: {integrity: sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==}
     dev: false
 
-  /@arethetypeswrong/cli@0.13.6:
-    resolution: {integrity: sha512-rNiAcz/kLdqqfA3NvUjtLCPV933MEo+K5dMJDA7afdOPmH5iS13pCiZyeZ21MDBQrxMpx6t5G/7OyRf+OcsoPA==}
+  /@arethetypeswrong/cli@0.13.7:
+    resolution: {integrity: sha512-zVoNiFfHH4bCHpdE2hZFgR0TNwYCvO8O+JmVL4dHvQfGE6LhsCGG4EnTVEd+7Z2nBBFiCXcCmEQCIiKTAs83bQ==}
     engines: {node: '>=18'}
     hasBin: true
     dependencies:
@@ -2116,10 +2104,6 @@ packages:
     dependencies:
       '@types/node': 18.19.8
       minipass: 4.2.8
-    dev: true
-
-  /@types/tmp@0.2.6:
-    resolution: {integrity: sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==}
     dev: true
 
   /@types/which@3.0.3:
@@ -6874,13 +6858,6 @@ packages:
     dependencies:
       os-tmpdir: 1.0.2
     dev: true
-
-  /tmp@0.2.1:
-    resolution: {integrity: sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==}
-    engines: {node: '>=8.17.0'}
-    dependencies:
-      rimraf: 3.0.2
-    dev: false
 
   /tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,9 +182,6 @@ importers:
       strip-json-comments:
         specifier: ^3.1.1
         version: 3.1.1
-      tar:
-        specifier: ^6.2.0
-        version: 6.2.0
     devDependencies:
       '@types/eslint':
         specifier: ^8.56.2
@@ -195,9 +192,6 @@ importers:
       '@types/strip-json-comments':
         specifier: ^3.0.0
         version: 3.0.0
-      '@types/tar':
-        specifier: ^6.1.9
-        version: 6.1.9
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
@@ -2094,13 +2088,6 @@ packages:
 
   /@types/tar@6.1.10:
     resolution: {integrity: sha512-60ZO+W0tRKJ3ggdzJKp75xKVlNogKYMqGvr2bMH/+k3T0BagfYTnbmVDFMJB1BFttz6yRgP5MDGP27eh7brrqw==}
-    dependencies:
-      '@types/node': 18.19.8
-      minipass: 4.2.8
-    dev: true
-
-  /@types/tar@6.1.9:
-    resolution: {integrity: sha512-T3+O+OQd9cdGmOXuKQY9+B0ceZHRlGVPQ7M5QZqkaPyP/vWnxPXM2aCegq8GP/n1n9dBfq2EBUqCSKKjQAVOPA==}
     dependencies:
       '@types/node': 18.19.8
       minipass: 4.2.8


### PR DESCRIPTION
This should be a performance win, but is also preparation for fixing https://github.com/DefinitelyTyped/DefinitelyTyped/issues/67361 and bringing dts-critic suggestions back.