### PR TITLE
feat: Remove run-sequence from expectedNpmVersionFailures.txt

### DIFF
--- a/packages/dtslint/expectedNpmVersionFailures.txt
+++ b/packages/dtslint/expectedNpmVersionFailures.txt
@@ -377,7 +377,6 @@ rollup-plugin-svelte-svg
 rosie
 route-parser
 routie
-run-sequence
 rx-jquery
 rx-node
 s3-uploader


### PR DESCRIPTION
Upon successful merge of [DT PR #70990](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70990), `run-sequence` can be removed from expectedNpmVersionFailures.txt.