### PR TITLE
Rework error collection, error if tslint.json is present

### DIFF
--- a/.changeset/chatty-jobs-pull.md
+++ b/.changeset/chatty-jobs-pull.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/dtslint": patch
+---
+
+Rework error collection

--- a/.changeset/fifty-points-eat.md
+++ b/.changeset/fifty-points-eat.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/dtslint": patch
+---
+
+Error if tslint.json is present

--- a/packages/dtslint/src/checks.ts
+++ b/packages/dtslint/src/checks.ts
@@ -165,11 +165,11 @@ export async function runAreTheTypesWrong(
   configPath: string,
   expectError: boolean,
 ): Promise<{
-  warnings?: string[];
-  errors?: string[];
+  warnings: string[];
+  errors: string[];
 }> {
-  let warnings: string[] | undefined;
-  let errors: string[] | undefined;
+  const warnings = [];
+  const errors = [];
   let result: {
     status: "pass" | "fail" | "error";
     output: string;
@@ -207,12 +207,12 @@ export async function runAreTheTypesWrong(
         break;
       case "fail":
         // Show output without failing the build.
-        (warnings ??= []).push(
+        warnings.push(
           `Ignoring attw failure because "${dirName}" is listed in 'failingPackages'.\n\n@arethetypeswrong/cli\n${output}`,
         );
         break;
       case "pass":
-        (errors ??= []).push(`attw passed: remove "${dirName}" from 'failingPackages' in attw.json\n\n${output}`);
+        errors.push(`attw passed: remove "${dirName}" from 'failingPackages' in attw.json\n\n${output}`);
         break;
       default:
         assertNever(status);
@@ -221,7 +221,7 @@ export async function runAreTheTypesWrong(
     switch (status) {
       case "error":
       case "fail":
-        (errors ??= []).push(`!@arethetypeswrong/cli\n${output}`);
+        errors.push(`!@arethetypeswrong/cli\n${output}`);
         break;
       case "pass":
         // Don't show anything for passing attw - most lint rules have no output on success.
@@ -236,12 +236,12 @@ export async function checkNpmVersionAndGetMatchingImplementationPackage(
   packageJson: header.Header,
   packageDirectoryNameWithVersion: string,
 ): Promise<{
-  warnings?: string[];
-  errors?: string[];
+  warnings: string[];
+  errors: string[];
   implementationPackage?: attw.Package;
 }> {
-  let warnings: string[] | undefined;
-  let errors: string[] | undefined;
+  const warnings: string[] = []
+  const errors: string[] = [];
   let hasNpmVersionMismatch = false;
   let implementationPackage;
   const attw = await import("@arethetypeswrong/core");
@@ -252,7 +252,7 @@ export async function checkNpmVersionAndGetMatchingImplementationPackage(
   if (packageId) {
     const { packageName, packageVersion, tarballUrl } = packageId;
     if (packageJson.nonNpm === true) {
-      (errors ??= []).push(
+      errors.push(
         `Package ${packageJson.name} is marked as non-npm, but ${packageName} exists on npm. ` +
           `If these types are being added to DefinitelyTyped for the first time, please choose ` +
           `a different name that does not conflict with an existing npm package.`,
@@ -261,7 +261,7 @@ export async function checkNpmVersionAndGetMatchingImplementationPackage(
       if (!satisfies(packageVersion, typesPackageVersion)) {
         hasNpmVersionMismatch = true;
         const isError = !npmVersionExemptions.has(packageDirectoryNameWithVersion);
-        const container = isError ? (errors ??= []) : (warnings ??= []);
+        const container = isError ? errors : warnings;
         container.push(
           (isError
             ? ""
@@ -279,12 +279,12 @@ export async function checkNpmVersionAndGetMatchingImplementationPackage(
       }
     }
   } else if (packageJson.nonNpm === "conflict") {
-    (errors ??= []).push(
+    errors.push(
       `Package ${packageJson.name} is marked as \`"nonNpm": "conflict"\`, but no conflicting package name was ` +
         `found on npm. These non-npm types can be makred as \`"nonNpm": true\` instead.`,
     );
   } else if (!packageJson.nonNpm) {
-    (errors ??= []).push(
+    errors.push(
       `Package ${packageJson.name} is not marked as non-npm, but no implementation package was found on npm. ` +
         `If these types are not for an npm package, please add \`"nonNpm": true\` to the package.json. ` +
         `Otherwise, ensure the name of this package matches the name of the npm package.`,
@@ -292,7 +292,7 @@ export async function checkNpmVersionAndGetMatchingImplementationPackage(
   }
 
   if (!hasNpmVersionMismatch && npmVersionExemptions.has(packageDirectoryNameWithVersion)) {
-    (warnings ??= []).push(
+    warnings.push(
       `${packageDirectoryNameWithVersion} can be removed from expectedNpmVersionFailures.txt in https://github.com/microsoft/DefinitelyTyped-tools/blob/main/packages/dtslint.`,
     );
   }

--- a/packages/dtslint/src/checks.ts
+++ b/packages/dtslint/src/checks.ts
@@ -240,7 +240,7 @@ export async function checkNpmVersionAndGetMatchingImplementationPackage(
   errors: string[];
   implementationPackage?: attw.Package;
 }> {
-  const warnings: string[] = []
+  const warnings: string[] = [];
   const errors: string[] = [];
   let hasNpmVersionMismatch = false;
   let implementationPackage;
@@ -278,7 +278,7 @@ export async function checkNpmVersionAndGetMatchingImplementationPackage(
         try {
           implementationPackage = await attw.createPackageFromTarballUrl(tarballUrl);
         } catch (err: any) {
-          (warnings ??= []).push(
+          warnings.push(
             `Failed to extract implementation package from ${tarballUrl}. This is likely a problem with @arethetypeswrong/core ` +
               `or the tarball data itself. @arethetypeswrong/cli will not run. Error:\n${err.stack ?? err.message}`,
           );

--- a/packages/dtslint/src/index.ts
+++ b/packages/dtslint/src/index.ts
@@ -379,5 +379,11 @@ function checkExpectedFiles(dirPath: string, isLatest: boolean): { errors: strin
     errors.push(`${dirPath}: Must contain 'index.d.ts'.`);
   }
 
+  if (fs.existsSync(joinPaths(dirPath, "tslint.json"))) {
+    errors.push(
+      `${dirPath}: Should not contain 'tslint.json'. This file is no longer required; place all lint-related options into .eslintrc.json.`,
+    );
+  }
+
   return { errors };
 }

--- a/packages/dtslint/src/index.ts
+++ b/packages/dtslint/src/index.ts
@@ -156,7 +156,7 @@ async function runTests(
   expectOnly: boolean,
   npmChecks: boolean | "only",
   tsLocal: string | undefined,
-): Promise<string | undefined> {
+): Promise<string> {
   // Assert that we're really on DefinitelyTyped.
   const dtRoot = findDTRoot(dirPath);
   const packageName = packageNameFromPath(dirPath);
@@ -174,25 +174,34 @@ async function runTests(
     throw new Error("\n\t* " + packageJson.join("\n\t* "));
   }
 
-  await assertNpmIgnoreExpected(dirPath);
-  assertNoOtherFiles(dirPath);
+  const warnings: string[] = [];
+  const errors: string[] = [];
 
   let implementationPackage;
-  let warnings: string[] | undefined;
-  let errors: string[] | undefined;
-
   if (npmChecks) {
-    ({ implementationPackage, warnings, errors } = await checkNpmVersionAndGetMatchingImplementationPackage(
+    const result = await checkNpmVersionAndGetMatchingImplementationPackage(
       packageJson,
       packageDirectoryNameWithVersion,
-    ));
+    );
+
+    implementationPackage = result.implementationPackage;
+    warnings.push(...result.warnings);
+    errors.push(...result.errors);
   }
 
   if (npmChecks !== "only") {
     const minVersion = maxVersion(packageJson.minimumTypeScriptVersion, TypeScriptVersion.lowest);
     if (onlyTestTsNext || tsLocal) {
       const tsVersion = tsLocal ? "local" : TypeScriptVersion.latest;
-      await testTypesVersion(dirPath, tsVersion, tsVersion, expectOnly, tsLocal, /*isLatest*/ true);
+      const testTypesResult = await testTypesVersion(
+        dirPath,
+        tsVersion,
+        tsVersion,
+        expectOnly,
+        tsLocal,
+        /*isLatest*/ true,
+      );
+      errors.push(...testTypesResult.errors);
     } else {
       // For example, typesVersions of [3.2, 3.5, 3.6] will have
       // associated ts3.2, ts3.5, ts3.6 directories, for
@@ -213,7 +222,8 @@ async function runTests(
         if (lows.length > 1) {
           console.log("testing from", low, "to", hi, "in", versionPath);
         }
-        await testTypesVersion(versionPath, low, hi, expectOnly, undefined, isLatest);
+        const testTypesResult = await testTypesVersion(versionPath, low, hi, expectOnly, undefined, isLatest);
+        errors.push(...testTypesResult.errors);
       }
     }
   }
@@ -224,8 +234,8 @@ async function runTests(
     const dirName = dirPath.slice(dtRoot.length + "/types/".length);
     const expectError = !!failingPackages?.includes(dirName);
     const attwResult = await runAreTheTypesWrong(dirName, dirPath, implementationPackage, attwJson, expectError);
-    (warnings ??= []).push(...(attwResult.warnings ?? []));
-    (errors ??= []).push(...(attwResult.errors ?? []));
+    warnings.push(...attwResult.warnings);
+    errors.push(...attwResult.errors);
   }
 
   const result = combineErrorsAndWarnings(errors, warnings);
@@ -235,15 +245,9 @@ async function runTests(
   return result;
 }
 
-function combineErrorsAndWarnings(
-  errors: string[] | undefined,
-  warnings: string[] | undefined,
-): Error | string | undefined {
-  if (!errors && !warnings) {
-    return undefined;
-  }
-  const message = (errors ?? []).concat(warnings ?? []).join("\n\n");
-  return errors?.length ? new Error(message) : message;
+function combineErrorsAndWarnings(errors: string[], warnings: string[]): Error | string {
+  const message = errors.concat(warnings).join("\n\n");
+  return errors.length ? new Error(message) : message;
 }
 
 function maxVersion(v1: AllTypeScriptVersion, v2: TypeScriptVersion): TypeScriptVersion {
@@ -265,16 +269,19 @@ async function testTypesVersion(
   expectOnly: boolean,
   tsLocal: string | undefined,
   isLatest: boolean,
-): Promise<void> {
-  assertIndexdts(dirPath);
+): Promise<{ errors: string[] }> {
+  const errors = [];
+  const checkExpectedFilesResult = checkExpectedFiles(dirPath, isLatest);
+  errors.push(...checkExpectedFilesResult.errors);
   const tsconfigErrors = checkTsconfig(dirPath, getCompilerOptions(dirPath));
   if (tsconfigErrors.length > 0) {
-    throw new Error("\n\t* " + tsconfigErrors.join("\n\t* "));
+    errors.push("\n\t* " + tsconfigErrors.join("\n\t* "));
   }
   const err = await lint(dirPath, lowVersion, hiVersion, isLatest, expectOnly, tsLocal);
   if (err) {
-    throw new Error(err);
+    errors.push(err);
   }
+  return { errors };
 }
 
 function findDTRoot(dirPath: string) {
@@ -336,42 +343,41 @@ if (require.main === module) {
   });
 }
 
-async function assertNpmIgnoreExpected(dirPath: string) {
-  const expected = ["*", "!**/*.d.ts", "!**/*.d.cts", "!**/*.d.mts", "!**/*.d.*.ts"];
+function checkExpectedFiles(dirPath: string, isLatest: boolean): { errors: string[] } {
+  const errors = [];
 
-  if (basename(dirname(dirPath)) === "types") {
-    for (const subdir of fs.readdirSync(dirPath, { withFileTypes: true })) {
-      if (subdir.isDirectory() && /^v(\d+)(\.(\d+))?$/.test(subdir.name)) {
-        expected.push(`/${subdir.name}/`);
+  if (isLatest) {
+    const expectedNpmIgnore = ["*", "!**/*.d.ts", "!**/*.d.cts", "!**/*.d.mts", "!**/*.d.*.ts"];
+
+    if (basename(dirname(dirPath)) === "types") {
+      for (const subdir of fs.readdirSync(dirPath, { withFileTypes: true })) {
+        if (subdir.isDirectory() && /^v(\d+)(\.(\d+))?$/.test(subdir.name)) {
+          expectedNpmIgnore.push(`/${subdir.name}/`);
+        }
       }
+    }
+
+    const expectedNpmIgnoreAsString = expectedNpmIgnore.join("\n");
+    const npmIgnorePath = joinPaths(dirPath, ".npmignore");
+    if (!fs.existsSync(npmIgnorePath)) {
+      errors.push(`${dirPath}: Missing '.npmignore'; should contain:\n${expectedNpmIgnoreAsString}`);
+    }
+
+    const actualNpmIgnore = fs.readFileSync(npmIgnorePath, "utf-8").trim().split(/\r?\n/);
+    if (!deepEquals(actualNpmIgnore, expectedNpmIgnore)) {
+      errors.push(`${dirPath}: Incorrect '.npmignore'; should be:\n${expectedNpmIgnoreAsString}`);
+    }
+
+    if (fs.existsSync(joinPaths(dirPath, "OTHER_FILES.txt"))) {
+      errors.push(
+        `${dirPath}: Should not contain 'OTHER_FILES.txt'. All files matching "**/*.d.{ts,cts,mts,*.ts}" are automatically included.`,
+      );
     }
   }
 
-  const expectedString = expected.join("\n");
-
-  const npmIgnorePath = joinPaths(dirPath, ".npmignore");
-  if (!fs.existsSync(npmIgnorePath)) {
-    throw new Error(`${dirPath}: Missing '.npmignore'; should contain:\n${expectedString}`);
-  }
-
-  const actualRaw = await fs.promises.readFile(npmIgnorePath, "utf-8");
-  const actual = actualRaw.trim().split(/\r?\n/);
-
-  if (!deepEquals(actual, expected)) {
-    throw new Error(`${dirPath}: Incorrect '.npmignore'; should be:\n${expectedString}`);
-  }
-}
-
-function assertNoOtherFiles(dirPath: string) {
-  if (fs.existsSync(joinPaths(dirPath, "OTHER_FILES.txt"))) {
-    throw new Error(
-      `${dirPath}: Should not contain 'OTHER_FILES.txt'. All files matching "**/*.d.{ts,cts,mts,*.ts}" are automatically included.`,
-    );
-  }
-}
-
-function assertIndexdts(dirPath: string) {
   if (!fs.existsSync(joinPaths(dirPath, "index.d.ts"))) {
-    throw new Error(`${dirPath}: Must contain 'index.d.ts'.`);
+    errors.push(`${dirPath}: Must contain 'index.d.ts'.`);
   }
+
+  return { errors };
 }


### PR DESCRIPTION
This is a noisy change; meant to just send the PR to error if tslint.json is present, but found myself changing a few other things to prevent dtslint from bailing early for simple problems like "npmignore is wrong" or "OTHER_FILES.txt or tslint.json is present".

We'll now not bail out early on errors, e.g. 

putting some random garbage in a dts file in a types version dir:

```
dtslint@0.2.7
testing from 4.6 to 4.8 in /home/jabaile/work/DefinitelyTyped/types/node/ts4.8
testing from 4.9 to 5.4 in /home/jabaile/work/DefinitelyTyped/types/node
Error: 
/home/jabaile/work/DefinitelyTyped/types/node/ts4.8/cluster.d.ts
  433:1  error  TypeScript@4.6, 4.7, 4.8 compile error: 
Statements are not allowed in ambient contexts  @definitelytyped/expect
  433:1  error  TypeScript@4.6, 4.7, 4.8 compile error: 
Cannot find name 'asdagnsdogsdf'                @definitelytyped/expect

✖ 2 problems (2 errors, 0 warnings)

    at combineErrorsAndWarnings (/home/jabaile/work/DefinitelyTyped-tools/packages/dtslint/src/index.ts:250:26)
    at runTests (/home/jabaile/work/DefinitelyTyped-tools/packages/dtslint/src/index.ts:241:18)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at main (/home/jabaile/work/DefinitelyTyped-tools/packages/dtslint/src/index.ts:103:22)
 ELIFECYCLE  Test failed. See above for more details.
```

Then with the new error about having a `tslint.json`:

```
dtslint@0.2.7
testing from 4.6 to 4.8 in /home/jabaile/work/DefinitelyTyped/types/node/ts4.8
testing from 4.9 to 5.4 in /home/jabaile/work/DefinitelyTyped/types/node
Error: /home/jabaile/work/DefinitelyTyped/types/node/ts4.8: Should not contain 'tslint.json'. This file is no longer required; place all lint-related options into .eslintrc.json.
    at combineErrorsAndWarnings (/home/jabaile/work/DefinitelyTyped-tools/packages/dtslint/src/index.ts:250:26)
    at runTests (/home/jabaile/work/DefinitelyTyped-tools/packages/dtslint/src/index.ts:241:18)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at main (/home/jabaile/work/DefinitelyTyped-tools/packages/dtslint/src/index.ts:103:22)
```

Perhaps not bailing out early is unwise; before, if there were errors, we would effectively skip ATTW. Maybe I should just make it not run ATTW if there are preceding errors?