### PR TITLE
Error on unused vars in declaration files

### DIFF
--- a/.changeset/popular-mangos-run.md
+++ b/.changeset/popular-mangos-run.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/eslint-plugin": patch
+---
+
+Error on unused vars in declaration files

--- a/packages/eslint-plugin/src/configs/all.ts
+++ b/packages/eslint-plugin/src/configs/all.ts
@@ -185,5 +185,11 @@ export const all: Linter.BaseConfig = {
         ],
       },
     },
+    {
+      files: ["*.d.cts", "*.d.mts", "*.d.ts", "*.d.*.ts"],
+      rules: {
+        "@typescript-eslint/no-unused-vars": ["error"],
+      },
+    },
   ],
 };

--- a/packages/eslint-plugin/test/__file_snapshots__/types/export-just-namespace/bad3.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/export-just-namespace/bad3.d.ts.lint
@@ -1,12 +1,15 @@
 types/export-just-namespace/bad3.d.ts
+  2:7  error  'other' is assigned a value but never used                                               @typescript-eslint/no-unused-vars
   3:1  error  Instead of `export =`-ing a namespace, use the body of the namespace as the module body  @definitelytyped/export-just-namespace
 
-✖ 1 problem (1 error, 0 warnings)
+✖ 2 problems (2 errors, 0 warnings)
 
 ==== types/export-just-namespace/bad3.d.ts ====
 
     namespace Stuff {}
     const other = "code";
+          ~~~~~
+!!! @typescript-eslint/no-unused-vars: 'other' is assigned a value but never used.
     export = Stuff;
     ~~~~~~~~~~~~~~~
 !!! @definitelytyped/export-just-namespace: Instead of `export =`-ing a namespace, use the body of the namespace as the module body.

--- a/packages/eslint-plugin/test/__file_snapshots__/types/export-just-namespace/good3.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/export-just-namespace/good3.d.ts.lint
@@ -1,5 +1,10 @@
-No errors
+types/export-just-namespace/good3.d.ts
+  1:13  error  'fs' is defined but never used  @typescript-eslint/no-unused-vars
+
+✖ 1 problem (1 error, 0 warnings)
 
 ==== types/export-just-namespace/good3.d.ts ====
 
     import * as fs from "fs";
+                ~~
+!!! @typescript-eslint/no-unused-vars: 'fs' is defined but never used.

--- a/packages/eslint-plugin/test/__file_snapshots__/types/export-just-namespace/good4.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/export-just-namespace/good4.d.ts.lint
@@ -1,5 +1,10 @@
-No errors
+types/export-just-namespace/good4.d.ts
+  1:7  error  'value' is assigned a value but never used  @typescript-eslint/no-unused-vars
+
+✖ 1 problem (1 error, 0 warnings)
 
 ==== types/export-just-namespace/good4.d.ts ====
 
     const value = 123;
+          ~~~~~
+!!! @typescript-eslint/no-unused-vars: 'value' is assigned a value but never used.

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-bad-reference/v0.1/index.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-bad-reference/v0.1/index.d.ts.lint
@@ -4,13 +4,20 @@ types/no-bad-reference/v0.1/index.d.ts
    2:22  error  The reference "../v1/index.d.ts" resolves outside of the package. Use a global reference to reference other packages           @definitelytyped/no-bad-reference
    3:22  error  The reference "../../foo/v0.1/index.d.ts" resolves outside of the package. Use a global reference to reference other packages  @definitelytyped/no-bad-reference
    4:22  error  The reference "../index.d.ts" resolves outside of the package. Use a global reference to reference other packages              @definitelytyped/no-bad-reference
+   6:13  error  'foo' is defined but never used                                                                                                @typescript-eslint/no-unused-vars
    6:22  error  The import "../../foo" resolves outside of the package. Use a bare import to reference other packages                          @definitelytyped/no-bad-reference
+   7:13  error  'foo2' is defined but never used                                                                                               @typescript-eslint/no-unused-vars
    7:23  error  The import "../v0.1" resolves to the current package, but uses relative paths                                                  @definitelytyped/no-bad-reference
+   8:13  error  'foo3' is defined but never used                                                                                               @typescript-eslint/no-unused-vars
    8:23  error  The import "../../foo/v0.1" resolves outside of the package. Use a bare import to reference other packages                     @definitelytyped/no-bad-reference
+   9:13  error  'va4' is defined but never used                                                                                                @typescript-eslint/no-unused-vars
    9:22  error  The import "../index" resolves outside of the package. Use a bare import to reference other packages                           @definitelytyped/no-bad-reference
+  12:10  error  'A' is defined but never used                                                                                                  @typescript-eslint/no-unused-vars
+  13:10  error  'B' is defined but never used                                                                                                  @typescript-eslint/no-unused-vars
+  14:10  error  'C' is defined but never used                                                                                                  @typescript-eslint/no-unused-vars
   14:22  error  The import "../index" resolves outside of the package. Use a bare import to reference other packages                           @definitelytyped/no-bad-reference
 
-✖ 10 problems (10 errors, 0 warnings)
+✖ 17 problems (17 errors, 0 warnings)
 
 ==== types/no-bad-reference/v0.1/index.d.ts ====
 
@@ -30,22 +37,36 @@ types/no-bad-reference/v0.1/index.d.ts
 !!! @definitelytyped/no-bad-reference: The reference "../index.d.ts" resolves outside of the package. Use a global reference to reference other packages.
     
     import * as foo from "../../foo";
+                ~~~
+!!! @typescript-eslint/no-unused-vars: 'foo' is defined but never used.
                          ~~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../../foo" resolves outside of the package. Use a bare import to reference other packages.
     import * as foo2 from "../v0.1";
+                ~~~~
+!!! @typescript-eslint/no-unused-vars: 'foo2' is defined but never used.
                           ~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../v0.1" resolves to the current package, but uses relative paths.
     import * as foo3 from "../../foo/v0.1";
+                ~~~~
+!!! @typescript-eslint/no-unused-vars: 'foo3' is defined but never used.
                           ~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../../foo/v0.1" resolves outside of the package. Use a bare import to reference other packages.
     import * as va4 from "../index";
+                ~~~
+!!! @typescript-eslint/no-unused-vars: 'va4' is defined but never used.
                          ~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../index" resolves outside of the package. Use a bare import to reference other packages.
     
     declare module "no-relative-references" {
       import A = require("no-relative-references/blah"); // Okay; relative
+             ~
+!!! @typescript-eslint/no-unused-vars: 'A' is defined but never used.
       import B = require("no-relative-references/v0.1"); // Okay; no versioned dir here
+             ~
+!!! @typescript-eslint/no-unused-vars: 'B' is defined but never used.
       import C = require("../index"); // Bad; parent dir
+             ~
+!!! @typescript-eslint/no-unused-vars: 'C' is defined but never used.
                          ~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../index" resolves outside of the package. Use a bare import to reference other packages.
     }

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-bad-reference/v11/index.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-bad-reference/v11/index.d.ts.lint
@@ -4,13 +4,20 @@ types/no-bad-reference/v11/index.d.ts
    2:22  error  The reference "../v11/index.d.ts" resolves to the current package, but uses relative paths                                   @definitelytyped/no-bad-reference
    3:22  error  The reference "../../foo/v1/index.d.ts" resolves outside of the package. Use a global reference to reference other packages  @definitelytyped/no-bad-reference
    4:22  error  The reference "../index.d.ts" resolves outside of the package. Use a global reference to reference other packages            @definitelytyped/no-bad-reference
+   6:13  error  'foo' is defined but never used                                                                                              @typescript-eslint/no-unused-vars
    6:22  error  The import "../../foo" resolves outside of the package. Use a bare import to reference other packages                        @definitelytyped/no-bad-reference
+   7:13  error  'foo2' is defined but never used                                                                                             @typescript-eslint/no-unused-vars
    7:23  error  The import "../v11" resolves to the current package, but uses relative paths                                                 @definitelytyped/no-bad-reference
