### PR TITLE
feat: Remove moment-precise-range-plugin from expectedNpmVersionFailures.txt

### DIFF
--- a/packages/dtslint/expectedNpmVersionFailures.txt
+++ b/packages/dtslint/expectedNpmVersionFailures.txt
@@ -269,7 +269,6 @@ mojang-minecraft-server-admin
 mojang-minecraft-ui
 mojang-net
 moment-business
-moment-precise-range-plugin
 mongoose-promise
 msgpack
 mu2


### PR DESCRIPTION
Upon successful merge of [DT PR #71074](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71074), `moment-precise-range-plugin` can be removed from expectedNpmVersionFailures.txt.
