### PR TITLE
Allow the jsxImportSource compiler option

### DIFF
--- a/.changeset/chilly-terms-rhyme.md
+++ b/.changeset/chilly-terms-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/dtslint": patch
+---
+
+Allow the `jsxImportSource` compiler option.

--- a/packages/dtslint/src/checks.ts
+++ b/packages/dtslint/src/checks.ts
@@ -82,6 +82,7 @@ export function checkTsconfig(config: Tsconfig): string[] {
       case "target":
       case "jsx":
       case "jsxFactory":
+      case "jsxImportSource":
       case "experimentalDecorators":
       case "noUnusedLocals":
       case "noUnusedParameters":


### PR DESCRIPTION
Some JSX frameworks don’t support the classic runtime. In order to support an automatic runtime other than `react`, they must specify the option `jsxImportSource`.

See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68955#issuecomment-2014831342