### PR TITLE
Fix cache being checked in by changesets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ packages/utils/cache
 !**/.vscode/settings.template.json
 !**/.vscode/launch.json
 !**/.vscode/extensions.json
+
+/cache

--- a/packages/publisher/test/isAlreadyDeprecated.test.ts
+++ b/packages/publisher/test/isAlreadyDeprecated.test.ts
@@ -2,7 +2,7 @@ import { NotNeededPackage } from "@definitelytyped/definitions-parser";
 import { isAlreadyDeprecated } from "../src/calculate-versions";
 
 describe("isAlreadyDeprecated", () => {
-  const shouldSkip = !process.env.CI;
+  const shouldSkip = !process.env.GITHUB_ACTIONS;
 
   (shouldSkip ? it.skip : it)("should report @types/commander as deprecated", async () => {
     const pkg = new NotNeededPackage("@types/commander", "commander", "2.12.2");


### PR DESCRIPTION
I guess in CI, we put the cache in a dir in the repo instead of tmp. Ignore that dir so the changeset workflow doesn't commit it, and then also make the CI check consistent with other uses.