### PR TITLE
feat: Add `@wordpress/media-utils` to allowed dependencies list

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -638,6 +638,7 @@
 @wordpress/data
 @wordpress/element
 @wordpress/keycodes
+@wordpress/media-utils
 abort-controller
 acorn
 actions-on-google


### PR DESCRIPTION
Needed for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70889 which removes `@types/wordpress__media-utils`, but the @types/wordpress_editor` package needs some types from `@wordpress/media-utils` now.