### PR TITLE
fix: Remove async-retry from expectedNpmVersionFailures.txt

### DIFF
--- a/packages/dtslint/expectedNpmVersionFailures.txt
+++ b/packages/dtslint/expectedNpmVersionFailures.txt
@@ -24,7 +24,6 @@ app-root-dir
 arbiter
 assertsharp
 async-polling
-async-retry
 atmosphere.js
 atpl
 azdata


### PR DESCRIPTION
fix: Remove async-retry from expectedNpmVersionFailures.txt

Upon successful merge of [DefinitelyTyped PR #70552](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70552), `async-retry` can be removed from `expectedNpmVersionFailures.txt`.
