### PR TITLE
Revert "Fix ExpectType with extra whitespace (#1011)"

### DIFF
--- a/.changeset/rude-ways-unite.md
+++ b/.changeset/rude-ways-unite.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/eslint-plugin": patch
+---
+
+Revert ExpectType bugfix

--- a/packages/eslint-plugin/src/rules/expect.ts
+++ b/packages/eslint-plugin/src/rules/expect.ts
@@ -401,7 +401,7 @@ function parseAssertions(sourceFile: ts.SourceFile): Assertions {
   const duplicates: number[] = [];
 
   const { text } = sourceFile;
-  const commentRegexp = /\/\/\s*\$ExpectType\s+(.*)/g;
+  const commentRegexp = /\/\/(.*)/g;
   const lineStarts = sourceFile.getLineStarts();
   let curLine = 0;
 
@@ -410,8 +410,13 @@ function parseAssertions(sourceFile: ts.SourceFile): Assertions {
     if (commentMatch === null) {
       break;
     }
+    // Match on the contents of that comment so we do nothing in a commented-out assertion,
+    // i.e. `// foo; // $ExpectType number`
+    if (!commentMatch[1].startsWith(" $ExpectType ")) {
+      continue;
+    }
     const line = getLine(commentMatch.index);
-    const expectedType = commentMatch[1].trim();
+    const expectedType = commentMatch[1].slice(" $ExpectType ".length);
     // Don't bother with the assertion if there are 2 assertions on 1 line. Just fail for the duplicate.
     if (typeAssertions.delete(line)) {
       duplicates.push(line);

--- a/packages/eslint-plugin/test/__file_snapshots__/types/expect/expect-tests.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/expect/expect-tests.ts.lint
@@ -3,12 +3,12 @@ types/expect/expect-tests.ts
   number
 got:
   1234                                                                    @definitelytyped/expect
-  16:1  error  TypeScript expected type to be:
+  14:1  error  TypeScript expected type to be:
   NotRightAtAll
 got:
   1234                                                             @definitelytyped/expect
-  47:1  error  Cannot match a node to this assertion. If this is a multiline function call, ensure the assertion is on the line above  @definitelytyped/expect
-  51:1  error  Cannot match a node to this assertion. If this is a multiline function call, ensure the assertion is on the line above  @definitelytyped/expect
+  45:1  error  Cannot match a node to this assertion. If this is a multiline function call, ensure the assertion is on the line above  @definitelytyped/expect
+  49:1  error  Cannot match a node to this assertion. If this is a multiline function call, ensure the assertion is on the line above  @definitelytyped/expect
 
 ✖ 4 problems (4 errors, 0 warnings)
 
@@ -30,8 +30,6 @@ got:
     // $ExpectType 1234
     expect.foo;
     
-    //    $ExpectType     1234   
-    expect.foo;
     
     // $ExpectType NotRightAtAll
     expect.foo;

--- a/packages/eslint-plugin/test/fixtures/types/expect/expect-tests.ts
+++ b/packages/eslint-plugin/test/fixtures/types/expect/expect-tests.ts
@@ -9,8 +9,6 @@ expect.foo;
 // $ExpectType 1234
 expect.foo;
 
-//    $ExpectType     1234   
-expect.foo;
 
 // $ExpectType NotRightAtAll
 expect.foo;


### PR DESCRIPTION
This was too breaky. There were a load more assertions that were uncaught.

I'll restore the bugfix later when I can sit down and run all of DT at once locally.