### PR TITLE
Clear expect rule program cache when heap is almost exhausted

### DIFF
--- a/.changeset/three-vans-fetch.md
+++ b/.changeset/three-vans-fetch.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/eslint-plugin": patch
+---
+
+Clear expect rule program cache when heap is almost exhausted

--- a/packages/eslint-plugin/src/rules/expect.ts
+++ b/packages/eslint-plugin/src/rules/expect.ts
@@ -1,10 +1,11 @@
-import { createRule, findTypesPackage, findUp } from "../util";
 import { ESLintUtils, TSESTree } from "@typescript-eslint/utils";
-import type * as ts from "typescript";
-import path from "path";
-import fs from "fs";
 import { ReportDescriptorMessageData } from "@typescript-eslint/utils/ts-eslint";
+import fs from "fs";
+import v8 from "node:v8";
+import path from "path";
 import * as semver from "semver";
+import type * as ts from "typescript";
+import { createRule, findTypesPackage, findUp } from "../util";
 
 type TSModule = typeof ts;
 
@@ -198,6 +199,12 @@ function getProgram(
     newProgram = createProgram(path.resolve(dirPath, configFile), ts);
     versionToProgram.set(cacheKey, newProgram);
   }
+
+  const heapUsage = v8.getHeapStatistics().used_heap_size / v8.getHeapStatistics().heap_size_limit;
+  if (heapUsage > 0.9) {
+    versionToProgram.clear();
+  }
+
   return newProgram;
 }
 

--- a/packages/eslint-plugin/src/rules/expect.ts
+++ b/packages/eslint-plugin/src/rules/expect.ts
@@ -200,7 +200,8 @@ function getProgram(
     versionToProgram.set(cacheKey, newProgram);
   }
 
-  const heapUsage = v8.getHeapStatistics().used_heap_size / v8.getHeapStatistics().heap_size_limit;
+  const heapStats = v8.getHeapStatistics();
+  const heapUsage = heapStats.used_heap_size / heapStats.heap_size_limit;
   if (heapUsage > 0.9) {
     versionToProgram.clear();
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -397,7 +397,7 @@ importers:
         version: /typescript@5.5.2
       typescript-5.6:
         specifier: npm:typescript@~5.6.0-0
-        version: /typescript@5.6.0-dev.20240618
+        version: /typescript@5.6.0-dev.20240628
 
   packages/typescript-versions: {}
 
@@ -6918,8 +6918,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /typescript@5.6.0-dev.20240618:
-    resolution: {integrity: sha512-nUnATyFjcoenJB7S5oPGea2s0dd8MVl+2NisBLm7E+zpXkX0KSLy8Y7aFNSQ+r1Hs/MrKfSlV4O8yiQpCuOqrQ==}
+  /typescript@5.6.0-dev.20240628:
+    resolution: {integrity: sha512-XT57Gllario2IUjypenMgUbdHrNGtD52J13FyZckIC+h4ic13TllkJmoypbUr0HIYQ9IUB3SLq6/SaSBD4DoyQ==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: false


### PR DESCRIPTION
There is some controversy over whether this is completely reliable, but it seems to work well in my tests, with and without `--max-old-space-size` passed in.

I initially tried to just stop adding new programs to the cache at a certain threshold, but somehow memory still shoots up after no more programs are being created at a modest heap usage. So we do this check and purge even if the current `getProgram` call didn’t eat up more memory itself.

This fixes the recent openui5 CI OOM.