### PR TITLE
Retry tags, exit only after too many errors

### DIFF
--- a/packages/retag/src/index.ts
+++ b/packages/retag/src/index.ts
@@ -14,6 +14,7 @@ import {
   LoggerWithErrors,
   cacheDir,
   nAtATime,
+  sleep,
 } from "@definitelytyped/utils";
 import { AnyPackage, TypingsData, AllPackages, getDefinitelyTyped } from "@definitelytyped/definitions-parser";
 import * as pacote from "pacote";
@@ -84,6 +85,7 @@ async function retry<T>(fn: () => Promise<T>, count: number): Promise<T> {
     try {
       return await fn();
     } catch (e) {
+      await sleep(5);
       lastError = e;
     }
   }

--- a/packages/retag/src/index.ts
+++ b/packages/retag/src/index.ts
@@ -65,7 +65,7 @@ async function tag(dry: boolean, definitelyTypedPath: string, name?: string) {
           const version = await getLatestTypingVersion(pkg);
           await updateTypeScriptVersionTags(pkg, version, publishClient, consoleLogger.info, dry);
           await updateLatestTag(pkg.name, version, publishClient, consoleLogger.info, dry);
-        }, 2);
+        }, /*count*/ 2, /*delaySeconds*/ 5);
       } catch (e: any) {
         consoleLogger.error(`Error tagging ${pkg.name}: ${e.stack || e}`);
         allowedErrors--;
@@ -79,13 +79,13 @@ async function tag(dry: boolean, definitelyTypedPath: string, name?: string) {
   // Don't tag notNeeded packages
 }
 
-async function retry<T>(fn: () => Promise<T>, count: number): Promise<T> {
+async function retry<T>(fn: () => Promise<T>, count: number, delaySeconds: number): Promise<T> {
   let lastError: any;
   for (let i = 0; i < count; i++) {
     try {
       return await fn();
     } catch (e) {
-      await sleep(5);
+      await sleep(delaySeconds);
       lastError = e;
     }
   }


### PR DESCRIPTION
https://github.com/microsoft/DefinitelyTyped-tools/actions/runs/10037065883 failed due to a 502 error, which should be retried. https://github.com/microsoft/DefinitelyTyped-tools/actions/runs/10140511504 failed due to a 400 error, which makes no sense.

Add some retries with a delay, ignore errors until we've seen too many.