+   8:13  error  'foo3' is defined but never used                                                                                             @typescript-eslint/no-unused-vars
    8:23  error  The import "../../foo/v11" resolves outside of the package. Use a bare import to reference other packages                    @definitelytyped/no-bad-reference
+   9:13  error  'va4' is defined but never used                                                                                              @typescript-eslint/no-unused-vars
    9:22  error  The import "../index" resolves outside of the package. Use a bare import to reference other packages                         @definitelytyped/no-bad-reference
+  12:10  error  'A' is defined but never used                                                                                                @typescript-eslint/no-unused-vars
+  13:10  error  'B' is defined but never used                                                                                                @typescript-eslint/no-unused-vars
+  14:10  error  'C' is defined but never used                                                                                                @typescript-eslint/no-unused-vars
   14:22  error  The import "../index" resolves outside of the package. Use a bare import to reference other packages                         @definitelytyped/no-bad-reference
 
-✖ 10 problems (10 errors, 0 warnings)
+✖ 17 problems (17 errors, 0 warnings)
 
 ==== types/no-bad-reference/v11/index.d.ts ====
 
@@ -30,22 +37,36 @@ types/no-bad-reference/v11/index.d.ts
 !!! @definitelytyped/no-bad-reference: The reference "../index.d.ts" resolves outside of the package. Use a global reference to reference other packages.
     
     import * as foo from "../../foo";
+                ~~~
+!!! @typescript-eslint/no-unused-vars: 'foo' is defined but never used.
                          ~~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../../foo" resolves outside of the package. Use a bare import to reference other packages.
     import * as foo2 from "../v11";
+                ~~~~
+!!! @typescript-eslint/no-unused-vars: 'foo2' is defined but never used.
                           ~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../v11" resolves to the current package, but uses relative paths.
     import * as foo3 from "../../foo/v11";
+                ~~~~
+!!! @typescript-eslint/no-unused-vars: 'foo3' is defined but never used.
                           ~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../../foo/v11" resolves outside of the package. Use a bare import to reference other packages.
     import * as va4 from "../index";
+                ~~~
+!!! @typescript-eslint/no-unused-vars: 'va4' is defined but never used.
                          ~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../index" resolves outside of the package. Use a bare import to reference other packages.
     
     declare module "no-relative-references" {
       import A = require("no-relative-references/blah"); // Okay; relative
+             ~
+!!! @typescript-eslint/no-unused-vars: 'A' is defined but never used.
       import B = require("no-relative-references/v11"); // Okay; no versioned dir here
+             ~
+!!! @typescript-eslint/no-unused-vars: 'B' is defined but never used.
       import C = require("../index"); // Bad; parent dir
+             ~
+!!! @typescript-eslint/no-unused-vars: 'C' is defined but never used.
                          ~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../index" resolves outside of the package. Use a bare import to reference other packages.
     }

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-const-enum/bad.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-const-enum/bad.d.ts.lint
@@ -1,10 +1,13 @@
 types/no-const-enum/bad.d.ts
-  1:1  error  Use of `const enum` is forbidden  @definitelytyped/no-const-enum
+  1:1   error  Use of `const enum` is forbidden  @definitelytyped/no-const-enum
+  1:12  error  'E' is defined but never used     @typescript-eslint/no-unused-vars
 
-✖ 1 problem (1 error, 0 warnings)
+✖ 2 problems (2 errors, 0 warnings)
 
 ==== types/no-const-enum/bad.d.ts ====
 
     const enum E { }
     ~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-const-enum: Use of `const enum` is forbidden.
+               ~
+!!! @typescript-eslint/no-unused-vars: 'E' is defined but never used.

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-const-enum/index.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-const-enum/index.d.ts.lint
@@ -1,5 +1,10 @@
-No errors
+types/no-const-enum/index.d.ts
+  1:6  error  'F' is defined but never used  @typescript-eslint/no-unused-vars
+
+✖ 1 problem (1 error, 0 warnings)
 
 ==== types/no-const-enum/index.d.ts ====
 
     enum F {}
+         ~
+!!! @typescript-eslint/no-unused-vars: 'F' is defined but never used.

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-import-default-of-export-equals/bad.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-import-default-of-export-equals/bad.d.ts.lint
@@ -1,12 +1,16 @@
 types/no-import-default-of-export-equals/bad.d.ts
+  2:15  error  'I' is defined but never used                                       @typescript-eslint/no-unused-vars
   7:12  error  The module a uses `export = `. Import with `import a = require(a)`  @definitelytyped/no-import-default-of-export-equals
+  7:12  error  'a' is defined but never used                                       @typescript-eslint/no-unused-vars
 
-✖ 1 problem (1 error, 0 warnings)
+✖ 3 problems (3 errors, 0 warnings)
 
 ==== types/no-import-default-of-export-equals/bad.d.ts ====
 
     declare module "a" {
         interface I { i: any }
+                  ~
+!!! @typescript-eslint/no-unused-vars: 'I' is defined but never used.
         export = I;
     }
     
@@ -14,4 +18,6 @@ types/no-import-default-of-export-equals/bad.d.ts
         import a from "a";
                ~
 !!! @definitelytyped/no-import-default-of-export-equals: The module a uses `export = `. Import with `import a = require(a)`.
+               ~
+!!! @typescript-eslint/no-unused-vars: 'a' is defined but never used.
     }

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-import-default-of-export-equals/index.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-import-default-of-export-equals/index.d.ts.lint
@@ -1,7 +1,8 @@
 types/no-import-default-of-export-equals/index.d.ts
-  1:1  error  Packages should contain value components, not just types  @definitelytyped/no-type-only-packages
+  1:1   error  Packages should contain value components, not just types  @definitelytyped/no-type-only-packages
+  7:12  error  'a' is defined but never used                             @typescript-eslint/no-unused-vars
 
-✖ 1 problem (1 error, 0 warnings)
+✖ 2 problems (2 errors, 0 warnings)
 
 ==== types/no-import-default-of-export-equals/index.d.ts ====
 
@@ -14,4 +15,6 @@ types/no-import-default-of-export-equals/index.d.ts
     
     declare module "bgood" {
         import a from "agood";
+               ~
+!!! @typescript-eslint/no-unused-vars: 'a' is defined but never used.
     }

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-import-of-dev-dependencies/bad.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-import-of-dev-dependencies/bad.d.ts.lint
@@ -6,11 +6,15 @@ types/no-import-of-dev-dependencies/bad.d.ts
   2:1   error  Do not use a triple slash reference for otherdevdep, use `import` style instead  @typescript-eslint/triple-slash-reference
   2:21  error  .d.ts files may not triple-slash reference packages in devDependencies           @definitelytyped/no-import-of-dev-dependencies
   4:1   error  .d.ts files may not import packages in devDependencies                           @definitelytyped/no-import-of-dev-dependencies
+  4:8   error  'devdep' is defined but never used                                               @typescript-eslint/no-unused-vars
   5:1   error  .d.ts files may not import packages in devDependencies                           @definitelytyped/no-import-of-dev-dependencies
+  5:13  error  'otherdevdep' is defined but never used                                          @typescript-eslint/no-unused-vars
   7:1   error  .d.ts files may not import packages in devDependencies                           @definitelytyped/no-import-of-dev-dependencies
+  7:8   error  'devdep2' is defined but never used                                              @typescript-eslint/no-unused-vars
   8:1   error  .d.ts files may not import packages in devDependencies                           @definitelytyped/no-import-of-dev-dependencies
+  8:8   error  'otherdevdep2' is defined but never used                                         @typescript-eslint/no-unused-vars
 
-✖ 10 problems (10 errors, 0 warnings)
+✖ 14 problems (14 errors, 0 warnings)
 
 ==== types/no-import-of-dev-dependencies/bad.d.ts ====
 
