### PR TITLE
feat: Remove shortid from expectedNpmVersionFailures.txt

### DIFF
--- a/packages/dtslint/expectedNpmVersionFailures.txt
+++ b/packages/dtslint/expectedNpmVersionFailures.txt
@@ -391,7 +391,6 @@ scrolltofixed
 sequencify
 servicenow
 sharepoint
-shortid
 signalfx-collect
 signalr/v1
 simple-cw-node


### PR DESCRIPTION
Upon successful merge of [DT PR #71003](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71003), `shortid` can be removed from expectedNpmVersionFailures.txt.
