### PR TITLE
Add '@trendmicro/tmicon' to 'allowedPackageJsonDependencies.txt'

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -496,6 +496,7 @@
 @streamparser/json
 @stripe/stripe-js
 @testing-library/dom
+@trendmicro/tmicon
 @tweenjs/tween.js
 @types/anymatch
 @types/autoprefixer


### PR DESCRIPTION
This pull request adds `@trendmicro/tmicon` to `allowedPackageJsonDependencies.txt` in the `definitions-parser` package to allow the `@types/tonic-ui__react-icons` package to use it as a `devDependency`.

See the DT PR where CI fails due to `@trendmicro/tmicon` missing: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69669