### PR TITLE
Support ts-expect-error for specific version ranges

### DIFF
--- a/.changeset/sixty-items-sin.md
+++ b/.changeset/sixty-items-sin.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/eslint-plugin": patch
+---
+
+Support ts-expect-error for specific version ranges

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -41,7 +41,9 @@
     "glob": "^10.3.10",
     "jest-file-snapshot": "^0.5.0",
     "strip-ansi": "^6.0.1",
-    "typescript": "^5.5.2"
+    "typescript": "^5.5.2",
+    "typescript-5.4": "npm:typescript@~5.4.0-0",
+    "typescript-5.5": "npm:typescript@~5.5.0-0"
   },
   "engines": {
     "node": ">=18.18.0"

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "@definitelytyped/utils": "workspace:*",
     "@typescript-eslint/types": "^7.14.1",
-    "@typescript-eslint/utils": "^7.14.1"
+    "@typescript-eslint/utils": "^7.14.1",
+    "semver": "^7.5.4"
   },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.14.1",
@@ -36,6 +37,7 @@
   "devDependencies": {
     "@definitelytyped/eslint-plugin": "link:",
     "@types/eslint": "^8.56.2",
+    "@types/semver": "^7.5.6",
     "glob": "^10.3.10",
     "jest-file-snapshot": "^0.5.0",
     "strip-ansi": "^6.0.1",

--- a/packages/eslint-plugin/src/rules/expect.ts
+++ b/packages/eslint-plugin/src/rules/expect.ts
@@ -273,7 +273,9 @@ function walk(
             if (!semver.satisfies(versionName, match[1].trim(), { loose: true })) {
               continue;
             }
-          } catch {}
+          } catch {
+            // Ignore any parsing errors.
+          }
         }
       }
 

