### PR TITLE
feat: Remove vinyl-paths from expectedNpmVersionFailures.txt

### DIFF
--- a/packages/dtslint/expectedNpmVersionFailures.txt
+++ b/packages/dtslint/expectedNpmVersionFailures.txt
@@ -432,7 +432,6 @@ utils-merge
 uws
 venn
 viewporter
-vinyl-paths
 vision/v4
 vscode
 vue-datetime


### PR DESCRIPTION
Upon successful merge of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71170, `vinyl-paths` can be removed from expectedNpmVersionFailures.txt.