### PR TITLE
feat: Add focus-trap to allowedPackageJsonDependencies.txt

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -735,6 +735,7 @@ final-form
 firebase-admin
 flatbush
 flatpickr
+focus-trap
 form-data
 fs-capacitor
 fs-jetpack


### PR DESCRIPTION
Needed for [DT PR #70863](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70863).

`focus-trap` has 1.4M weekly downloads, and only contain 1 dependency `"tabbable": "^6.2.0"` from its [package.json](https://github.com/focus-trap/focus-trap/blob/b20124419632e76c497ef9dd75c329e85f116b50/package.json#L66-L68)

I think it is reasonable to have it in DT-tool allowed dep list. 