--- a/packages/eslint-plugin/src/rules/expect.ts
+++ b/packages/eslint-plugin/src/rules/expect.ts
@@ -242,7 +242,7 @@ const zeroSourceLocation: Readonly<TSESTree.SourceLocation> = {
 
 const expectTypeToken = "$ExpectType";
 
-// Based on scanner.ts
+// Based on TypeScript's scanner.ts
 const expectErrorSingleLine = /^\/\/\/?\s*@ts-expect-error\s+(.*)/
 const expectErrorMultiLine = /^(?:\/|\*)*\s*@ts-expect-error\s+(.*)/;
 

--- a/packages/eslint-plugin/src/rules/expect.ts
+++ b/packages/eslint-plugin/src/rules/expect.ts
@@ -269,12 +269,17 @@ function walk(
         const text = sourceFile.text.slice(diagnostic.start!, diagnostic.start! + diagnostic.length!);
         const match = text.match(expectErrorSingleLine) || text.match(expectErrorMultiLine);
         if (match) {
+          let range: semver.Range | undefined;
           try {
-            if (!semver.satisfies(versionName, match[1].trim(), { loose: true })) {
-              continue;
-            }
+            range = new semver.Range(match[1].trim())
           } catch {
             // Ignore any parsing errors.
+          }
+
+          if (range) {
+            if (!semver.satisfies(versionName, range, { loose: true })) {
+              continue;
+            }
           }
         }
       }

--- a/packages/eslint-plugin/test/__file_snapshots__/types/expect-error-range/expect-error-range-tests.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/expect-error-range/expect-error-range-tests.ts.lint
@@ -1,0 +1,39 @@
+types/expect-error-range/expect-error-range-tests.ts
+  7:7  error  TypeScript@5.4 compile error: 
+Type 'string | undefined' is not assignable to type 'string'.
+  Type 'undefined' is not assignable to type 'string'  @definitelytyped/expect
+  9:7  error  TypeScript@5.4, 5.5 compile error: 
+Property 'trim' does not exist on type 'never'                                                                  @definitelytyped/expect
+
+✖ 2 problems (2 errors, 0 warnings)
+
+==== types/expect-error-range/expect-error-range-tests.ts ====
+
+    const elem = ["value", undefined].filter(x => x != null)[0];
+    declare const test: typeof elem & undefined
+    
+    
+    // These should give expect errors:
+    
+    const isStringNoIgnore: string = elem;
+          ~~~~~~~~~~~~~~~~
+!!! @definitelytyped/expect: TypeScript@5.4 compile error: 
+!!!                        : Type 'string | undefined' is not assignable to type 'string'.
+!!!                        :   Type 'undefined' is not assignable to type 'string'.
+    
+    test?.trim();
+          ~~~~
+!!! @definitelytyped/expect: TypeScript@5.4, 5.5 compile error: 
+!!!                        : Property 'trim' does not exist on type 'never'.
+    
+    
+    
+    // These should give expect these should not:
+    
+    
+    // @ts-expect-error <5.5
+    const isStringIgnore: string = elem;
+    
+    
+    // @ts-expect-error >=5.5
+    test?.trim();

--- a/packages/eslint-plugin/test/__file_snapshots__/types/expect-error-range/expect-error-range-tests.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/expect-error-range/expect-error-range-tests.ts.lint
@@ -18,7 +18,7 @@ Unused '@ts-expect-error' directive                                             
 ==== types/expect-error-range/expect-error-range-tests.ts ====
 
     // In TypeScript <5.5, elem will have type "string",
-    // but 5.5 it will be "string | number".
+    // but 5.5 it will be "string | undefined".
     const elem = ["value", undefined].filter(x => x != null)[0];
     
     

--- a/packages/eslint-plugin/test/__file_snapshots__/types/expect-error-range/expect-error-range-tests.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/expect-error-range/expect-error-range-tests.ts.lint
@@ -1,39 +1,37 @@
 types/expect-error-range/expect-error-range-tests.ts
-  7:7  error  TypeScript@5.4 compile error: 
+   7:7  error  TypeScript@5.4 compile error: 
 Type 'string | undefined' is not assignable to type 'string'.
   Type 'undefined' is not assignable to type 'string'  @definitelytyped/expect
-  9:7  error  TypeScript@5.4, 5.5 compile error: 
-Property 'trim' does not exist on type 'never'                                                                  @definitelytyped/expect
+  10:7  error  TypeScript@5.5 compile error: 
+Type 'string' is not assignable to type 'never'                                                                      @definitelytyped/expect
 
 ✖ 2 problems (2 errors, 0 warnings)
 
 ==== types/expect-error-range/expect-error-range-tests.ts ====
 
+    // In TypeScript <5.5, elem will have type "string",
+    // but 5.5 it will be "string | number".
     const elem = ["value", undefined].filter(x => x != null)[0];
-    declare const test: typeof elem & undefined
     
     
-    // These should give expect errors:
-    
-    const isStringNoIgnore: string = elem;
-          ~~~~~~~~~~~~~~~~
+    // This should error in 5.4, but not 5.5.
+    const test1a: string = elem;
+          ~~~~~~
 !!! @definitelytyped/expect: TypeScript@5.4 compile error: 
 !!!                        : Type 'string | undefined' is not assignable to type 'string'.
 !!!                        :   Type 'undefined' is not assignable to type 'string'.
     
-    test?.trim();
-          ~~~~
-!!! @definitelytyped/expect: TypeScript@5.4, 5.5 compile error: 
-!!!                        : Property 'trim' does not exist on type 'never'.
+    // This should error in 5.5, but not 5.4.
+    const test1b: undefined extends typeof elem ? typeof elem : never = elem;
+          ~~~~~~
+!!! @definitelytyped/expect: TypeScript@5.5 compile error: 
+!!!                        : Type 'string' is not assignable to type 'never'.
     
     
-    
-    // These should give expect these should not:
-    
+    // None of these expects should error.
     
     // @ts-expect-error <5.5
-    const isStringIgnore: string = elem;
-    
+    const test2a: string = elem;
     
     // @ts-expect-error >=5.5
-    test?.trim();
+    const test2b: undefined extends typeof elem ? typeof elem : never = elem;

--- a/packages/eslint-plugin/test/__file_snapshots__/types/expect-error-range/expect-error-range-tests.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/expect-error-range/expect-error-range-tests.ts.lint
@@ -1,11 +1,19 @@
 types/expect-error-range/expect-error-range-tests.ts
-   7:7  error  TypeScript@5.4 compile error: 
+   8:11  error  TypeScript@5.4 compile error: 
 Type 'string | undefined' is not assignable to type 'string'.
   Type 'undefined' is not assignable to type 'string'  @definitelytyped/expect
-  10:7  error  TypeScript@5.5 compile error: 
+  11:11  error  TypeScript@5.5 compile error: 
 Type 'string' is not assignable to type 'never'                                                                      @definitelytyped/expect
+  16:5   error  TypeScript@5.5 compile error: 
+Unused '@ts-expect-error' directive                                                                                  @definitelytyped/expect
+  20:5   error  TypeScript@5.4 compile error: 
+Unused '@ts-expect-error' directive                                                                                  @definitelytyped/expect
+  27:5   error  TypeScript@5.5 compile error: 
+Unused '@ts-expect-error' directive                                                                                  @definitelytyped/expect
+  31:5   error  TypeScript@5.4 compile error: 
+Unused '@ts-expect-error' directive                                                                                  @definitelytyped/expect
 
-✖ 2 problems (2 errors, 0 warnings)
+✖ 6 problems (6 errors, 0 warnings)
 
 ==== types/expect-error-range/expect-error-range-tests.ts ====
 
@@ -14,24 +22,59 @@ Type 'string' is not assignable to type 'never'                                 
     const elem = ["value", undefined].filter(x => x != null)[0];
     
     
-    // This should error in 5.4, but not 5.5.
-    const test1a: string = elem;
-          ~~~~~~
+    {
+        // This should error in 5.4, but not 5.5.
+        const test1: string = elem;
+              ~~~~~
 !!! @definitelytyped/expect: TypeScript@5.4 compile error: 
 !!!                        : Type 'string | undefined' is not assignable to type 'string'.
 !!!                        :   Type 'undefined' is not assignable to type 'string'.
     
-    // This should error in 5.5, but not 5.4.
-    const test1b: undefined extends typeof elem ? typeof elem : never = elem;
-          ~~~~~~
+        // This should error in 5.5, but not 5.4.
+        const test2: undefined extends typeof elem ? typeof elem : never = elem;
+              ~~~~~
 !!! @definitelytyped/expect: TypeScript@5.5 compile error: 
 !!!                        : Type 'string' is not assignable to type 'never'.
+    }
     
+    {
+        // This should error in 5.5, but not 5.4.
+        // @ts-expect-error
+        ~~~~~~~~~~~~~~~~~~~
+!!! @definitelytyped/expect: TypeScript@5.5 compile error: 
+!!!                        : Unused '@ts-expect-error' directive.
+        const test1: string = elem;
+    
+        // This should error in 5.4, but not 5.5.
+        // @ts-expect-error
+        ~~~~~~~~~~~~~~~~~~~
+!!! @definitelytyped/expect: TypeScript@5.4 compile error: 
+!!!                        : Unused '@ts-expect-error' directive.
+        const test2: undefined extends typeof elem ? typeof elem : never = elem;
+    }
+    
+    // These should be treated as though there is no range.
+    {
+        // This should error in 5.5, but not 5.4.
+        // @ts-expect-error random non-range text
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! @definitelytyped/expect: TypeScript@5.5 compile error: 
+!!!                        : Unused '@ts-expect-error' directive.
+        const test1: string = elem;
+    
+        // This should error in 5.4, but not 5.5.
+        // @ts-expect-error random non-range text
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! @definitelytyped/expect: TypeScript@5.4 compile error: 
+!!!                        : Unused '@ts-expect-error' directive.
+        const test2: undefined extends typeof elem ? typeof elem : never = elem;
+    }
     
     // None of these expects should error.
+    {
+        // @ts-expect-error <5.5
+        const test1: string = elem;
     
-    // @ts-expect-error <5.5
-    const test2a: string = elem;
-    
-    // @ts-expect-error >=5.5
-    const test2b: undefined extends typeof elem ? typeof elem : never = elem;
+        // @ts-expect-error >=5.5
+        const test2: undefined extends typeof elem ? typeof elem : never = elem;
+    }

--- a/packages/eslint-plugin/test/__file_snapshots__/types/expect-error-range/index.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/expect-error-range/index.d.ts.lint
@@ -1,19 +1,5 @@
-types/expect-error-range/index.d.ts
-  7:12  error  Array type using 'readonly T[]' is forbidden for non-simple types. Use 'ReadonlyArray<T>' instead  @typescript-eslint/array-type
-
-✖ 1 problem (1 error, 0 warnings)
-  1 error and 0 warnings potentially fixable with the `--fix` option.
+No errors
 
 ==== types/expect-error-range/index.d.ts ====
 
-    export const foo = 1234;
-    
-    export const aUnion: string | number | undefined;
-    
-    export function complicatedUnion<T extends string | number>(x: T, y: T): {
-        prop1: "a" | "b" | "c";
-        prop2: readonly (string | number)[];
-               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! @typescript-eslint/array-type: Array type using 'readonly T[]' is forbidden for non-simple types. Use 'ReadonlyArray<T>' instead.
-        prop3: ReadonlyArray<string | number>;
-    };
+    export const value: number;

--- a/packages/eslint-plugin/test/__file_snapshots__/types/expect-error-range/index.d.ts.lint
+++ b/packages/eslint-plugin/test/__file_snapshots__/types/expect-error-range/index.d.ts.lint
@@ -1,0 +1,19 @@
+types/expect-error-range/index.d.ts
+  7:12  error  Array type using 'readonly T[]' is forbidden for non-simple types. Use 'ReadonlyArray<T>' instead  @typescript-eslint/array-type
+
+✖ 1 problem (1 error, 0 warnings)
+  1 error and 0 warnings potentially fixable with the `--fix` option.
+
+==== types/expect-error-range/index.d.ts ====
+
+    export const foo = 1234;
+    
+    export const aUnion: string | number | undefined;
+    
+    export function complicatedUnion<T extends string | number>(x: T, y: T): {
+        prop1: "a" | "b" | "c";
+        prop2: readonly (string | number)[];
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! @typescript-eslint/array-type: Array type using 'readonly T[]' is forbidden for non-simple types. Use 'ReadonlyArray<T>' instead.
+        prop3: ReadonlyArray<string | number>;
+    };

--- a/packages/eslint-plugin/test/fixtures/types/expect-error-range/.eslintrc.js
+++ b/packages/eslint-plugin/test/fixtures/types/expect-error-range/.eslintrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+  settings: {
+    dt: {
+      versionsToTest: [
+        { versionName: "5.4", path: "typescript-5.4" },
+        { versionName: "5.5", path: "typescript-5.5" }
+      ]
+    }
+  },
+};

