### PR TITLE
chore: add mapbox-gl to allowedPackageJsonDependencies.txt

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -795,6 +795,7 @@ long
 lottie-web
 magic-string
 mali
+mapbox-gl
 markdownlint
 marked
 meshoptimizer


### PR DESCRIPTION
Mapbox GL js [now has native types](https://github.com/mapbox/mapbox-gl-js/releases/tag/v3.5.0), so these are what should be imported for updated versions of child types.

Originally opened this to unblock the failing test at https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70144