### PR TITLE
Error on versioned directories when parent npmignores are missing subdir

### DIFF
--- a/.changeset/hot-dogs-leave.md
+++ b/.changeset/hot-dogs-leave.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/dtslint": patch
+---
+
+Error on versioned directories when parent npmignores are missing subdir

--- a/packages/dtslint/src/index.ts
+++ b/packages/dtslint/src/index.ts
@@ -355,6 +355,17 @@ function checkExpectedFiles(dirPath: string, isLatest: boolean): { errors: strin
           expectedNpmIgnore.push(`/${subdir.name}/`);
         }
       }
+    } else {
+      const thisDir = `/${basename(dirPath)}/`;
+      const parentNpmIgnorePath = joinPaths(dirname(dirPath), ".npmignore");
+      if (!fs.existsSync(parentNpmIgnorePath)) {
+        errors.push(`${dirPath}: Missing parent '.npmignore'`);
+      } else {
+        const parentNpmIgnore = fs.readFileSync(parentNpmIgnorePath, "utf-8").trim().split(/\r?\n/);
+        if (!parentNpmIgnore.includes(thisDir)) {
+          errors.push(`${dirPath}: Parent package '.npmignore' should contain ${thisDir}`);
+        }
+      }
     }
 
     const expectedNpmIgnoreAsString = expectedNpmIgnore.join("\n");


### PR DESCRIPTION
This fixes https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68891#issuecomment-1977524592; I thought checking on the main dir would be enough, but if the parent dir doesn't change, it's not tested!