--- a/packages/eslint-plugin/test/fixtures/types/expect-error-range/expect-error-range-tests.ts
+++ b/packages/eslint-plugin/test/fixtures/types/expect-error-range/expect-error-range-tests.ts
@@ -1,21 +1,19 @@
+// In TypeScript <5.5, elem will have type "string",
+// but 5.5 it will be "string | number".
 const elem = ["value", undefined].filter(x => x != null)[0];
-declare const test: typeof elem & undefined
 
 
-// These should give expect errors:
+// This should error in 5.4, but not 5.5.
+const test1a: string = elem;
 
-const isStringNoIgnore: string = elem;
-
-test?.trim();
-
+// This should error in 5.5, but not 5.4.
+const test1b: undefined extends typeof elem ? typeof elem : never = elem;
 
 
-// These should give expect these should not:
-
+// None of these expects should error.
 
 // @ts-expect-error <5.5
-const isStringIgnore: string = elem;
-
+const test2a: string = elem;
 
 // @ts-expect-error >=5.5
-test?.trim();
+const test2b: undefined extends typeof elem ? typeof elem : never = elem;

--- a/packages/eslint-plugin/test/fixtures/types/expect-error-range/expect-error-range-tests.ts
+++ b/packages/eslint-plugin/test/fixtures/types/expect-error-range/expect-error-range-tests.ts
@@ -3,17 +3,41 @@
 const elem = ["value", undefined].filter(x => x != null)[0];
 
 
