### PR TITLE
Install pnpm in CI via pnpm-action

### DIFF
--- a/.github/workflows/check-parse-results.yml
+++ b/.github/workflows/check-parse-results.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: 'lts/*'
-      - run: npm install -g pnpm
+      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
       - run: pnpm config set store-dir $PNPM_CACHE_FOLDER
       - run: pnpm install
       - run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       with:
         node-version: 'lts/*'
-    - run: npm install -g pnpm
+    - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
     - run: pnpm config set store-dir $PNPM_CACHE_FOLDER
     - name: install
       run: pnpm install
@@ -55,7 +55,7 @@ jobs:
     - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       with:
         node-version: 'lts/*'
-    - run: npm install -g pnpm
+    - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
     - run: pnpm install
     - name: Check for missing changesets
       run: |

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: 'lts/*'
 
-      - run: npm install -g pnpm
+      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
       - name: Get pnpm cache info
         id: pnpm-cache
         shell: bash

--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: 'lts/*'
-      - run: npm install -g pnpm
+      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
       - run: pnpm config set store-dir $PNPM_CACHE_FOLDER
       - run: pnpm install --frozen-lockfile
       - run: pnpm build

--- a/.github/workflows/update-ts-version-tags.yml
+++ b/.github/workflows/update-ts-version-tags.yml
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       with:
         node-version: 'lts/*'
-    - run: npm install -g pnpm
+    - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
     - name: Get pnpm cache info
       id: pnpm-cache
       shell: bash

--- a/.github/workflows/version-or-publish.yml
+++ b/.github/workflows/version-or-publish.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: 20
-      - run: npm install -g pnpm
+      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
       - run: pnpm config set store-dir $PNPM_CACHE_FOLDER
       - run: pnpm install
       - run: pnpm build


### PR DESCRIPTION
pnpm v9 is out, and one thing it does is yell if the `package.json` package manager field mismatches, which is does since CI was unpinned.