### PR TITLE
feat: Remove domurl from expectedNpmVersionFailures.txt

### DIFF
--- a/packages/dtslint/expectedNpmVersionFailures.txt
+++ b/packages/dtslint/expectedNpmVersionFailures.txt
@@ -88,7 +88,6 @@ decorum
 deep-freeze
 deku
 desmos
-domurl
 double-ended-queue
 dts-bundle
 durandal/v1


### PR DESCRIPTION
Upon successful merge of DefinitelyTyped [PR #70675](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70675), `domurl` can be removed from expectedNpmVersionFailures.txt.