-// This should error in 5.4, but not 5.5.
-const test1a: string = elem;
+{
+    // This should error in 5.4, but not 5.5.
+    const test1: string = elem;
 
-// This should error in 5.5, but not 5.4.
-const test1b: undefined extends typeof elem ? typeof elem : never = elem;
+    // This should error in 5.5, but not 5.4.
+    const test2: undefined extends typeof elem ? typeof elem : never = elem;
+}
 
+{
+    // This should error in 5.5, but not 5.4.
+    // @ts-expect-error
+    const test1: string = elem;
+
+    // This should error in 5.4, but not 5.5.
+    // @ts-expect-error
+    const test2: undefined extends typeof elem ? typeof elem : never = elem;
+}
+
+// These should be treated as though there is no range.
+{
+    // This should error in 5.5, but not 5.4.
+    // @ts-expect-error random non-range text
+    const test1: string = elem;
+
+    // This should error in 5.4, but not 5.5.
+    // @ts-expect-error random non-range text
+    const test2: undefined extends typeof elem ? typeof elem : never = elem;
+}
 
 // None of these expects should error.
+{
+    // @ts-expect-error <5.5
+    const test1: string = elem;
 
-// @ts-expect-error <5.5
-const test2a: string = elem;
+    // @ts-expect-error >=5.5
+    const test2: undefined extends typeof elem ? typeof elem : never = elem;
+}
 
