### PR TITLE
Add sharp to allowed external packages

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -902,6 +902,7 @@ scroll-behavior
 scroll-into-view-if-needed
 semantic-ui-react
 serialize-query-params
+sharp
 shell-exec
 should
 simple-markdown


### PR DESCRIPTION
@types/puppeteer-screenshot-tester will depend on the types self-declared by the sharp package (see [this PR on DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70435))