### PR TITLE
feat: Remove merge-stream from expectedNpmVersionFailures.txt

### DIFF
--- a/packages/dtslint/expectedNpmVersionFailures.txt
+++ b/packages/dtslint/expectedNpmVersionFailures.txt
@@ -261,7 +261,6 @@ material-ui
 mathjax
 mdast
 mem-cache
-merge-stream
 messenger
 method-override
 microservice-utilities


### PR DESCRIPTION
Upon successful merge of DefinitelyTyped [PR #70701](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70701), `merge-stream` can be removed from expectedNpmVersionFailures.txt.