-// @ts-expect-error >=5.5
-const test2b: undefined extends typeof elem ? typeof elem : never = elem;

--- a/packages/eslint-plugin/test/fixtures/types/expect-error-range/expect-error-range-tests.ts
+++ b/packages/eslint-plugin/test/fixtures/types/expect-error-range/expect-error-range-tests.ts
@@ -1,5 +1,5 @@
 // In TypeScript <5.5, elem will have type "string",
-// but 5.5 it will be "string | number".
+// but 5.5 it will be "string | undefined".
 const elem = ["value", undefined].filter(x => x != null)[0];
 
 

--- a/packages/eslint-plugin/test/fixtures/types/expect-error-range/expect-error-range-tests.ts
+++ b/packages/eslint-plugin/test/fixtures/types/expect-error-range/expect-error-range-tests.ts
@@ -1,0 +1,21 @@
+const elem = ["value", undefined].filter(x => x != null)[0];
+declare const test: typeof elem & undefined
+
+
+// These should give expect errors:
+
+const isStringNoIgnore: string = elem;
+
+test?.trim();
+
+
+
+// These should give expect these should not:
+
+
+// @ts-expect-error <5.5
+const isStringIgnore: string = elem;
+
+
+// @ts-expect-error >=5.5
+test?.trim();

--- a/packages/eslint-plugin/test/fixtures/types/expect-error-range/index.d.ts
+++ b/packages/eslint-plugin/test/fixtures/types/expect-error-range/index.d.ts
@@ -1,0 +1,9 @@
+export const foo = 1234;
+
+export const aUnion: string | number | undefined;
+
+export function complicatedUnion<T extends string | number>(x: T, y: T): {
+    prop1: "a" | "b" | "c";
+    prop2: readonly (string | number)[];
+    prop3: ReadonlyArray<string | number>;
+};

