### PR TITLE
feat: Remove sleep from expectedNpmVersionFailures.txt

### DIFF
--- a/packages/dtslint/expectedNpmVersionFailures.txt
+++ b/packages/dtslint/expectedNpmVersionFailures.txt
@@ -400,7 +400,6 @@ simple-xml
 sipml
 six-runtime
 ski
-sleep
 socket.io.users
 soundjs
 space-pen


### PR DESCRIPTION
Upon successful merge of [DT PR #70979](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70979), `sleep` can be removed from expectedNpmVersionFailures.txt.
