### PR TITLE
feat: Remove stream-meter from expectedNpmVersionFailures.txt

### DIFF
--- a/packages/dtslint/expectedNpmVersionFailures.txt
+++ b/packages/dtslint/expectedNpmVersionFailures.txt
@@ -405,7 +405,6 @@ socket.io.users
 soundjs
 space-pen
 spectrum
-stream-meter
 stream-series
 stream-to-array/v0
 styled-components-react-native


### PR DESCRIPTION
Upon successful merge of [DT PR #70961](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70961), `stream-meter` can be removed from expectedNpmVersionFailures.txt.
