### PR TITLE
feat: Remove rison from expectedNpmVersionFailures.txt

### DIFF
--- a/packages/dtslint/expectedNpmVersionFailures.txt
+++ b/packages/dtslint/expectedNpmVersionFailures.txt
@@ -373,7 +373,6 @@ rickshaw
 riderize__passport-strava-oauth2
 riot-api-nodejs
 riotjs
-rison
 rn-fetch-blob
 rollup-plugin-svelte-svg
 rosie


### PR DESCRIPTION
Upon successful merge of [DT PR #70883](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70883), `rison` can be removed from expectedNpmVersionFailures.txt.
