### PR TITLE
feat: Remove trayballoon from expectedNpmVersionFailures.txt

### DIFF
--- a/packages/dtslint/expectedNpmVersionFailures.txt
+++ b/packages/dtslint/expectedNpmVersionFailures.txt
@@ -421,7 +421,6 @@ tinajs__tina-redux
 tooltipster
 topojson
 torrent-stream
-trayballoon
 trim
 underscore-ko
 underscore.string


### PR DESCRIPTION
Upon successful merge of [DT PR #71062](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71062), `trayballoon` can be removed from expectedNpmVersionFailures.txt.