### PR TITLE
Add `@wordpress/keycodes` to allowedPackageJsonDependencies.txt

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -584,6 +584,7 @@
 @wordpress/core-data
 @wordpress/data
 @wordpress/element
+@wordpress/keycodes
 abort-controller
 acorn
 actions-on-google


### PR DESCRIPTION
I'm adding `@wordpress/keycodes` because checks are failing in this PR: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69133

![image](https://github.com/microsoft/DefinitelyTyped-tools/assets/25438601/6825cf03-c646-4ed8-988b-149db1c5027e)
