### PR TITLE
feat: Remove json-merge-patch from expectedNpmVersionFailures.txt

### DIFF
--- a/packages/dtslint/expectedNpmVersionFailures.txt
+++ b/packages/dtslint/expectedNpmVersionFailures.txt
@@ -215,7 +215,6 @@ js.spec
 jsbn
 jsdeferred
 json-editor
-json-merge-patch
 json-patch
 json-pointer
 json-schema


### PR DESCRIPTION
Upon successful merge of DefinitelyTyped [PR #70571](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70571), `json-merge-patch` can be removed from expectedNpmVersionFailures.txt.
