### PR TITLE
feat: Remove tz-format from expectedNpmVersionFailures.txt

### DIFF
--- a/packages/dtslint/expectedNpmVersionFailures.txt
+++ b/packages/dtslint/expectedNpmVersionFailures.txt
@@ -423,7 +423,6 @@ topojson
 torrent-stream
 trayballoon
 trim
-tz-format
 underscore-ko
 underscore.string
 url-join/v0


### PR DESCRIPTION
Upon successful merge of [DT PR #71041](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71041), `tz-format` can be removed from expectedNpmVersionFailures.txt.
