### PR TITLE
feat: Remove friendly-errors-webpack-plugin from expectedNpmVersionFailures.txt

### DIFF
--- a/packages/dtslint/expectedNpmVersionFailures.txt
+++ b/packages/dtslint/expectedNpmVersionFailures.txt
@@ -132,7 +132,6 @@ flot
 flowjs
 fm-websync
 foundation
-friendly-errors-webpack-plugin
 ftdomdelegate
 gamedig
 generic-functions


### PR DESCRIPTION
Upon successful merge of [DT PR #71061](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71061), `friendly-errors-webpack-plugin` can be removed from expectedNpmVersionFailures.txt.
