### PR TITLE
Add @webgpu/types to allowed external packages

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -631,6 +631,7 @@
 @uirouter/angularjs
 @vue/reactivity
 @vue/test-utils
+@webgpu/types
 @wordpress/api-fetch
 @wordpress/components
 @wordpress/core-data


### PR DESCRIPTION
@types/three will need to depend on these types (see https://github.com/three-types/three-ts-types/pull/1173)