@@ -32,13 +36,21 @@ types/no-import-of-dev-dependencies/bad.d.ts
     import devdep from "devdep";
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-import-of-dev-dependencies: .d.ts files may not import packages in devDependencies.
+           ~~~~~~
+!!! @typescript-eslint/no-unused-vars: 'devdep' is defined but never used.
     import * as otherdevdep from "otherdevdep";
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-import-of-dev-dependencies: .d.ts files may not import packages in devDependencies.
+                ~~~~~~~~~~~
+!!! @typescript-eslint/no-unused-vars: 'otherdevdep' is defined but never used.
     
     import devdep2 = require("devdep");
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-import-of-dev-dependencies: .d.ts files may not import packages in devDependencies.
+           ~~~~~~~
+!!! @typescript-eslint/no-unused-vars: 'devdep2' is defined but never used.
     import otherdevdep2 = require("otherdevdep");
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-import-of-dev-dependencies: .d.ts files may not import packages in devDependencies.
+           ~~~~~~~~~~~~
+!!! @typescript-eslint/no-unused-vars: 'otherdevdep2' is defined but never used.

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-import-of-dev-dependencies/index.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-import-of-dev-dependencies/index.d.ts.lint
@@ -2,10 +2,14 @@ types/no-import-of-dev-dependencies/index.d.ts
   1:1  error  Packages should contain value components, not just types                          @definitelytyped/no-type-only-packages
   1:1  error  Do not use a triple slash reference for other, use `import` style instead         @typescript-eslint/triple-slash-reference
   1:1  error  Do not use a triple slash reference for other, use `import` style instead         @typescript-eslint/triple-slash-reference
+  3:8  error  'other' is defined but never used                                                 @typescript-eslint/no-unused-vars
   4:1  error  Declaration file should not use a global import of itself. Use a relative import  @definitelytyped/no-self-import
+  4:8  error  'self' is defined but never used                                                  @typescript-eslint/no-unused-vars
+  6:8  error  'other2' is defined but never used                                                @typescript-eslint/no-unused-vars
   7:1  error  Declaration file should not use a global import of itself. Use a relative import  @definitelytyped/no-self-import
+  7:8  error  'self2' is defined but never used                                                 @typescript-eslint/no-unused-vars
 
-✖ 5 problems (5 errors, 0 warnings)
+✖ 9 problems (9 errors, 0 warnings)
 
 ==== types/no-import-of-dev-dependencies/index.d.ts ====
 
@@ -18,11 +22,19 @@ types/no-import-of-dev-dependencies/index.d.ts
 !!! @typescript-eslint/triple-slash-reference: Do not use a triple slash reference for other, use `import` style instead.
     
     import other from "other";
+           ~~~~~
+!!! @typescript-eslint/no-unused-vars: 'other' is defined but never used.
     import self from "no-import-of-dev-dependencies";
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
+           ~~~~
+!!! @typescript-eslint/no-unused-vars: 'self' is defined but never used.
     
     import other2 = require("other");
+           ~~~~~~
+!!! @typescript-eslint/no-unused-vars: 'other2' is defined but never used.
     import self2 = require("no-import-of-dev-dependencies");
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
+           ~~~~~
+!!! @typescript-eslint/no-unused-vars: 'self2' is defined but never used.

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-old-dt-header/index.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-old-dt-header/index.d.ts.lint
@@ -1,8 +1,10 @@
 types/no-old-dt-header/index.d.ts
-  1:1  error  Specify package metadata in package.json. Do not use a header like `// Type definitions for foo 1.2`  @definitelytyped/no-old-dt-header
-  1:1  error  Packages should contain value components, not just types                                              @definitelytyped/no-type-only-packages
+   1:1   error  Specify package metadata in package.json. Do not use a header like `// Type definitions for foo 1.2`  @definitelytyped/no-old-dt-header
+   1:1   error  Packages should contain value components, not just types                                              @definitelytyped/no-type-only-packages
+  13:13  error  'anime' is defined but never used                                                                     @typescript-eslint/no-unused-vars
+  14:13  error  'three' is defined but never used                                                                     @typescript-eslint/no-unused-vars
 
-✖ 2 problems (2 errors, 0 warnings)
+✖ 4 problems (4 errors, 0 warnings)
 
 ==== types/no-old-dt-header/index.d.ts ====
 
@@ -23,4 +25,8 @@ types/no-old-dt-header/index.d.ts
      */
     
     import * as anime from "animejs";
+                ~~~~~
+!!! @typescript-eslint/no-unused-vars: 'anime' is defined but never used.
     import * as three from "three";
+                ~~~~~
+!!! @typescript-eslint/no-unused-vars: 'three' is defined but never used.

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-relative-references/index.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-relative-references/index.d.ts.lint
@@ -3,16 +3,21 @@ types/no-relative-references/index.d.ts
    1:22  error  The reference "../foo/index.d.ts" resolves outside of the package. Use a global reference to reference other packages         @definitelytyped/no-bad-reference
    2:22  error  The reference "./v1/index.d.ts" resolves outside of the package. Use a global reference to reference other packages           @definitelytyped/no-bad-reference
    3:22  error  The reference "../foo/v1/index.d.ts" resolves outside of the package. Use a global reference to reference other packages      @definitelytyped/no-bad-reference
+   5:13  error  'foo' is defined but never used                                                                                               @typescript-eslint/no-unused-vars
    5:22  error  The import "../foo" resolves outside of the package. Use a bare import to reference other packages                            @definitelytyped/no-bad-reference
    6:1   error  Don't import an old version of the current package                                                                            @definitelytyped/no-self-import
+   6:13  error  'foo2' is defined but never used                                                                                              @typescript-eslint/no-unused-vars
    6:23  error  The import "./v1" resolves outside of the package. Use a bare import to reference other packages                              @definitelytyped/no-bad-reference
+   7:13  error  'foo3' is defined but never used                                                                                              @typescript-eslint/no-unused-vars
    7:23  error  The import "../foo/v1" resolves outside of the package. Use a bare import to reference other packages                         @definitelytyped/no-bad-reference
    9:16  error  Instead of declaring a module with `declare module "no-relative-references"`, write its contents in directly in "index.d.ts"  @definitelytyped/no-declare-current-package
   10:3   error  Declaration file should not use a global import of itself. Use a relative import                                              @definitelytyped/no-self-import
+  10:10  error  'A' is defined but never used                                                                                                 @typescript-eslint/no-unused-vars
   11:3   error  Declaration file should not use a global import of itself. Use a relative import                                              @definitelytyped/no-self-import
+  11:10  error  'B' is defined but never used                                                                                                 @typescript-eslint/no-unused-vars
   11:22  error  The import "no-relative-references/v1" resolves outside of the package. Use a bare import to reference other packages         @definitelytyped/no-bad-reference
 
-✖ 12 problems (12 errors, 0 warnings)
+✖ 17 problems (17 errors, 0 warnings)
 
 ==== types/no-relative-references/index.d.ts ====
 
@@ -29,14 +34,20 @@ types/no-relative-references/index.d.ts
 !!! @definitelytyped/no-bad-reference: The reference "../foo/v1/index.d.ts" resolves outside of the package. Use a global reference to reference other packages.
     
     import * as foo from "../foo";
+                ~~~
+!!! @typescript-eslint/no-unused-vars: 'foo' is defined but never used.
                          ~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../foo" resolves outside of the package. Use a bare import to reference other packages.
     import * as foo2 from "./v1";
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Don't import an old version of the current package.
+                ~~~~
+!!! @typescript-eslint/no-unused-vars: 'foo2' is defined but never used.
                           ~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "./v1" resolves outside of the package. Use a bare import to reference other packages.
     import * as foo3 from "../foo/v1";
+                ~~~~
+!!! @typescript-eslint/no-unused-vars: 'foo3' is defined but never used.
                           ~~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../foo/v1" resolves outside of the package. Use a bare import to reference other packages.
     
