### PR TITLE
Keep the newest 50 merged PRs, not the oldest 50 merged PRs

### DIFF
--- a/packages/mergebot/src/run.ts
+++ b/packages/mergebot/src/run.ts
@@ -137,7 +137,7 @@ const start = async function () {
     if (!recentlyMerged) {
       throw new Error(`Could not find the 'Recently Merged' column in ${Array.from(columns.keys())}`);
     }
-    const afterFirst50 = recentlyMerged.sort((l, r) => l.updatedAt.localeCompare(r.updatedAt)).slice(50);
+    const afterFirst50 = recentlyMerged.sort((l, r) => r.updatedAt.localeCompare(l.updatedAt)).slice(50);
     if (afterFirst50.length > 0) {
       console.log(`Cutting "Recently Merged" projects to the last 50`);
       for (const card of afterFirst50) await deleteObject(card.id);


### PR DESCRIPTION
I've been wondering why ancient PRs are on the board. The code here sorts the dates _ascending_, then throws away the first 50, deleting the rest. Except, that's the newest entries, which are the most important ones. Oops.