### PR TITLE
feat: Remove stream-series from expectedNpmVersionFailures.txt

### DIFF
--- a/packages/dtslint/expectedNpmVersionFailures.txt
+++ b/packages/dtslint/expectedNpmVersionFailures.txt
@@ -404,7 +404,6 @@ socket.io.users
 soundjs
 space-pen
 spectrum
-stream-series
 stream-to-array/v0
 styled-components-react-native
 succinct


### PR DESCRIPTION
Upon successful merge of [DT PR #71002](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71002), `stream-series` can be removed from expectedNpmVersionFailures.txt.