--- a/packages/eslint-plugin/test/fixtures/types/expect-error-range/index.d.ts
+++ b/packages/eslint-plugin/test/fixtures/types/expect-error-range/index.d.ts
@@ -1,9 +1,1 @@
-export const foo = 1234;
-
-export const aUnion: string | number | undefined;
-
-export function complicatedUnion<T extends string | number>(x: T, y: T): {
-    prop1: "a" | "b" | "c";
-    prop2: readonly (string | number)[];
-    prop3: ReadonlyArray<string | number>;
-};
+export const value: number;

--- a/packages/eslint-plugin/test/fixtures/types/expect-error-range/package.json
+++ b/packages/eslint-plugin/test/fixtures/types/expect-error-range/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "@types/expect-error-range",
+    "version": "2.0.9999",
+    "owners": []
+}

--- a/packages/eslint-plugin/test/fixtures/types/expect-error-range/tsconfig.json
+++ b/packages/eslint-plugin/test/fixtures/types/expect-error-range/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "expect-error-range-tests.ts"
+    ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,6 +269,12 @@ importers:
       typescript:
         specifier: ^5.5.2
         version: 5.5.2
+      typescript-5.4:
+        specifier: npm:typescript@~5.4.0-0
+        version: /typescript@5.4.2
+      typescript-5.5:
+        specifier: npm:typescript@~5.5.0-0
+        version: /typescript@5.5.2
 
   packages/header-parser:
     dependencies:
@@ -6906,7 +6912,6 @@ packages:
     resolution: {integrity: sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==}
     engines: {node: '>=14.17'}
     hasBin: true
