### PR TITLE
Don't complain about 'export import =' in strict-export-declare-modifiers

### DIFF
--- a/.changeset/quiet-flies-develop.md
+++ b/.changeset/quiet-flies-develop.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/eslint-plugin": patch
+---
+
+Don't complain about 'export import =' in strict-export-declare-modifiers

--- a/packages/eslint-plugin/src/rules/strict-export-declare-modifiers.ts
+++ b/packages/eslint-plugin/src/rules/strict-export-declare-modifiers.ts
@@ -129,7 +129,12 @@ const rule = createRule({
     function checkBlock(block: ts.ModuleBlock, autoExportEnabled: boolean): void {
       for (const statement of block.statements) {
         // Compiler will error for 'declare' here anyway, so just check for 'export'.
-        if (isExport(statement) && autoExportEnabled && !isDefault(statement)) {
+        if (
+          !ts.isImportEqualsDeclaration(statement) &&
+          isExport(statement) &&
+          autoExportEnabled &&
+          !isDefault(statement)
+        ) {
           context.report({
             loc: getModifierLoc(statement as ts.HasModifiers, ts.SyntaxKind.ExportKeyword),
             messageId: "redundantExport",

--- a/packages/eslint-plugin/test/__file_snapshots__/types/strict-export-declare-modifiers/good10.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/strict-export-declare-modifiers/good10.d.ts.lint
@@ -1,7 +1,4 @@
-types/strict-export-declare-modifiers/good10.d.ts
-  4:5  error  'export' keyword is redundant here because all declarations in this module are exported automatically. If you have a good reason to export some declarations and not others, add 'export {}' to the module to shut off automatic exporting  @definitelytyped/strict-export-declare-modifiers
-
-✖ 1 problem (1 error, 0 warnings)
+No errors
 
 ==== types/strict-export-declare-modifiers/good10.d.ts ====
 
@@ -9,8 +6,6 @@ types/strict-export-declare-modifiers/good10.d.ts
     
     export namespace Foo {
         export import C = good1.C;
-        ~~~~~~
-!!! @definitelytyped/strict-export-declare-modifiers: 'export' keyword is redundant here because all declarations in this module are exported automatically. If you have a good reason to export some declarations and not others, add 'export {}' to the module to shut off automatic exporting.
     
         const foo: number;
     }

--- a/packages/eslint-plugin/test/__file_snapshots__/types/strict-export-declare-modifiers/good10.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/strict-export-declare-modifiers/good10.d.ts.lint
@@ -1,0 +1,16 @@
+types/strict-export-declare-modifiers/good10.d.ts
+  4:5  error  'export' keyword is redundant here because all declarations in this module are exported automatically. If you have a good reason to export some declarations and not others, add 'export {}' to the module to shut off automatic exporting  @definitelytyped/strict-export-declare-modifiers
+
+✖ 1 problem (1 error, 0 warnings)
+
+==== types/strict-export-declare-modifiers/good10.d.ts ====
+
+    import * as good1 from './good1';
+    
+    export namespace Foo {
+        export import C = good1.C;
+        ~~~~~~
+!!! @definitelytyped/strict-export-declare-modifiers: 'export' keyword is redundant here because all declarations in this module are exported automatically. If you have a good reason to export some declarations and not others, add 'export {}' to the module to shut off automatic exporting.
+    
+        const foo: number;
+    }

--- a/packages/eslint-plugin/test/fixtures/types/strict-export-declare-modifiers/good10.d.ts
+++ b/packages/eslint-plugin/test/fixtures/types/strict-export-declare-modifiers/good10.d.ts
@@ -1,0 +1,7 @@
+import * as good1 from './good1';
+
+export namespace Foo {
+    export import C = good1.C;
+
+    const foo: number;
+}

--- a/packages/eslint-plugin/test/fixtures/types/strict-export-declare-modifiers/tsconfig.json
+++ b/packages/eslint-plugin/test/fixtures/types/strict-export-declare-modifiers/tsconfig.json
@@ -23,6 +23,7 @@
         "good7.d.ts",
         "good8.d.ts",
         "good9.d.ts",
+        "good10.d.ts",
         "bad1.d.ts",
         "bad2.d.ts",
         "bad3.d.ts",


### PR DESCRIPTION
Motivated by:

```ts
import implementation = require("./implementation");
import polyfill = require("./polyfill");
import shim = require("./shim");

type Implementation = typeof implementation;
type Polyfill = typeof polyfill;
type Shim = typeof shim;

declare namespace index {
    export import Flags = implementation.Flags;

    const implementation: Implementation;
    const polyfill: Polyfill;
    const shim: Shim;
}

declare function index(re: ThisParameterType<Implementation>): implementation.Flags;

export = index;
```

This errors on the export even though it's required to get the right behavior and also _does not_ make all of the other namespace members unexported.