### PR TITLE
feat: Remove noisejs from expectedNpmVersionFailures.txt

### DIFF
--- a/packages/dtslint/expectedNpmVersionFailures.txt
+++ b/packages/dtslint/expectedNpmVersionFailures.txt
@@ -295,7 +295,6 @@ node-sass-middleware
 node-uuid
 nodegit
 nodeunit
-noisejs
 nomnom
 notify
 notifyjs-browser


### PR DESCRIPTION
Upon successful merge of DefinitelyTyped [PR #70665](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70665), `noisejs` can be removed from expectedNpmVersionFailures.txt.
