### PR TITLE
New project board: 2 small followups

### DIFF
--- a/packages/mergebot/README.md
+++ b/packages/mergebot/README.md
@@ -99,7 +99,7 @@ To create fixtures of a current PR:
 
 ```sh
 # To create a fixture for PR 43161
-pnpm run create-fixture -- 43161
+pnpm run create-fixture 43161
 ```
 
 Then you can work against these fixtures offline with:

--- a/packages/mergebot/src/run.ts
+++ b/packages/mergebot/src/run.ts
@@ -127,6 +127,7 @@ const start = async function () {
   console.log("Cleaning up cards");
   const { columns, id: projectId } = await getProjectBoardCards();
   const deleteObject = async (id: string) => {
+    console.log(`  Deleting card ${id}`);
     const mutation = createMutation<schema.DeleteProjectV2ItemInput>("deleteProjectV2Item", { projectId, itemId: id });
     await client.mutate(mutation);
   };
@@ -153,10 +154,10 @@ const start = async function () {
       if (!info) {
         // don't automatically delete these, eg, PRs that were created
         // during the scan would end up here.
-        return console.log(`  Should delete "${id}" (PR #???)`);
+        console.log(`  Should delete "${id}" (PR #???)`);
+      } else if (info.state !== "OPEN") {
+        await deleteObject(id);
       }
-      if (info.state === "OPEN") continue;
-      await deleteObject(id);
     }
   }
   if (failures.length) {

--- a/packages/mergebot/src/run.ts
+++ b/packages/mergebot/src/run.ts
@@ -126,12 +126,7 @@ const start = async function () {
   //
   console.log("Cleaning up cards");
   const { columns, id: projectId } = await getProjectBoardCards();
-  const deleteObject = async (id: string, shoulda?: string) => {
-    if (shoulda) {
-      // don't automatically delete these, eg, PRs that were created
-      // during the scan would end up here.
-      return console.log(`  Should delete "${id}" (${shoulda})`);
-    }
+  const deleteObject = async (id: string) => {
     const mutation = createMutation<schema.DeleteProjectV2ItemInput>("deleteProjectV2Item", { projectId, itemId: id });
     await client.mutate(mutation);
   };
@@ -150,15 +145,18 @@ const start = async function () {
   // Handle other columns
   for (const [name, cards] of columns) {
     if (name === "Recently Merged") continue;
-    const ids = cards.map((c) => c.id).filter((c) => !cardIDs.includes(c));
+    const ids = cards.map((c) => c.id).filter((id) => !cardIDs.includes(id));
     if (ids.length === 0) continue;
     console.log(`Cleaning up closed PRs in "${name}"`);
     for (const id of ids) {
       const info = await runQueryToGetPRForCardId(id);
-      await deleteObject(
-        id,
-        info === undefined ? "???" : info.state === "CLOSED" || info.state === "MERGED" ? undefined : "#" + info.number,
-      );
+      if (!info) {
+        // don't automatically delete these, eg, PRs that were created
+        // during the scan would end up here.
+        return console.log(`  Should delete "${id}" (PR #???)`);
+      }
+      if (info.state === "OPEN") continue;
+      await deleteObject(id);
     }
   }
   if (failures.length) {


### PR DESCRIPTION
1. Update the webhook for manual card moves. The code compiles but I have no idea how to test it -- I don't know what the rules are for manual moves that the bot will respect.
2. Fix the "Should delete" output of run.ts to not print for open PRs, only closed and merged ones that were created, then closed, during the run of run.ts itself. Also add "Deleting" output when *actually* deleting a PR.
3. Fix one now-incorrect syntax for a `pnpm` call in the README (`--` is no longer needed).