### PR TITLE
feat: Remove react-s-alert from expectedNpmVersionFailures.txt

### DIFF
--- a/packages/dtslint/expectedNpmVersionFailures.txt
+++ b/packages/dtslint/expectedNpmVersionFailures.txt
@@ -352,7 +352,6 @@ react-pointable
 react-router-navigation
 react-router-navigation-core
 react-router-redux
-react-s-alert
 react-sortable-tree
 react-sortable-tree-theme-file-explorer
 react-svg-pan-zoom-loader


### PR DESCRIPTION
Upon successful merge of [DT PR #71101](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71101), `react-s-alert` can be removed from expectedNpmVersionFailures.txt.
