### PR TITLE
fix: remove `aws-lambda` from expected npm version failures

### DIFF
--- a/.changeset/eleven-emus-warn.md
+++ b/.changeset/eleven-emus-warn.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/dtslint": patch
+---
+
+remove `aws-lambda` from expected npm version failures

--- a/packages/dtslint/expectedNpmVersionFailures.txt
+++ b/packages/dtslint/expectedNpmVersionFailures.txt
@@ -37,7 +37,6 @@ async-retry
 atlaskit__layer
 atmosphere.js
 atpl
-aws-lambda
 azdata
 azure-sb
 babel-types


### PR DESCRIPTION
See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68667 - I think I'm doing this right...