### PR TITLE
Fix generated version in dts-gen

### DIFF
--- a/.changeset/clever-pens-bow.md
+++ b/.changeset/clever-pens-bow.md
@@ -1,0 +1,5 @@
+---
+"dts-gen": patch
+---
+
+Fix invalid generated version

--- a/packages/dts-gen/src/definitely-typed.ts
+++ b/packages/dts-gen/src/definitely-typed.ts
@@ -109,7 +109,7 @@ async function getPackageJson(dtName: string, packageName: string): Promise<{}> 
   return {
     private: true,
     name: `@types/${dtName}`,
-    version: `${version}.0.9999`,
+    version: `${version}.9999`,
     projects: [project],
     devDependencies: {
       [`@types/${dtName}`]: "workspace:.",


### PR DESCRIPTION
I got this wrong when I updated dts-gen to the new versioning scheme. `version` is already major/minor.


see also https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69355#discussion_r1565328208