### PR TITLE
Add Reselect to the allowed list of external dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -833,6 +833,7 @@ redux-persist
 redux-saga
 redux-thunk
 remark
+reselect
 rimraf
 rollup
 rrule


### PR DESCRIPTION
This PR:

  - [X] Adds [Reselect](https://github.com/reduxjs/reselect) to the allowed list of external dependencies.
  
DefinitelyTyped PR that requires this change: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68578