### PR TITLE
feat: Remove gulp-help-doc from expectedNpmVersionFailures.txt

### DIFF
--- a/packages/dtslint/expectedNpmVersionFailures.txt
+++ b/packages/dtslint/expectedNpmVersionFailures.txt
@@ -154,7 +154,6 @@ gulp-changed
 gulp-cheerio
 gulp-coffeeify
 gulp-espower
-gulp-help-doc
 gulp-load-plugins
 gulp-mocha
 gulp-ng-annotate


### PR DESCRIPTION
Upon successful merge of DefinitelyTyped [PR #70708](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70708), `gulp-help-doc` can be removed from expectedNpmVersionFailures.txt.
