### PR TITLE
Switch expect to using settings for versionsToTest

### DIFF
--- a/.changeset/thirty-pugs-compete.md
+++ b/.changeset/thirty-pugs-compete.md
@@ -1,0 +1,6 @@
+---
+"@definitelytyped/eslint-plugin": patch
+"@definitelytyped/dtslint": patch
+---
+
+Switch expect to using settings for versionsToTest

--- a/packages/dtslint/src/lint.ts
+++ b/packages/dtslint/src/lint.ts
@@ -86,11 +86,17 @@ function getEslintOptions(
   const allFiles = ["*.ts", "*.cts", "*.mts", "*.tsx"];
 
   const overrideConfig: ESLint.Options["overrideConfig"] = {
+    settings: {
+      dt: {
+        versionsToTest,
+      },
+    },
     overrides: [
       {
         files: allFiles,
         rules: {
-          "@definitelytyped/expect": ["error", { versionsToTest }],
+          // This prevents anyone from disabling this rule.
+          "@definitelytyped/expect": ["error"],
         },
       },
     ],

--- a/packages/eslint-plugin/src/rules/expect.ts
+++ b/packages/eslint-plugin/src/rules/expect.ts
@@ -8,24 +8,7 @@ import { ReportDescriptorMessageData } from "@typescript-eslint/utils/ts-eslint"
 type TSModule = typeof ts;
 const builtinTypeScript = require("typescript") as TSModule;
 
-type Options = [
-  {
-    versionsToTest?: {
-      readonly versionName: string;
-      readonly path: string;
-    }[];
-  },
-];
-type MessageIds =
-  | "noTsconfig"
-  | "twoAssertions"
-  | "failure"
-  | "diagnostic"
-  | "programContents"
-  | "noMatch"
-  | "needInstall";
-
-const rule = createRule<Options, MessageIds>({
+const rule = createRule({
   name: "expect",
   meta: {
     type: "problem",
@@ -108,9 +91,9 @@ Then re-run.`,
           existing.versions.add(versionName);
         };
 
-        let versionsToTest = context.options[0]?.versionsToTest;
         let reportDiagnostics = true;
-        if (!versionsToTest?.length) {
+        let { versionsToTest } = getSettings(context);
+        if (!versionsToTest) {
           // In the editor, just use the built-in install of TypeScript.
           versionsToTest = [{ versionName: "", path: require.resolve("typescript") }];
           reportDiagnostics = false;
@@ -144,6 +127,38 @@ Then re-run.`,
     };
   },
 });
+
+interface VersionToTest {
+  readonly versionName: string;
+  readonly path: string;
+}
+
+interface Settings {
+  readonly versionsToTest?: readonly VersionToTest[];
+}
+
+function getSettings(context: Parameters<(typeof rule)["create"]>[0]): Settings {
+  // TODO: do a zod/valita like thing?
+
+  const dt = context.settings.dt;
+  if (!dt || typeof dt !== "object") {
+    return {};
+  }
+
+  let versionsToTest = (dt as Record<string, unknown>).versionsToTest;
+  versionsToTest ??= undefined;
+  if (!Array.isArray(versionsToTest)) {
+    throw new Error("Invalid versionsToTest");
+  }
+
+  for (const version of versionsToTest) {
+    if (typeof version !== "object" || typeof version.versionName !== "string" || typeof version.path !== "string") {
+      throw new Error("Invalid version to test");
+    }
+  }
+
+  return { versionsToTest };
+}
 
 const programCache = new WeakMap<ts.Program, Map<string, ts.Program>>();
 /** Maps a ts.Program to one created with the version specified in `options`. */
@@ -185,6 +200,8 @@ function createProgram(configFile: string, ts: TSModule): ts.Program {
   const host = ts.createCompilerHost(parsed.options, true);
   return ts.createProgram(parsed.fileNames, parsed.options, host);
 }
+
+type MessageIds = keyof (typeof rule)["meta"]["messages"];
 
 interface ReporterInfo {
   versionName: string;

--- a/packages/eslint-plugin/src/rules/expect.ts
+++ b/packages/eslint-plugin/src/rules/expect.ts
@@ -138,8 +138,6 @@ interface Settings {
 }
 
 function getSettings(context: Parameters<(typeof rule)["create"]>[0]): Settings {
-  // TODO: do a zod/valita like thing?
-
   const dt = context.settings.dt;
   if (!dt || typeof dt !== "object") {
     return {};

--- a/packages/eslint-plugin/test/fixtures/types/expect-diagnostics-versioned/.eslintrc.js
+++ b/packages/eslint-plugin/test/fixtures/types/expect-diagnostics-versioned/.eslintrc.js
@@ -1,10 +1,7 @@
 module.exports = {
-  overrides: [
-    {
-      files: ["*.ts", "*.cts", "*.mts", "*.tsx"],
-      rules: {
-        "@definitelytyped/expect": ["error", { versionsToTest: [{ versionName: "x.y", path: "typescript" }] }],
-      },
-    },
-  ]
+  settings: {
+    dt: {
+      versionsToTest: [{ versionName: "x.y", path: "typescript" }]
+    }
+  },
 };


### PR DESCRIPTION
`settings` are global, cascading/merging options that get passed down to rules. When I moved `expect` to eslint, I didn't really know how they worked, so opted to use `Options`, which were hacky and required overrides.

But now we're wanting to check multiple tsconfigs, so we need somewhere to store that information. We can't add another option because `dtslint`'s options will totally override any user provided options. But if we use `settings`, they will merge together, so dtslint can set the TS versions, and the user can specify something like `extraTsconfigs: ["./tsconfig.dom.json"]`.