### PR TITLE
Add `eslint-visitor-keys` to `allowedPackageJsonDependencies.txt`

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -665,6 +665,7 @@ ember-qunit
 ember-resolver
 ember-source
 eris
+eslint-visitor-keys
 ethers
 eventemitter2
 eventemitter3


### PR DESCRIPTION
Added `eslint-visitor-keys`, used in DefinitelyTyped/DefinitelyTyped#69145, to `allowedPackageJsonDependencies.txt`.