### PR TITLE
feat: Remove random-string from expectedNpmVersionFailures.txt

### DIFF
--- a/packages/dtslint/expectedNpmVersionFailures.txt
+++ b/packages/dtslint/expectedNpmVersionFailures.txt
@@ -337,7 +337,6 @@ purl
 q-retry
 qunit/v1
 radius
-random-string
 rangy
 raty
 react-better-password


### PR DESCRIPTION
Upon successful merge of DefinitelyTyped [PR #70658](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70658), `random-string` can be removed from expectedNpmVersionFailures.txt.