-    dev: false
 
   /typescript@5.5.2:
     resolution: {integrity: sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,6 +244,9 @@ importers:
       eslint-plugin-jsdoc:
         specifier: ^44.0.0
         version: 44.2.7(eslint@8.57.0)
+      semver:
+        specifier: ^7.5.4
+        version: 7.6.2
     devDependencies:
       '@definitelytyped/eslint-plugin':
         specifier: 'link:'
@@ -251,6 +254,9 @@ importers:
       '@types/eslint':
         specifier: ^8.56.2
         version: 8.56.2
+      '@types/semver':
+        specifier: ^7.5.6
+        version: 7.5.6
       glob:
         specifier: ^10.3.10
         version: 10.3.10
@@ -828,7 +834,7 @@ packages:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.5.4
+      semver: 7.6.2
     dev: true
 
   /@changesets/assemble-release-plan@6.0.2:
@@ -840,7 +846,7 @@ packages:
       '@changesets/should-skip-package': 0.1.0
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.5.4
+      semver: 7.6.2
     dev: true
 
   /@changesets/changelog-git@0.2.0:
@@ -882,7 +888,7 @@ packages:
       p-limit: 2.3.0
       preferred-pm: 3.1.2
       resolve-from: 5.0.0
-      semver: 7.5.4
+      semver: 7.6.2
       spawndamnit: 2.0.0
       term-size: 2.2.1
       tty-table: 4.2.3
@@ -913,7 +919,7 @@ packages:
       '@manypkg/get-packages': 1.1.3
       chalk: 2.4.2
       fs-extra: 7.0.1
-      semver: 7.5.4
+      semver: 7.6.2
     dev: true
 
   /@changesets/get-release-plan@4.0.2:
@@ -1466,7 +1472,7 @@ packages:
     resolution: {integrity: sha512-7kZUAaLscfgbwBQRbvdMYaZOWyMEcPTH/tJjnyAWJ/dvvs9Ef+CERx/qJb9GExJpl1qipaDGn7KqHnFGGixd0w==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
-      semver: 7.5.4
+      semver: 7.6.2
     dev: false
 
   /@npmcli/git@5.0.3:
@@ -1479,7 +1485,7 @@ packages:
       proc-log: 3.0.0
       promise-inflight: 1.0.1
       promise-retry: 2.0.1
-      semver: 7.5.4
+      semver: 7.6.2
       which: 4.0.0
     transitivePeerDependencies:
       - bluebird
@@ -1523,7 +1529,7 @@ packages:
       json-parse-even-better-errors: 3.0.0
       normalize-package-data: 6.0.0
       proc-log: 3.0.0
-      semver: 7.5.4
+      semver: 7.6.2
     transitivePeerDependencies:
       - bluebird
     dev: true
@@ -1706,7 +1712,7 @@ packages:
     engines: {node: '>=14.6'}
     dependencies:
       hosted-git-info: 4.1.0
-      semver: 7.5.4
+      semver: 7.6.2
       validate-npm-package-name: 4.0.0
     dev: true
 
@@ -1735,7 +1741,7 @@ packages:
       path-temp: 2.1.0
       ramda: /@pnpm/ramda@0.28.1
       rename-overwrite: 5.0.0
-      semver: 7.5.4
+      semver: 7.6.2
       ssri: 10.0.5
       version-selector-type: 3.0.0
     transitivePeerDependencies:
@@ -1750,7 +1756,7 @@ packages:
     resolution: {integrity: sha512-yQ0pMthlw8rTgS/C9hrjne+NEnnSNevCjtdodd7i15I59jMBYciHifZ/vjg0NY+Jl+USTc3dBE+0h/4tdYjMKg==}
     engines: {node: '>=16.14'}
     dependencies:
-      semver: 7.5.4
+      semver: 7.6.2
     dev: true
 
   /@pnpm/resolver-base@11.0.2:
@@ -1789,7 +1795,7 @@ packages:
       request: 2.88.2
       retry: 0.12.0
       safe-buffer: 5.2.1
-      semver: 7.5.4
+      semver: 7.6.2
       slide: 1.1.6
       ssri: 8.0.1
     optionalDependencies:
@@ -2639,7 +2645,7 @@ packages:
   /builtins@5.0.1:
     resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
     dependencies:
-      semver: 7.5.4
+      semver: 7.6.2
 
   /cacache@18.0.0:
     resolution: {integrity: sha512-I7mVOPl3PUCeRub1U8YoGz2Lqv9WOBpobZ8RyWFXmReuILz+3OAyTa5oH3QPdtKZD7N0Yk00aLfzn0qvp8dZ1w==}
@@ -3350,7 +3356,7 @@ packages:
       escape-string-regexp: 4.0.0
       eslint: 8.57.0
       esquery: 1.5.0
-      semver: 7.5.4
+      semver: 7.6.2
       spdx-expression-parse: 3.0.1
     transitivePeerDependencies:
       - supports-color
@@ -3370,7 +3376,7 @@ packages:
       eslint: 8.57.0
       esquery: 1.5.0
       is-builtin-module: 3.2.1
-      semver: 7.5.4
+      semver: 7.6.2
       spdx-expression-parse: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -4295,7 +4301,7 @@ packages:
       '@babel/parser': 7.23.3
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.5.4
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4308,7 +4314,7 @@ packages:
       '@babel/parser': 7.23.3
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.5.4
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4715,7 +4721,7 @@ packages:
       jest-util: 29.7.0
       natural-compare: 1.4.0
       pretty-format: 29.7.0
-      semver: 7.5.4
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5031,7 +5037,7 @@ packages:
     resolution: {integrity: sha512-Yj9mA8fPiVgOUpByoTZO5pNrcl5Yk37FcSHsUINpAsaBIEZIuqcCclDZJCVxqQShDsmYX8QG63svJiTbOATZwg==}
     engines: {node: 14 || >=16.14}
     dependencies:
-      semver: 7.5.4
+      semver: 7.6.2
 
   /lru-cache@4.1.5:
     resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
@@ -5062,7 +5068,7 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.5.4
+      semver: 7.6.2
     dev: true
 
   /make-error@1.3.6:
@@ -5382,7 +5388,7 @@ packages:
       make-fetch-happen: 13.0.0
       nopt: 7.2.0
       proc-log: 3.0.0
-      semver: 7.5.4
+      semver: 7.6.2
       tar: 6.2.1
       which: 4.0.0
     transitivePeerDependencies:
@@ -5410,7 +5416,7 @@ packages:
     dependencies:
       hosted-git-info: 2.8.9
       resolve: 1.22.8
-      semver: 7.5.4
+      semver: 7.6.2
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -5420,7 +5426,7 @@ packages:
     dependencies:
       hosted-git-info: 4.1.0
       is-core-module: 2.13.1
-      semver: 7.5.4
+      semver: 7.6.2
       validate-npm-package-license: 3.0.4
     dev: false
 
@@ -5430,7 +5436,7 @@ packages:
     dependencies:
       hosted-git-info: 7.0.1
       is-core-module: 2.13.1
-      semver: 7.5.4
+      semver: 7.6.2
       validate-npm-package-license: 3.0.4
 
   /normalize-path@3.0.0:
@@ -5449,7 +5455,7 @@ packages:
     resolution: {integrity: sha512-W29RiK/xtpCGqn6f3ixfRYGk+zRyr+Ew9F2E20BfXxT5/euLdA/Nm7fO7OeTGuAmTs30cpgInyJ0cYe708YTZw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
-      semver: 7.5.4
+      semver: 7.6.2
 
   /npm-normalize-package-bin@3.0.1:
     resolution: {integrity: sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==}
@@ -5461,7 +5467,7 @@ packages:
     dependencies:
       hosted-git-info: 7.0.1
       proc-log: 3.0.0
-      semver: 7.5.4
+      semver: 7.6.2
       validate-npm-package-name: 5.0.0
 
   /npm-package-arg@8.1.5:
@@ -5469,7 +5475,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       hosted-git-info: 4.1.0
-      semver: 7.5.4
+      semver: 7.6.2
       validate-npm-package-name: 3.0.0
     dev: false
 
@@ -5487,7 +5493,7 @@ packages:
       npm-install-checks: 6.3.0
       npm-normalize-package-bin: 3.0.1
       npm-package-arg: 11.0.1
-      semver: 7.5.4
+      semver: 7.6.2
 
   /npm-registry-fetch@16.1.0:
     resolution: {integrity: sha512-PQCELXKt8Azvxnt5Y85GseQDJJlglTFM9L9U9gkv2y4e9s0k3GVDdOx3YoB6gm2Do0hlkzC39iCGXby+Wve1Bw==}
@@ -5745,7 +5751,7 @@ packages:
     resolution: {integrity: sha512-InpdgIdNe5xWMEUcrVQUniQKwnggBtJ7+SCwh7zQAZwbbIYZV9XdgJyhtmDSSvykFyQXoe4BINnzKTfCwWLs5g==}
     engines: {node: '>=8.15'}
     dependencies:
-      semver: 7.5.4
+      semver: 7.6.2
     dev: true
 
   /path-exists@4.0.0:
@@ -6176,6 +6182,7 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
+    dev: false
 
   /semver@7.6.2:
     resolution: {integrity: sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==}
@@ -6733,7 +6740,7 @@ packages:
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.5.4
+      semver: 7.6.2
       typescript: 5.5.2
       yargs-parser: 21.1.1
     dev: true
@@ -7053,7 +7060,7 @@ packages:
     resolution: {integrity: sha512-PSvMIZS7C1MuVNBXl/CDG2pZq8EXy/NW2dHIdm3bVP5N0PC8utDK8ttXLXj44Gn3J0lQE3U7Mpm1estAOd+eiA==}
     engines: {node: '>=10.13'}
     dependencies:
-      semver: 7.5.4
+      semver: 7.6.2
     dev: true
 
   /vlq@0.2.3:


### PR DESCRIPTION
This enables writing:

```ts
// @ts-expect-error >=5.5
```

Which means "only expect an error in 5.5 and above".