### PR TITLE
Don’t crash when implementation package fails to extract

### DIFF
--- a/.changeset/little-timers-reflect.md
+++ b/.changeset/little-timers-reflect.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/dtslint": patch
+---
+
+Don’t crash when implementation package fails to extract

--- a/packages/dtslint/src/checks.ts
+++ b/packages/dtslint/src/checks.ts
@@ -275,7 +275,14 @@ export async function checkNpmVersionAndGetMatchingImplementationPackage(
             `that does not conflict with an existing npm package.`,
         );
       } else {
-        implementationPackage = await attw.createPackageFromTarballUrl(tarballUrl);
+        try {
+          implementationPackage = await attw.createPackageFromTarballUrl(tarballUrl);
+        } catch (err: any) {
+          (warnings ??= []).push(
+            `Failed to extract implementation package from ${tarballUrl}. This is likely a problem with @arethetypeswrong/core ` +
+            `or the tarball data itself. @arethetypeswrong/cli will not run. Error:\n${err.stack ?? err.message}`
+          );
+        }
       }
     }
   } else if (packageJson.nonNpm === "conflict") {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  fflate: '>=0.8.2'
   tough-cookie@<4.1.3: '>=4.1.3'
   semver@<5.7.2: '>=5.7.2'
   semver@>=6.0.0 <6.3.1: '>=6.3.1'
@@ -473,7 +472,7 @@ packages:
     engines: {node: '>=18'}
     dependencies:
       '@andrewbranch/untar.js': 1.0.3
-      fflate: 0.8.2
+      fflate: 0.7.4
       semver: 7.5.4
       ts-expose-internals-conditionally: 1.0.0-empty.0
       typescript: 5.3.3
@@ -3795,8 +3794,8 @@ packages:
         optional: true
     dev: true
 
-  /fflate@0.8.2:
-    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+  /fflate@0.7.4:
+    resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
     dev: false
 
   /file-entry-cache@6.0.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  fflate: '>=0.8.2'
   tough-cookie@<4.1.3: '>=4.1.3'
   semver@<5.7.2: '>=5.7.2'
   semver@>=6.0.0 <6.3.1: '>=6.3.1'
@@ -472,7 +473,7 @@ packages:
     engines: {node: '>=18'}
     dependencies:
       '@andrewbranch/untar.js': 1.0.3
-      fflate: 0.7.4
+      fflate: 0.8.2
       semver: 7.5.4
       ts-expose-internals-conditionally: 1.0.0-empty.0
       typescript: 5.3.3
@@ -3794,8 +3795,8 @@ packages:
         optional: true
     dev: true
 
-  /fflate@0.7.4:
-    resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
+  /fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
     dev: false
 
   /file-entry-cache@6.0.1:


### PR DESCRIPTION
Example output:

```
❯ pnpm test optimist
Debugger attached.

> definitely-typed@0.0.3 test /Users/andrew/Developer/microsoft/DefinitelyTyped
> node --enable-source-maps node_modules/@definitelytyped/dtslint/ types "optimist"

Debugger attached.
dtslint@0.2.7

Warnings:

Failed to extract implementation package from https://registry.npmjs.org/optimist/-/optimist-0.0.7.tgz. This is likely a problem with @arethetypeswrong/core or the tarball data itself. @arethetypeswrong/cli will not run. Error:
SyntaxError: Expected double-quoted property name in JSON at position 207
    at JSON.parse (<anonymous>)
    at extractTarball (/Users/andrew/Developer/microsoft/DefinitelyTyped-tools/node_modules/.pnpm/@arethetypeswrong+core@0.13.6/node_modules/@arethetypeswrong/core/src/createPackage.ts:285:28)
    at Module.createPackageFromTarballUrl (/Users/andrew/Developer/microsoft/DefinitelyTyped-tools/node_modules/.pnpm/@arethetypeswrong+core@0.13.6/node_modules/@arethetypeswrong/core/src/createPackage.ts:268:50)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at checkNpmVersionAndGetMatchingImplementationPackage (/Users/andrew/Developer/microsoft/DefinitelyTyped-tools/packages/dtslint/src/checks.ts:279:35)
    at runTests (/Users/andrew/Developer/microsoft/DefinitelyTyped-tools/packages/dtslint/src/index.ts:185:52)
    at main (/Users/andrew/Developer/microsoft/DefinitelyTyped-tools/packages/dtslint/src/index.ts:103:22)
```