### PR TITLE
Update TS versions; removing 4.8, shipping 5.6, supporting 5.8

### DIFF
--- a/.changeset/sweet-crews-impress.md
+++ b/.changeset/sweet-crews-impress.md
@@ -1,0 +1,6 @@
+---
+"@definitelytyped/typescript-packages": patch
+"@definitelytyped/typescript-versions": patch
+---
+
+Update TS versions; removing 4.8, shipping 5.6, supporting 5.8

--- a/packages/publisher/test/generate-packages.test.ts
+++ b/packages/publisher/test/generate-packages.test.ts
@@ -169,7 +169,7 @@ testo({
         "@types/express": "*"
     },
     "typesPublisherContentHash": "53300522250468c4161b10d962cac2d9d8f2cfee1b3dfef4b749a7c3ec839275",
-    "typeScriptVersion": "4.8"
+    "typeScriptVersion": "4.9"
 }`);
   },
   basicNotNeededPackageJson() {

--- a/packages/typescript-packages/package.json
+++ b/packages/typescript-packages/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@definitelytyped/typescript-versions": "workspace:*",
-    "typescript-4.8": "npm:typescript@~4.8.0-0",
     "typescript-4.9": "npm:typescript@~4.9.0-0",
     "typescript-5.0": "npm:typescript@~5.0.0-0",
     "typescript-5.1": "npm:typescript@~5.1.0-0",
@@ -31,6 +30,7 @@
     "typescript-5.4": "npm:typescript@~5.4.0-0",
     "typescript-5.5": "npm:typescript@~5.5.0-0",
     "typescript-5.6": "npm:typescript@~5.6.0-0",
-    "typescript-5.7": "npm:typescript@~5.7.0-0"
+    "typescript-5.7": "npm:typescript@~5.7.0-0",
+    "typescript-5.8": "npm:typescript@~5.8.0-0"
   }
 }

--- a/packages/typescript-versions/src/index.ts
+++ b/packages/typescript-versions/src/index.ts
@@ -41,9 +41,9 @@ export type AllTypeScriptVersion = UnsupportedTypeScriptVersion | TypeScriptVers
 
 export namespace TypeScriptVersion {
   /** Add to this list when a version actually ships.  */
-  export const shipped = ["4.8", "4.9", "5.0", "5.1", "5.2", "5.3", "5.4", "5.5"] as const;
+  export const shipped = ["4.9", "5.0", "5.1", "5.2", "5.3", "5.4", "5.5", "5.6"] as const;
   /** Add to this list when a version is available as typescript@next */
-  export const supported = [...shipped, "5.6", "5.7"] as const;
+  export const supported = [...shipped, "5.7", "5.8"] as const;
   /** Add to this list when it will no longer be supported on Definitely Typed */
   export const unsupported = [
     "2.0",
@@ -74,6 +74,7 @@ export namespace TypeScriptVersion {
     "4.5",
     "4.6",
     "4.7",
+    "4.8",
   ] as const;
   export const all: readonly AllTypeScriptVersion[] = [...unsupported, ...supported];
   export const lowest = supported[0];

--- a/packages/typescript-versions/test/index.test.ts
+++ b/packages/typescript-versions/test/index.test.ts
@@ -18,13 +18,13 @@ describe("all", () => {
 
 describe("isSupported", () => {
   it("works", () => {
-    expect(TypeScriptVersion.isSupported("5.1")).toBeTruthy();
+    expect(TypeScriptVersion.isSupported("5.6")).toBeTruthy();
   });
-  it("supports 4.8", () => {
-    expect(TypeScriptVersion.isSupported("4.8")).toBeTruthy();
+  it("supports 4.9", () => {
+    expect(TypeScriptVersion.isSupported("4.9")).toBeTruthy();
   });
-  it("does not support 4.7", () => {
-    expect(!TypeScriptVersion.isSupported("4.7")).toBeTruthy();
+  it("does not support 4.8", () => {
+    expect(!TypeScriptVersion.isSupported("4.8")).toBeTruthy();
   });
 });
 
@@ -42,10 +42,10 @@ describe("isTypeScriptVersion", () => {
 
 describe("range", () => {
   it("works", () => {
-    expect(TypeScriptVersion.range("4.9")).toEqual(["4.9", "5.0", "5.1", "5.2", "5.3", "5.4", "5.5", "5.6", "5.7"]);
+    expect(TypeScriptVersion.range("5.0")).toEqual(["5.0", "5.1", "5.2", "5.3", "5.4", "5.5", "5.6", "5.7", "5.8"]);
   });
   it("includes 4.8 onwards", () => {
-    expect(TypeScriptVersion.range("4.8")).toEqual(TypeScriptVersion.supported);
+    expect(TypeScriptVersion.range("4.9")).toEqual(TypeScriptVersion.supported);
   });
 });
 
@@ -60,11 +60,12 @@ describe("tagsToUpdate", () => {
       "ts5.5",
       "ts5.6",
       "ts5.7",
+      "ts5.8",
       "latest",
     ]);
   });
-  it("allows 4.8 onwards", () => {
-    expect(TypeScriptVersion.tagsToUpdate("4.8")).toEqual(
+  it("allows 4.9 onwards", () => {
+    expect(TypeScriptVersion.tagsToUpdate("4.9")).toEqual(
       TypeScriptVersion.supported.map((s) => "ts" + s).concat("latest"),
     );
   });

--- a/packages/typescript-versions/test/index.test.ts
+++ b/packages/typescript-versions/test/index.test.ts
@@ -44,7 +44,7 @@ describe("range", () => {
   it("works", () => {
     expect(TypeScriptVersion.range("5.0")).toEqual(["5.0", "5.1", "5.2", "5.3", "5.4", "5.5", "5.6", "5.7", "5.8"]);
   });
-  it("includes 4.8 onwards", () => {
+  it("includes 4.9 onwards", () => {
     expect(TypeScriptVersion.range("4.9")).toEqual(TypeScriptVersion.supported);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -450,9 +450,6 @@ importers:
       '@definitelytyped/typescript-versions':
         specifier: workspace:*
         version: link:../typescript-versions
-      typescript-4.8:
-        specifier: npm:typescript@~4.8.0-0
-        version: /typescript@4.8.4
       typescript-4.9:
         specifier: npm:typescript@~4.9.0-0
         version: /typescript@4.9.5
@@ -480,6 +477,9 @@ importers:
       typescript-5.7:
         specifier: npm:typescript@~5.7.0-0
         version: /typescript@5.7.0-dev.20240930
+      typescript-5.8:
+        specifier: npm:typescript@~5.8.0-0
+        version: /typescript@5.8.0-dev.20241106
 
   packages/typescript-versions: {}
 
@@ -10030,12 +10030,6 @@ packages:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
     dev: false
 
-  /typescript@4.8.4:
-    resolution: {integrity: sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
-    dev: false
-
   /typescript@4.9.5:
     resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
@@ -10089,6 +10083,12 @@ packages:
 
   /typescript@5.7.0-dev.20240930:
     resolution: {integrity: sha512-mGW96cpbwcYuc264UPqGpKBLNebFFtVEXRLPwSwxVEub9tSyMI+XGFGxsznop7pU8E1ntx4OC4cN1n5MnzO0+Q==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: false
+
+  /typescript@5.8.0-dev.20241106:
+    resolution: {integrity: sha512-oFqIoJnR/s4hq5I2MBDdeJThRVyyhRV5eo2EmxllNkSe76ycucq2h4QgWnq0g4Opf4KQjpi1m/jhgMoiwDc8CQ==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -473,7 +473,7 @@ importers:
         version: /typescript@5.5.2
       typescript-5.6:
         specifier: npm:typescript@~5.6.0-0
-        version: /typescript@5.6.0-dev.20240628
+        version: /typescript@5.6.3
       typescript-5.7:
         specifier: npm:typescript@~5.7.0-0
         version: /typescript@5.7.0-dev.20240930
@@ -10069,12 +10069,6 @@ packages:
     resolution: {integrity: sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==}
     engines: {node: '>=14.17'}
     hasBin: true
-
-  /typescript@5.6.0-dev.20240628:
-    resolution: {integrity: sha512-XT57Gllario2IUjypenMgUbdHrNGtD52J13FyZckIC+h4ic13TllkJmoypbUr0HIYQ9IUB3SLq6/SaSBD4DoyQ==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-    dev: false
 
   /typescript@5.6.3:
     resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}


### PR DESCRIPTION
Seemingly forgotten at the release of 5.6.

When 5.7 comes out, 4.9 will be dropped too.