@@ -46,9 +57,13 @@ types/no-relative-references/index.d.ts
       import A = require("no-relative-references/blah"); // Okay; relative
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
+             ~
+!!! @typescript-eslint/no-unused-vars: 'A' is defined but never used.
       import B = require("no-relative-references/v1"); // Bad; versioned subdir
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
+             ~
+!!! @typescript-eslint/no-unused-vars: 'B' is defined but never used.
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "no-relative-references/v1" resolves outside of the package. Use a bare import to reference other packages.
     }

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-relative-references/other/other.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-relative-references/other/other.d.ts.lint
@@ -2,11 +2,14 @@ types/no-relative-references/other/other.d.ts
   1:22  error  The reference "../../foo/index.d.ts" resolves outside of the package. Use a global reference to reference other packages     @definitelytyped/no-bad-reference
   2:22  error  The reference "../v1/index.d.ts" resolves outside of the package. Use a global reference to reference other packages         @definitelytyped/no-bad-reference
   3:22  error  The reference "../../foo/v1/index.d.ts" resolves outside of the package. Use a global reference to reference other packages  @definitelytyped/no-bad-reference
+  5:13  error  'foo' is defined but never used                                                                                              @typescript-eslint/no-unused-vars
   5:22  error  The import "../../foo" resolves outside of the package. Use a bare import to reference other packages                        @definitelytyped/no-bad-reference
+  6:13  error  'foo2' is defined but never used                                                                                             @typescript-eslint/no-unused-vars
   6:23  error  The import "../v1" resolves outside of the package. Use a bare import to reference other packages                            @definitelytyped/no-bad-reference
+  7:13  error  'foo3' is defined but never used                                                                                             @typescript-eslint/no-unused-vars
   7:23  error  The import "../../foo/v1" resolves outside of the package. Use a bare import to reference other packages                     @definitelytyped/no-bad-reference
 
-✖ 6 problems (6 errors, 0 warnings)
+✖ 9 problems (9 errors, 0 warnings)
 
 ==== types/no-relative-references/other/other.d.ts ====
 
@@ -21,11 +24,17 @@ types/no-relative-references/other/other.d.ts
 !!! @definitelytyped/no-bad-reference: The reference "../../foo/v1/index.d.ts" resolves outside of the package. Use a global reference to reference other packages.
     
     import * as foo from "../../foo";
+                ~~~
+!!! @typescript-eslint/no-unused-vars: 'foo' is defined but never used.
                          ~~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../../foo" resolves outside of the package. Use a bare import to reference other packages.
     import * as foo2 from "../v1";
+                ~~~~
+!!! @typescript-eslint/no-unused-vars: 'foo2' is defined but never used.
                           ~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../v1" resolves outside of the package. Use a bare import to reference other packages.
     import * as foo3 from "../../foo/v1";
+                ~~~~
+!!! @typescript-eslint/no-unused-vars: 'foo3' is defined but never used.
                           ~~~~~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../../foo/v1" resolves outside of the package. Use a bare import to reference other packages.

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-relative-references/v1/index.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-relative-references/v1/index.d.ts.lint
@@ -4,16 +4,23 @@ types/no-relative-references/v1/index.d.ts
    2:22  error  The reference "../v1/index.d.ts" resolves to the current package, but uses relative paths                                     @definitelytyped/no-bad-reference
    3:22  error  The reference "../../foo/v1/index.d.ts" resolves outside of the package. Use a global reference to reference other packages   @definitelytyped/no-bad-reference
    4:22  error  The reference "../index.d.ts" resolves outside of the package. Use a global reference to reference other packages             @definitelytyped/no-bad-reference
+   6:13  error  'foo' is defined but never used                                                                                               @typescript-eslint/no-unused-vars
    6:22  error  The import "../../foo" resolves outside of the package. Use a bare import to reference other packages                         @definitelytyped/no-bad-reference
+   7:13  error  'foo2' is defined but never used                                                                                              @typescript-eslint/no-unused-vars
    7:23  error  The import "../v1" resolves to the current package, but uses relative paths                                                   @definitelytyped/no-bad-reference
+   8:13  error  'foo3' is defined but never used                                                                                              @typescript-eslint/no-unused-vars
    8:23  error  The import "../../foo/v1" resolves outside of the package. Use a bare import to reference other packages                      @definitelytyped/no-bad-reference
+   9:13  error  'va4' is defined but never used                                                                                               @typescript-eslint/no-unused-vars
    9:22  error  The import "../index" resolves outside of the package. Use a bare import to reference other packages                          @definitelytyped/no-bad-reference
   11:16  error  Instead of declaring a module with `declare module "no-relative-references"`, write its contents in directly in "index.d.ts"  @definitelytyped/no-declare-current-package
   12:3   error  Declaration file should not use a global import of itself. Use a relative import                                              @definitelytyped/no-self-import
+  12:10  error  'A' is defined but never used                                                                                                 @typescript-eslint/no-unused-vars
   13:3   error  Declaration file should not use a global import of itself. Use a relative import                                              @definitelytyped/no-self-import
+  13:10  error  'B' is defined but never used                                                                                                 @typescript-eslint/no-unused-vars
+  14:10  error  'C' is defined but never used                                                                                                 @typescript-eslint/no-unused-vars
   14:22  error  The import "../index" resolves outside of the package. Use a bare import to reference other packages                          @definitelytyped/no-bad-reference
 
-✖ 13 problems (13 errors, 0 warnings)
+✖ 20 problems (20 errors, 0 warnings)
 
 ==== types/no-relative-references/v1/index.d.ts ====
 
@@ -33,15 +40,23 @@ types/no-relative-references/v1/index.d.ts
 !!! @definitelytyped/no-bad-reference: The reference "../index.d.ts" resolves outside of the package. Use a global reference to reference other packages.
     
     import * as foo from "../../foo";
+                ~~~
+!!! @typescript-eslint/no-unused-vars: 'foo' is defined but never used.
                          ~~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../../foo" resolves outside of the package. Use a bare import to reference other packages.
     import * as foo2 from "../v1";
+                ~~~~
+!!! @typescript-eslint/no-unused-vars: 'foo2' is defined but never used.
                           ~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../v1" resolves to the current package, but uses relative paths.
     import * as foo3 from "../../foo/v1";
+                ~~~~
+!!! @typescript-eslint/no-unused-vars: 'foo3' is defined but never used.
                           ~~~~~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../../foo/v1" resolves outside of the package. Use a bare import to reference other packages.
     import * as va4 from "../index";
+                ~~~
+!!! @typescript-eslint/no-unused-vars: 'va4' is defined but never used.
                          ~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../index" resolves outside of the package. Use a bare import to reference other packages.
     
@@ -51,10 +66,16 @@ types/no-relative-references/v1/index.d.ts
       import A = require("no-relative-references/blah"); // Okay; relative
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
+             ~
+!!! @typescript-eslint/no-unused-vars: 'A' is defined but never used.
       import B = require("no-relative-references/v1"); // Okay; no versioned dir here
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
+             ~
+!!! @typescript-eslint/no-unused-vars: 'B' is defined but never used.
       import C = require("../index"); // Bad; parent dir
+             ~
+!!! @typescript-eslint/no-unused-vars: 'C' is defined but never used.
                          ~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../index" resolves outside of the package. Use a bare import to reference other packages.
     }

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-relative-references/v1/other/other.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-relative-references/v1/other/other.d.ts.lint
@@ -2,11 +2,14 @@ types/no-relative-references/v1/other/other.d.ts
   1:22  error  The reference "../../../foo/index.d.ts" resolves outside of the package. Use a global reference to reference other packages     @definitelytyped/no-bad-reference
   2:22  error  The reference "../../v1/index.d.ts" resolves to the current package, but uses relative paths                                    @definitelytyped/no-bad-reference
   3:22  error  The reference "../../../foo/v1/index.d.ts" resolves outside of the package. Use a global reference to reference other packages  @definitelytyped/no-bad-reference
+  5:13  error  'foo' is defined but never used                                                                                                 @typescript-eslint/no-unused-vars
   5:22  error  The import "../../../foo" resolves outside of the package. Use a bare import to reference other packages                        @definitelytyped/no-bad-reference
