### PR TITLE
feat: Remove lazypipe from expectedNpmVersionFailures.txt

### DIFF
--- a/packages/dtslint/expectedNpmVersionFailures.txt
+++ b/packages/dtslint/expectedNpmVersionFailures.txt
@@ -233,7 +233,6 @@ knockstrap
 koa-proxy
 konami.js
 kos-core
-lazypipe
 leadfoot
 leaflet-curve
 leaflet-editable/v0


### PR DESCRIPTION
Upon successful merge of DefinitelyTyped [PR #70686](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70686), `lazypipe` can be removed from expectedNpmVersionFailures.txt.
