### PR TITLE
feat: Add esbuild to allowedPackageJsonDependencies.txt

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -718,6 +718,7 @@ ember-qunit
 ember-resolver
 ember-source
 eris
+esbuild
 eslint-visitor-keys
 ethers
 eventemitter2


### PR DESCRIPTION
There are existing esbuild-plugin in the DT repo currently, including one of my ongoing [PR #70733](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70733). To facilitate adding or modifying these types in DT side, I would like to ask DT-tools maintainer to kindly accept and merge this PR.