+  6:13  error  'foo2' is defined but never used                                                                                                @typescript-eslint/no-unused-vars
   6:23  error  The import "../../v1" resolves to the current package, but uses relative paths                                                  @definitelytyped/no-bad-reference
+  7:13  error  'foo3' is defined but never used                                                                                                @typescript-eslint/no-unused-vars
   7:23  error  The import "../../../foo/v1" resolves outside of the package. Use a bare import to reference other packages                     @definitelytyped/no-bad-reference
 
-✖ 6 problems (6 errors, 0 warnings)
+✖ 9 problems (9 errors, 0 warnings)
 
 ==== types/no-relative-references/v1/other/other.d.ts ====
 
@@ -21,11 +24,17 @@ types/no-relative-references/v1/other/other.d.ts
 !!! @definitelytyped/no-bad-reference: The reference "../../../foo/v1/index.d.ts" resolves outside of the package. Use a global reference to reference other packages.
     
     import * as foo from "../../../foo";
+                ~~~
+!!! @typescript-eslint/no-unused-vars: 'foo' is defined but never used.
                          ~~~~~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../../../foo" resolves outside of the package. Use a bare import to reference other packages.
     import * as foo2 from "../../v1";
+                ~~~~
+!!! @typescript-eslint/no-unused-vars: 'foo2' is defined but never used.
                           ~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../../v1" resolves to the current package, but uses relative paths.
     import * as foo3 from "../../../foo/v1";
+                ~~~~
+!!! @typescript-eslint/no-unused-vars: 'foo3' is defined but never used.
                           ~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../../../foo/v1" resolves outside of the package. Use a bare import to reference other packages.

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-self-import/bad.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-self-import/bad.d.ts.lint
@@ -1,65 +1,107 @@
 types/no-self-import/bad.d.ts
    1:1  error  Declaration file should not use a global import of itself. Use a relative import  @definitelytyped/no-self-import
+   1:8  error  'myself' is defined but never used                                                @typescript-eslint/no-unused-vars
    2:1  error  Declaration file should not use a global import of itself. Use a relative import  @definitelytyped/no-self-import
+   2:8  error  'abc' is defined but never used                                                   @typescript-eslint/no-unused-vars
    4:1  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
+   4:8  error  'old1' is defined but never used                                                  @typescript-eslint/no-unused-vars
    5:1  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
+   5:8  error  'old2' is defined but never used                                                  @typescript-eslint/no-unused-vars
    6:1  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
+   6:8  error  'old3' is defined but never used                                                  @typescript-eslint/no-unused-vars
    7:1  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
+   7:8  error  'old4' is defined but never used                                                  @typescript-eslint/no-unused-vars
    8:1  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
+   8:8  error  'old5' is defined but never used                                                  @typescript-eslint/no-unused-vars
   10:1  error  Declaration file should not use a global import of itself. Use a relative import  @definitelytyped/no-self-import
+  10:8  error  'myselfRequired' is defined but never used                                        @typescript-eslint/no-unused-vars
   11:1  error  Declaration file should not use a global import of itself. Use a relative import  @definitelytyped/no-self-import
+  11:8  error  'abcRequired' is defined but never used                                           @typescript-eslint/no-unused-vars
   13:1  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
+  13:8  error  'old1Required' is defined but never used                                          @typescript-eslint/no-unused-vars
   14:1  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
+  14:8  error  'old2Required' is defined but never used                                          @typescript-eslint/no-unused-vars
   15:1  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
+  15:8  error  'old3Required' is defined but never used                                          @typescript-eslint/no-unused-vars
   16:1  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
+  16:8  error  'old4Required' is defined but never used                                          @typescript-eslint/no-unused-vars
   17:1  error  Don't import an old version of the current package                                @definitelytyped/no-self-import
+  17:8  error  'old5Required' is defined but never used                                          @typescript-eslint/no-unused-vars
 
-✖ 14 problems (14 errors, 0 warnings)
+✖ 28 problems (28 errors, 0 warnings)
 
 ==== types/no-self-import/bad.d.ts ====
 
     import myself from "no-self-import";
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
+           ~~~~~~
+!!! @typescript-eslint/no-unused-vars: 'myself' is defined but never used.
     import abc from "no-self-import/abc.d.ts"
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
+           ~~~
+!!! @typescript-eslint/no-unused-vars: 'abc' is defined but never used.
     
     import old1 from "./v11";
     ~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Don't import an old version of the current package.
+           ~~~~
+!!! @typescript-eslint/no-unused-vars: 'old1' is defined but never used.
     import old2 from "./v11/index";
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Don't import an old version of the current package.
+           ~~~~
+!!! @typescript-eslint/no-unused-vars: 'old2' is defined but never used.
     import old3 from "./v11/subdir/file";
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Don't import an old version of the current package.
+           ~~~~
+!!! @typescript-eslint/no-unused-vars: 'old3' is defined but never used.
     import old4 from "./v0.1"
     ~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Don't import an old version of the current package.
+           ~~~~
+!!! @typescript-eslint/no-unused-vars: 'old4' is defined but never used.
     import old5 from "./v0.1/index"
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Don't import an old version of the current package.
+           ~~~~
+!!! @typescript-eslint/no-unused-vars: 'old5' is defined but never used.
     
     import myselfRequired = require("no-self-import");
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
+           ~~~~~~~~~~~~~~
+!!! @typescript-eslint/no-unused-vars: 'myselfRequired' is defined but never used.
     import abcRequired = require("no-self-import/abc.d.ts");
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
+           ~~~~~~~~~~~
+!!! @typescript-eslint/no-unused-vars: 'abcRequired' is defined but never used.
     
     import old1Required = require("./v11");
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Don't import an old version of the current package.
+           ~~~~~~~~~~~~
+!!! @typescript-eslint/no-unused-vars: 'old1Required' is defined but never used.
     import old2Required = require("./v11/index");
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Don't import an old version of the current package.
+           ~~~~~~~~~~~~
+!!! @typescript-eslint/no-unused-vars: 'old2Required' is defined but never used.
     import old3Required = require("./v11/subdir/file");
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Don't import an old version of the current package.
+           ~~~~~~~~~~~~
+!!! @typescript-eslint/no-unused-vars: 'old3Required' is defined but never used.
     import old4Required = require("./v0.1");
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Don't import an old version of the current package.
+           ~~~~~~~~~~~~
+!!! @typescript-eslint/no-unused-vars: 'old4Required' is defined but never used.
     import old5Required = require("./v0.1/index");
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Don't import an old version of the current package.
+           ~~~~~~~~~~~~
+!!! @typescript-eslint/no-unused-vars: 'old5Required' is defined but never used.

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-self-import/index.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-self-import/index.d.ts.lint
@@ -1,24 +1,36 @@
 types/no-self-import/index.d.ts
-  1:1  error  Packages should contain value components, not just types  @definitelytyped/no-type-only-packages
+   1:1  error  Packages should contain value components, not just types  @definitelytyped/no-type-only-packages
+   1:8  error  'other' is defined but never used                         @typescript-eslint/no-unused-vars
+   5:8  error  'old' is defined but never used                           @typescript-eslint/no-unused-vars
+   9:8  error  'otherRequired' is defined but never used                 @typescript-eslint/no-unused-vars
+  13:8  error  'oldRequired' is defined but never used                   @typescript-eslint/no-unused-vars
 
-✖ 1 problem (1 error, 0 warnings)
+✖ 5 problems (5 errors, 0 warnings)
 
 ==== types/no-self-import/index.d.ts ====
 
     import other from "other-package";
     ~
 !!! @definitelytyped/no-type-only-packages: Packages should contain value components, not just types.
+           ~~~~~
+!!! @typescript-eslint/no-unused-vars: 'other' is defined but never used.
     
     import other from "other-package/this-package";
     
     import old from "./v1gardenpath"
+           ~~~
+!!! @typescript-eslint/no-unused-vars: 'old' is defined but never used.
     
     import old from "./v1verb/other"
     
     import otherRequired = require("other-package");
