### PR TITLE
feat: Remove multiparty from expectedNpmVersionFailures.txt

### DIFF
--- a/packages/dtslint/expectedNpmVersionFailures.txt
+++ b/packages/dtslint/expectedNpmVersionFailures.txt
@@ -279,7 +279,6 @@ moment-precise-range-plugin
 mongoose-promise
 msgpack
 mu2
-multiparty
 natural-sort
 nedb-logger
 neo4j


### PR DESCRIPTION
Upon successful merge of DefinitelyTyped [PR #70666](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70666), `multiparty` can be removed from expectedNpmVersionFailures.txt.
