### PR TITLE
feat: Remove svg-injector from expectedNpmVersionFailures.txt

### DIFF
--- a/packages/dtslint/expectedNpmVersionFailures.txt
+++ b/packages/dtslint/expectedNpmVersionFailures.txt
@@ -412,7 +412,6 @@ stream-series
 stream-to-array/v0
 styled-components-react-native
 succinct
-svg-injector
 swagger-schema-official
 swig
 swipe


### PR DESCRIPTION
Upon successful merge of DefinitelyTyped [PR #70722](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70722), `svg-injector` can be removed from expectedNpmVersionFailures.txt.