+           ~~~~~~~~~~~~~
+!!! @typescript-eslint/no-unused-vars: 'otherRequired' is defined but never used.
     
     import otherRequired = require("other-package/this-package");
     
     import oldRequired = require("./v1gardenpath");
+           ~~~~~~~~~~~
+!!! @typescript-eslint/no-unused-vars: 'oldRequired' is defined but never used.
     
     import oldRequired = require("./v1verb/other");

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-single-declare-module/index.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-single-declare-module/index.d.ts.lint
@@ -1,11 +1,14 @@
 types/no-single-declare-module/index.d.ts
   1:1  error  Packages should contain value components, not just types  @definitelytyped/no-type-only-packages
+  1:8  error  'x' is defined but never used                             @typescript-eslint/no-unused-vars
 
-✖ 1 problem (1 error, 0 warnings)
+✖ 2 problems (2 errors, 0 warnings)
 
 ==== types/no-single-declare-module/index.d.ts ====
 
     import x from "x";
     ~
 !!! @definitelytyped/no-type-only-packages: Packages should contain value components, not just types.
+           ~
+!!! @typescript-eslint/no-unused-vars: 'x' is defined but never used.
     declare module "foo" {}

--- a/packages/eslint-plugin/test/__file_snapshots__/types/no-type-only-packages-namespace/index.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/no-type-only-packages-namespace/index.d.ts.lint
@@ -1,13 +1,30 @@
-No errors
+types/no-type-only-packages-namespace/index.d.ts
+  2:14  error  'stringToBytes' is defined but never used  @typescript-eslint/no-unused-vars
+  3:14  error  'bytesToString' is defined but never used  @typescript-eslint/no-unused-vars
+  5:15  error  'UTF8' is defined but never used           @typescript-eslint/no-unused-vars
+  6:18  error  'stringToBytes' is defined but never used  @typescript-eslint/no-unused-vars
+  7:18  error  'bytesToString' is defined but never used  @typescript-eslint/no-unused-vars
+
+✖ 5 problems (5 errors, 0 warnings)
 
 ==== types/no-type-only-packages-namespace/index.d.ts ====
 
     export namespace convertString {
         function stringToBytes(str: string): number[];
+                 ~~~~~~~~~~~~~
+!!! @typescript-eslint/no-unused-vars: 'stringToBytes' is defined but never used.
         function bytesToString(bytes: number[]): string;
+                 ~~~~~~~~~~~~~
+!!! @typescript-eslint/no-unused-vars: 'bytesToString' is defined but never used.
     
         namespace UTF8 {
+                  ~~~~
+!!! @typescript-eslint/no-unused-vars: 'UTF8' is defined but never used.
             function stringToBytes(str: string): number[];
+                     ~~~~~~~~~~~~~
+!!! @typescript-eslint/no-unused-vars: 'stringToBytes' is defined but never used.
             function bytesToString(bytes: number[]): string;
+                     ~~~~~~~~~~~~~
+!!! @typescript-eslint/no-unused-vars: 'bytesToString' is defined but never used.
         }
     }

--- a/packages/eslint-plugin/test/__file_snapshots__/types/prefer-declare-function/bad.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/prefer-declare-function/bad.d.ts.lint
@@ -1,12 +1,15 @@
 types/prefer-declare-function/bad.d.ts
   1:14  error  Use a function declaration instead of a variable of function type                                                                                                                                                                           @definitelytyped/prefer-declare-function
   3:11  error  All declarations in this module are exported automatically. Prefer to explicitly write 'export' for clarity. If you have a good reason not to export this declaration, add 'export {}' to the module to shut off automatic exporting        @definitelytyped/strict-export-declare-modifiers
+  3:11  error  'N' is defined but never used                                                                                                                                                                                                               @typescript-eslint/no-unused-vars
   4:5   error  'export' keyword is redundant here because all declarations in this module are exported automatically. If you have a good reason to export some declarations and not others, add 'export {}' to the module to shut off automatic exporting  @definitelytyped/strict-export-declare-modifiers
   4:18  error  Use a function declaration instead of a variable of function type                                                                                                                                                                           @definitelytyped/prefer-declare-function
   7:11  error  All declarations in this module are exported automatically. Prefer to explicitly write 'export' for clarity. If you have a good reason not to export this declaration, add 'export {}' to the module to shut off automatic exporting        @definitelytyped/strict-export-declare-modifiers
+  7:11  error  'N2' is defined but never used                                                                                                                                                                                                              @typescript-eslint/no-unused-vars
   8:11  error  Use a function declaration instead of a variable of function type                                                                                                                                                                           @definitelytyped/prefer-declare-function
+  8:11  error  'example' is defined but never used                                                                                                                                                                                                         @typescript-eslint/no-unused-vars
 
-✖ 6 problems (6 errors, 0 warnings)
+✖ 9 problems (9 errors, 0 warnings)
 
 ==== types/prefer-declare-function/bad.d.ts ====
 
