### PR TITLE
feat: Remove natural-sort from expectedNpmVersionFailures.txt

### DIFF
--- a/packages/dtslint/expectedNpmVersionFailures.txt
+++ b/packages/dtslint/expectedNpmVersionFailures.txt
@@ -274,7 +274,6 @@ moment-precise-range-plugin
 mongoose-promise
 msgpack
 mu2
-natural-sort
 nedb-logger
 neo4j
 netlify-auth-providers


### PR DESCRIPTION
Upon successful merge of [DT PR #70898](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70898), `natural-sort` can be removed from expectedNpmVersionFailures.txt.
