### PR TITLE
feat: Remove milliseconds from expectedNpmVersionFailures.txt

### DIFF
--- a/packages/dtslint/expectedNpmVersionFailures.txt
+++ b/packages/dtslint/expectedNpmVersionFailures.txt
@@ -267,7 +267,6 @@ merge-stream
 messenger
 method-override
 microservice-utilities
-milliseconds
 mina
 mixpanel
 mixto


### PR DESCRIPTION
Upon successful merge of DefinitelyTyped [PR #70674](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70674), `milliseconds` can be removed from expectedNpmVersionFailures.txt.