@@ -17,6 +20,8 @@ types/prefer-declare-function/bad.d.ts
     namespace N {
               ~
 !!! @definitelytyped/strict-export-declare-modifiers: All declarations in this module are exported automatically. Prefer to explicitly write 'export' for clarity. If you have a good reason not to export this declaration, add 'export {}' to the module to shut off automatic exporting.
+              ~
+!!! @typescript-eslint/no-unused-vars: 'N' is defined but never used.
         export const example: () => void;
         ~~~~~~
 !!! @definitelytyped/strict-export-declare-modifiers: 'export' keyword is redundant here because all declarations in this module are exported automatically. If you have a good reason to export some declarations and not others, add 'export {}' to the module to shut off automatic exporting.
@@ -27,7 +32,11 @@ types/prefer-declare-function/bad.d.ts
     namespace N2 {
               ~~
 !!! @definitelytyped/strict-export-declare-modifiers: All declarations in this module are exported automatically. Prefer to explicitly write 'export' for clarity. If you have a good reason not to export this declaration, add 'export {}' to the module to shut off automatic exporting.
+              ~~
+!!! @typescript-eslint/no-unused-vars: 'N2' is defined but never used.
         const example: () => void;
               ~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/prefer-declare-function: Use a function declaration instead of a variable of function type.
+              ~~~~~~~~~~~~~~~~~~~
+!!! @typescript-eslint/no-unused-vars: 'example' is defined but never used.
     }

--- a/packages/eslint-plugin/test/__file_snapshots__/types/prefer-declare-function/index.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/prefer-declare-function/index.d.ts.lint
@@ -1,14 +1,17 @@
 types/prefer-declare-function/index.d.ts
   1:10  error  All declarations in this module are exported automatically. Prefer to explicitly write 'export' for clarity. If you have a good reason not to export this declaration, add 'export {}' to the module to shut off automatic exporting  @definitelytyped/strict-export-declare-modifiers
+  1:10  error  'example' is defined but never used                                                                                                                                                                                                   @typescript-eslint/no-unused-vars
   2:14  error  Use a function declaration instead of a variable of function type                                                                                                                                                                     @definitelytyped/prefer-declare-function
 
-✖ 2 problems (2 errors, 0 warnings)
+✖ 3 problems (3 errors, 0 warnings)
 
 ==== types/prefer-declare-function/index.d.ts ====
 
     function example(): void
              ~~~~~~~
 !!! @definitelytyped/strict-export-declare-modifiers: All declarations in this module are exported automatically. Prefer to explicitly write 'export' for clarity. If you have a good reason not to export this declaration, add 'export {}' to the module to shut off automatic exporting.
+             ~~~~~~~
+!!! @typescript-eslint/no-unused-vars: 'example' is defined but never used.
     export const example2: () => void;
                  ~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/prefer-declare-function: Use a function declaration instead of a variable of function type.

--- a/packages/eslint-plugin/test/__file_snapshots__/types/scoped__no-relative-references/index.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/scoped__no-relative-references/index.d.ts.lint
@@ -3,16 +3,21 @@ types/scoped__no-relative-references/index.d.ts
    1:22  error  The reference "../foo/index.d.ts" resolves outside of the package. Use a global reference to reference other packages                 @definitelytyped/no-bad-reference
    2:22  error  The reference "./v1/index.d.ts" resolves outside of the package. Use a global reference to reference other packages                   @definitelytyped/no-bad-reference
    3:22  error  The reference "../foo/v1/index.d.ts" resolves outside of the package. Use a global reference to reference other packages              @definitelytyped/no-bad-reference
+   5:13  error  'foo' is defined but never used                                                                                                       @typescript-eslint/no-unused-vars
    5:22  error  The import "../foo" resolves outside of the package. Use a bare import to reference other packages                                    @definitelytyped/no-bad-reference
    6:1   error  Don't import an old version of the current package                                                                                    @definitelytyped/no-self-import
+   6:13  error  'foo2' is defined but never used                                                                                                      @typescript-eslint/no-unused-vars
    6:23  error  The import "./v1" resolves outside of the package. Use a bare import to reference other packages                                      @definitelytyped/no-bad-reference
+   7:13  error  'foo3' is defined but never used                                                                                                      @typescript-eslint/no-unused-vars
    7:23  error  The import "../foo/v1" resolves outside of the package. Use a bare import to reference other packages                                 @definitelytyped/no-bad-reference
    9:16  error  Instead of declaring a module with `declare module "@scoped/no-relative-references"`, write its contents in directly in "index.d.ts"  @definitelytyped/no-declare-current-package
   10:3   error  Declaration file should not use a global import of itself. Use a relative import                                                      @definitelytyped/no-self-import
+  10:10  error  'A' is defined but never used                                                                                                         @typescript-eslint/no-unused-vars
   11:3   error  Declaration file should not use a global import of itself. Use a relative import                                                      @definitelytyped/no-self-import
+  11:10  error  'B' is defined but never used                                                                                                         @typescript-eslint/no-unused-vars
   11:22  error  The import "@scoped/no-relative-references/v1" resolves outside of the package. Use a bare import to reference other packages         @definitelytyped/no-bad-reference
 
-✖ 12 problems (12 errors, 0 warnings)
+✖ 17 problems (17 errors, 0 warnings)
 
 ==== types/scoped__no-relative-references/index.d.ts ====
 
@@ -29,14 +34,20 @@ types/scoped__no-relative-references/index.d.ts
 !!! @definitelytyped/no-bad-reference: The reference "../foo/v1/index.d.ts" resolves outside of the package. Use a global reference to reference other packages.
     
     import * as foo from "../foo";
+                ~~~
+!!! @typescript-eslint/no-unused-vars: 'foo' is defined but never used.
                          ~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../foo" resolves outside of the package. Use a bare import to reference other packages.
     import * as foo2 from "./v1";
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Don't import an old version of the current package.
+                ~~~~
+!!! @typescript-eslint/no-unused-vars: 'foo2' is defined but never used.
                           ~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "./v1" resolves outside of the package. Use a bare import to reference other packages.
     import * as foo3 from "../foo/v1";
+                ~~~~
+!!! @typescript-eslint/no-unused-vars: 'foo3' is defined but never used.
                           ~~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../foo/v1" resolves outside of the package. Use a bare import to reference other packages.
     
@@ -46,9 +57,13 @@ types/scoped__no-relative-references/index.d.ts
       import A = require("@scoped/no-relative-references/blah"); // Okay; relative
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
+             ~
+!!! @typescript-eslint/no-unused-vars: 'A' is defined but never used.
       import B = require("@scoped/no-relative-references/v1"); // Bad; versioned subdir
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
+             ~
+!!! @typescript-eslint/no-unused-vars: 'B' is defined but never used.
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "@scoped/no-relative-references/v1" resolves outside of the package. Use a bare import to reference other packages.
     }

--- a/packages/eslint-plugin/test/__file_snapshots__/types/scoped__no-relative-references/other/other.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/scoped__no-relative-references/other/other.d.ts.lint
@@ -2,11 +2,14 @@ types/scoped__no-relative-references/other/other.d.ts
   1:22  error  The reference "../../foo/index.d.ts" resolves outside of the package. Use a global reference to reference other packages     @definitelytyped/no-bad-reference
   2:22  error  The reference "../v1/index.d.ts" resolves outside of the package. Use a global reference to reference other packages         @definitelytyped/no-bad-reference
   3:22  error  The reference "../../foo/v1/index.d.ts" resolves outside of the package. Use a global reference to reference other packages  @definitelytyped/no-bad-reference
+  5:13  error  'foo' is defined but never used                                                                                              @typescript-eslint/no-unused-vars
   5:22  error  The import "../../foo" resolves outside of the package. Use a bare import to reference other packages                        @definitelytyped/no-bad-reference
+  6:13  error  'foo2' is defined but never used                                                                                             @typescript-eslint/no-unused-vars
   6:23  error  The import "../v1" resolves outside of the package. Use a bare import to reference other packages                            @definitelytyped/no-bad-reference
+  7:13  error  'foo3' is defined but never used                                                                                             @typescript-eslint/no-unused-vars
   7:23  error  The import "../../foo/v1" resolves outside of the package. Use a bare import to reference other packages                     @definitelytyped/no-bad-reference
 
-✖ 6 problems (6 errors, 0 warnings)
+✖ 9 problems (9 errors, 0 warnings)
 
 ==== types/scoped__no-relative-references/other/other.d.ts ====
 
@@ -21,11 +24,17 @@ types/scoped__no-relative-references/other/other.d.ts
 !!! @definitelytyped/no-bad-reference: The reference "../../foo/v1/index.d.ts" resolves outside of the package. Use a global reference to reference other packages.
     
     import * as foo from "../../foo";
+                ~~~
+!!! @typescript-eslint/no-unused-vars: 'foo' is defined but never used.
                          ~~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../../foo" resolves outside of the package. Use a bare import to reference other packages.
     import * as foo2 from "../v1";
+                ~~~~
+!!! @typescript-eslint/no-unused-vars: 'foo2' is defined but never used.
                           ~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../v1" resolves outside of the package. Use a bare import to reference other packages.
     import * as foo3 from "../../foo/v1";
+                ~~~~
+!!! @typescript-eslint/no-unused-vars: 'foo3' is defined but never used.
                           ~~~~~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../../foo/v1" resolves outside of the package. Use a bare import to reference other packages.

--- a/packages/eslint-plugin/test/__file_snapshots__/types/scoped__no-relative-references/v1/index.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/scoped__no-relative-references/v1/index.d.ts.lint
@@ -4,16 +4,23 @@ types/scoped__no-relative-references/v1/index.d.ts
    2:22  error  The reference "../v1/index.d.ts" resolves to the current package, but uses relative paths                                             @definitelytyped/no-bad-reference
    3:22  error  The reference "../../foo/v1/index.d.ts" resolves outside of the package. Use a global reference to reference other packages           @definitelytyped/no-bad-reference
    4:22  error  The reference "../index.d.ts" resolves outside of the package. Use a global reference to reference other packages                     @definitelytyped/no-bad-reference
+   6:13  error  'foo' is defined but never used                                                                                                       @typescript-eslint/no-unused-vars
    6:22  error  The import "../../foo" resolves outside of the package. Use a bare import to reference other packages                                 @definitelytyped/no-bad-reference
+   7:13  error  'foo2' is defined but never used                                                                                                      @typescript-eslint/no-unused-vars
    7:23  error  The import "../v1" resolves to the current package, but uses relative paths                                                           @definitelytyped/no-bad-reference
+   8:13  error  'foo3' is defined but never used                                                                                                      @typescript-eslint/no-unused-vars
    8:23  error  The import "../../foo/v1" resolves outside of the package. Use a bare import to reference other packages                              @definitelytyped/no-bad-reference
