### PR TITLE
Fix ExpectType with extra whitespace

### DIFF
--- a/.changeset/chatty-stingrays-walk.md
+++ b/.changeset/chatty-stingrays-walk.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/eslint-plugin": patch
+---
+
+Fix ExpectType with extra whitespace

--- a/packages/eslint-plugin/src/rules/expect.ts
+++ b/packages/eslint-plugin/src/rules/expect.ts
@@ -401,7 +401,7 @@ function parseAssertions(sourceFile: ts.SourceFile): Assertions {
   const duplicates: number[] = [];
 
   const { text } = sourceFile;
-  const commentRegexp = /\/\/(.*)/g;
+  const commentRegexp = /\/\/\s*\$ExpectType\s+(.*)/g;
   const lineStarts = sourceFile.getLineStarts();
   let curLine = 0;
 
@@ -410,13 +410,8 @@ function parseAssertions(sourceFile: ts.SourceFile): Assertions {
     if (commentMatch === null) {
       break;
     }
-    // Match on the contents of that comment so we do nothing in a commented-out assertion,
-    // i.e. `// foo; // $ExpectType number`
-    if (!commentMatch[1].startsWith(" $ExpectType ")) {
-      continue;
-    }
     const line = getLine(commentMatch.index);
-    const expectedType = commentMatch[1].slice(" $ExpectType ".length);
+    const expectedType = commentMatch[1].trim();
     // Don't bother with the assertion if there are 2 assertions on 1 line. Just fail for the duplicate.
     if (typeAssertions.delete(line)) {
       duplicates.push(line);

--- a/packages/eslint-plugin/test/__file_snapshots__/types/expect/expect-tests.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/expect/expect-tests.ts.lint
@@ -3,12 +3,12 @@ types/expect/expect-tests.ts
   number
 got:
   1234                                                                    @definitelytyped/expect
-  14:1  error  TypeScript expected type to be:
+  16:1  error  TypeScript expected type to be:
   NotRightAtAll
 got:
   1234                                                             @definitelytyped/expect
-  45:1  error  Cannot match a node to this assertion. If this is a multiline function call, ensure the assertion is on the line above  @definitelytyped/expect
-  49:1  error  Cannot match a node to this assertion. If this is a multiline function call, ensure the assertion is on the line above  @definitelytyped/expect
+  47:1  error  Cannot match a node to this assertion. If this is a multiline function call, ensure the assertion is on the line above  @definitelytyped/expect
+  51:1  error  Cannot match a node to this assertion. If this is a multiline function call, ensure the assertion is on the line above  @definitelytyped/expect
 
 ✖ 4 problems (4 errors, 0 warnings)
 
@@ -30,6 +30,8 @@ got:
     // $ExpectType 1234
     expect.foo;
     
+    //    $ExpectType     1234   
+    expect.foo;
     
     // $ExpectType NotRightAtAll
     expect.foo;

--- a/packages/eslint-plugin/test/fixtures/types/expect/expect-tests.ts
+++ b/packages/eslint-plugin/test/fixtures/types/expect/expect-tests.ts
@@ -9,6 +9,8 @@ expect.foo;
 // $ExpectType 1234
 expect.foo;
 
+//    $ExpectType     1234   
+expect.foo;
 
 // $ExpectType NotRightAtAll
 expect.foo;


### PR DESCRIPTION
Noticed this when looking at a DT break; we were strict about there being exactly one space before and after `$ExpectType`, but silently ignored anything that didn't match that. There are quite a few `$ExpectType`s on DT that are being silently ignored!

Rather than being strict, this just ignores the extra whitespace.