### PR TITLE
feat: Remove moment-business from expectedNpmVersionFailures.txt

### DIFF
--- a/packages/dtslint/expectedNpmVersionFailures.txt
+++ b/packages/dtslint/expectedNpmVersionFailures.txt
@@ -268,7 +268,6 @@ mixto
 mojang-minecraft-server-admin
 mojang-minecraft-ui
 mojang-net
-moment-business
 moment-precise-range-plugin
 mongoose-promise
 msgpack


### PR DESCRIPTION
Upon successful merge of [DT PR #71072](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71072), `moment-business` can be removed from expectedNpmVersionFailures.txt.