+   9:13  error  'va4' is defined but never used                                                                                                       @typescript-eslint/no-unused-vars
    9:22  error  The import "../index" resolves outside of the package. Use a bare import to reference other packages                                  @definitelytyped/no-bad-reference
   11:16  error  Instead of declaring a module with `declare module "@scoped/no-relative-references"`, write its contents in directly in "index.d.ts"  @definitelytyped/no-declare-current-package
   12:3   error  Declaration file should not use a global import of itself. Use a relative import                                                      @definitelytyped/no-self-import
+  12:10  error  'A' is defined but never used                                                                                                         @typescript-eslint/no-unused-vars
   13:3   error  Declaration file should not use a global import of itself. Use a relative import                                                      @definitelytyped/no-self-import
+  13:10  error  'B' is defined but never used                                                                                                         @typescript-eslint/no-unused-vars
+  14:10  error  'C' is defined but never used                                                                                                         @typescript-eslint/no-unused-vars
   14:22  error  The import "../index" resolves outside of the package. Use a bare import to reference other packages                                  @definitelytyped/no-bad-reference
 
-✖ 13 problems (13 errors, 0 warnings)
+✖ 20 problems (20 errors, 0 warnings)
 
 ==== types/scoped__no-relative-references/v1/index.d.ts ====
 
@@ -33,15 +40,23 @@ types/scoped__no-relative-references/v1/index.d.ts
 !!! @definitelytyped/no-bad-reference: The reference "../index.d.ts" resolves outside of the package. Use a global reference to reference other packages.
     
     import * as foo from "../../foo";
+                ~~~
+!!! @typescript-eslint/no-unused-vars: 'foo' is defined but never used.
                          ~~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../../foo" resolves outside of the package. Use a bare import to reference other packages.
     import * as foo2 from "../v1";
+                ~~~~
+!!! @typescript-eslint/no-unused-vars: 'foo2' is defined but never used.
                           ~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../v1" resolves to the current package, but uses relative paths.
     import * as foo3 from "../../foo/v1";
+                ~~~~
+!!! @typescript-eslint/no-unused-vars: 'foo3' is defined but never used.
                           ~~~~~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../../foo/v1" resolves outside of the package. Use a bare import to reference other packages.
     import * as va4 from "../index";
+                ~~~
+!!! @typescript-eslint/no-unused-vars: 'va4' is defined but never used.
                          ~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../index" resolves outside of the package. Use a bare import to reference other packages.
     
@@ -51,10 +66,16 @@ types/scoped__no-relative-references/v1/index.d.ts
       import A = require("@scoped/no-relative-references/blah"); // Okay; relative
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
+             ~
+!!! @typescript-eslint/no-unused-vars: 'A' is defined but never used.
       import B = require("@scoped/no-relative-references/v1"); // Okay; no versioned dir here
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-self-import: Declaration file should not use a global import of itself. Use a relative import.
+             ~
+!!! @typescript-eslint/no-unused-vars: 'B' is defined but never used.
       import C = require("../index"); // Bad; parent dir
+             ~
+!!! @typescript-eslint/no-unused-vars: 'C' is defined but never used.
                          ~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../index" resolves outside of the package. Use a bare import to reference other packages.
     }

--- a/packages/eslint-plugin/test/__file_snapshots__/types/scoped__no-relative-references/v1/other/other.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/scoped__no-relative-references/v1/other/other.d.ts.lint
@@ -2,11 +2,14 @@ types/scoped__no-relative-references/v1/other/other.d.ts
   1:22  error  The reference "../../../foo/index.d.ts" resolves outside of the package. Use a global reference to reference other packages     @definitelytyped/no-bad-reference
   2:22  error  The reference "../../v1/index.d.ts" resolves to the current package, but uses relative paths                                    @definitelytyped/no-bad-reference
   3:22  error  The reference "../../../foo/v1/index.d.ts" resolves outside of the package. Use a global reference to reference other packages  @definitelytyped/no-bad-reference
+  5:13  error  'foo' is defined but never used                                                                                                 @typescript-eslint/no-unused-vars
   5:22  error  The import "../../../foo" resolves outside of the package. Use a bare import to reference other packages                        @definitelytyped/no-bad-reference
+  6:13  error  'foo2' is defined but never used                                                                                                @typescript-eslint/no-unused-vars
   6:23  error  The import "../../v1" resolves to the current package, but uses relative paths                                                  @definitelytyped/no-bad-reference
+  7:13  error  'foo3' is defined but never used                                                                                                @typescript-eslint/no-unused-vars
   7:23  error  The import "../../../foo/v1" resolves outside of the package. Use a bare import to reference other packages                     @definitelytyped/no-bad-reference
 
-✖ 6 problems (6 errors, 0 warnings)
+✖ 9 problems (9 errors, 0 warnings)
 
 ==== types/scoped__no-relative-references/v1/other/other.d.ts ====
 
@@ -21,11 +24,17 @@ types/scoped__no-relative-references/v1/other/other.d.ts
 !!! @definitelytyped/no-bad-reference: The reference "../../../foo/v1/index.d.ts" resolves outside of the package. Use a global reference to reference other packages.
     
     import * as foo from "../../../foo";
+                ~~~
+!!! @typescript-eslint/no-unused-vars: 'foo' is defined but never used.
                          ~~~~~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../../../foo" resolves outside of the package. Use a bare import to reference other packages.
     import * as foo2 from "../../v1";
+                ~~~~
+!!! @typescript-eslint/no-unused-vars: 'foo2' is defined but never used.
                           ~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../../v1" resolves to the current package, but uses relative paths.
     import * as foo3 from "../../../foo/v1";
+                ~~~~
+!!! @typescript-eslint/no-unused-vars: 'foo3' is defined but never used.
                           ~~~~~~~~~~~~~~~~~
 !!! @definitelytyped/no-bad-reference: The import "../../../foo/v1" resolves outside of the package. Use a bare import to reference other packages.

--- a/packages/eslint-plugin/test/__file_snapshots__/types/strict-export-declare-modifiers/good10.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/strict-export-declare-modifiers/good10.d.ts.lint
@@ -1,4 +1,7 @@
-No errors
+types/strict-export-declare-modifiers/good10.d.ts
+  6:11  error  'foo' is defined but never used  @typescript-eslint/no-unused-vars
+
+✖ 1 problem (1 error, 0 warnings)
 
 ==== types/strict-export-declare-modifiers/good10.d.ts ====
 
@@ -8,4 +11,6 @@ No errors
         export import C = good1.C;
     
         const foo: number;
+              ~~~~~~~~~~~
+!!! @typescript-eslint/no-unused-vars: 'foo' is defined but never used.
     }

--- a/packages/eslint-plugin/test/__file_snapshots__/types/strict-export-declare-modifiers/good9.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/strict-export-declare-modifiers/good9.d.ts.lint
@@ -1,7 +1,12 @@
-No errors
+types/strict-export-declare-modifiers/good9.d.ts
+  1:13  error  'bar' is defined but never used  @typescript-eslint/no-unused-vars
+
+✖ 1 problem (1 error, 0 warnings)
 
 ==== types/strict-export-declare-modifiers/good9.d.ts ====
 
     import * as bar from "bar";
+                ~~~
+!!! @typescript-eslint/no-unused-vars: 'bar' is defined but never used.
     import bar = require("bar");
     export as namespace Bar;

--- a/packages/eslint-plugin/test/__snapshots__/plugin.test.ts.snap
+++ b/packages/eslint-plugin/test/__snapshots__/plugin.test.ts.snap
@@ -105,6 +105,19 @@ exports[`plugin should have the expected exports 1`] = `
             ],
           },
         },
+        {
+          "files": [
+            "*.d.cts",
+            "*.d.mts",
+            "*.d.ts",
+            "*.d.*.ts",
+          ],
+          "rules": {
+            "@typescript-eslint/no-unused-vars": [
+              "error",
+            ],
+          },
+        },
       ],
       "plugins": [
         "@definitelytyped",


### PR DESCRIPTION
This is a replacement for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44272, aiming to complain in declaration files only.

Running this on all of DT now to see what happens, but I suspect that it's a lot of double-firing for "I used a type parameter one time".