### PR TITLE
Fix incorrect newlines in package readmes with peer deps

### DIFF
--- a/packages/publisher/src/generate-packages.ts
+++ b/packages/publisher/src/generate-packages.ts
@@ -81,7 +81,7 @@ async function generateTypingPackage(typing: TypingsData, version: string, dt: F
       ? typesDirectory
       : typesDirectory.subDir(typing.versionDirectoryName);
 
-  await writeCommonOutputs(typing, createPackageJSON(typing, version), createReadme(typing, packageFS));
+  await writeCommonOutputs(typing, createPackageJSON(typing, version), createReadme(typing, packageFS, new Date()));
   await Promise.all(
     typing.getFiles().map(async (file) => writeFile(await outputFilePath(typing, file), packageFS.readFile(file))),
   );
@@ -170,7 +170,7 @@ export function createNotNeededPackageJSON(pkg: NotNeededPackage): string {
   return JSON.stringify(out, undefined, 4);
 }
 
-export function createReadme(typing: TypingsData, packageFS: FS): string {
+export function createReadme(typing: TypingsData, packageFS: FS, now: Date): string {
   const lines: string[] = [];
   lines.push("# Installation");
   lines.push(`> \`npm install --save ${typing.name}\``);
@@ -199,7 +199,7 @@ export function createReadme(typing: TypingsData, packageFS: FS): string {
 
   lines.push("");
   lines.push("### Additional Details");
-  lines.push(` * Last updated: ${new Date().toUTCString()}`);
+  lines.push(` * Last updated: ${now.toUTCString()}`);
   const dependencies = Object.keys(typing.dependencies).sort();
   lines.push(
     ` * Dependencies: ${

--- a/packages/publisher/src/generate-packages.ts
+++ b/packages/publisher/src/generate-packages.ts
@@ -206,14 +206,13 @@ export function createReadme(typing: TypingsData, packageFS: FS, now: Date): str
       dependencies.length ? dependencies.map((d) => `[${d}](https://npmjs.com/package/${d})`).join(", ") : "none"
     }`,
   );
-  lines.push("");
   const peerDependencies = Object.keys(typing.peerDependencies).sort();
   if (peerDependencies.length) {
     lines.push(
       ` * Peer dependencies: ${peerDependencies.map((d) => `[${d}](https://npmjs.com/package/${d})`).join(", ")}`,
     );
-    lines.push("");
   }
+  lines.push("");
 
   lines.push("# Credits");
   const contributors = typing.contributors

--- a/packages/publisher/test/__snapshots__/generate-packages.test.ts.snap
+++ b/packages/publisher/test/__snapshots__/generate-packages.test.ts.snap
@@ -97,7 +97,7 @@ This package contains type definitions for jquery (jquery.org).
 Files were exported from https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/jquery.
 
 ### Additional Details
- * Last updated: Mon, 09 Dec 2024 20:00:00 GMT
+ * Last updated: Mon, 09 Dec 2024 20:10:05 GMT
  * Dependencies: [@types/madeira](https://npmjs.com/package/@types/madeira)
  * Peer dependencies: [@types/express](https://npmjs.com/package/@types/express)
 
@@ -122,7 +122,7 @@ type T = import("./types");
 \`\`\`\`
 
 ### Additional Details
- * Last updated: Mon, 09 Dec 2024 20:00:00 GMT
+ * Last updated: Mon, 09 Dec 2024 20:10:05 GMT
  * Dependencies: [@types/madeira](https://npmjs.com/package/@types/madeira)
  * Peer dependencies: [@types/express](https://npmjs.com/package/@types/express)
 
@@ -147,7 +147,7 @@ type T = import("./types");
 \`\`\`\`
 
 ### Additional Details
- * Last updated: Mon, 09 Dec 2024 20:00:00 GMT
+ * Last updated: Mon, 09 Dec 2024 20:10:05 GMT
  * Dependencies: [@types/example](https://npmjs.com/package/@types/example), [@types/madeira](https://npmjs.com/package/@types/madeira)
  * Peer dependencies: [@types/example2](https://npmjs.com/package/@types/example2), [@types/express](https://npmjs.com/package/@types/express)
 

--- a/packages/publisher/test/__snapshots__/generate-packages.test.ts.snap
+++ b/packages/publisher/test/__snapshots__/generate-packages.test.ts.snap
@@ -99,7 +99,6 @@ Files were exported from https://github.com/DefinitelyTyped/DefinitelyTyped/tree
 ### Additional Details
  * Last updated: Mon, 09 Dec 2024 20:00:00 GMT
  * Dependencies: [@types/madeira](https://npmjs.com/package/@types/madeira)
-
  * Peer dependencies: [@types/express](https://npmjs.com/package/@types/express)
 
 # Credits
@@ -125,7 +124,6 @@ type T = import("./types");
 ### Additional Details
  * Last updated: Mon, 09 Dec 2024 20:00:00 GMT
  * Dependencies: [@types/madeira](https://npmjs.com/package/@types/madeira)
-
  * Peer dependencies: [@types/express](https://npmjs.com/package/@types/express)
 
 # Credits
@@ -151,7 +149,6 @@ type T = import("./types");
 ### Additional Details
  * Last updated: Mon, 09 Dec 2024 20:00:00 GMT
  * Dependencies: [@types/example](https://npmjs.com/package/@types/example), [@types/madeira](https://npmjs.com/package/@types/madeira)
-
  * Peer dependencies: [@types/example2](https://npmjs.com/package/@types/example2), [@types/express](https://npmjs.com/package/@types/express)
 
 # Credits

--- a/packages/publisher/test/__snapshots__/generate-packages.test.ts.snap
+++ b/packages/publisher/test/__snapshots__/generate-packages.test.ts.snap
@@ -1,0 +1,175 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`apacheLicenseText 1`] = `
+"Copyright 2024 A, E
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
+`;
+
+exports[`basicNotNeededPackageJson 1`] = `
+"{
+    "name": "@types/absalom",
+    "version": "1.1.1",
+    "description": "Stub TypeScript definitions entry for alternate, which provides its own types definitions",
+    "main": "",
+    "scripts": {},
+    "license": "MIT",
+    "dependencies": {
+        "alternate": "*"
+    },
+    "deprecated": "This is a stub types definition. alternate provides its own type definitions, so you do not need this installed."
+}"
+`;
+
+exports[`basicPackageJson 1`] = `
+"{
+    "name": "@types/jquery",
+    "version": "1.0",
+    "description": "TypeScript definitions for jquery",
+    "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/jquery",
+    "license": "MIT",
+    "contributors": [
+        {
+            "name": "A",
+            "url": "b@c.d"
+        },
+        {
+            "name": "E",
+            "githubUsername": "e",
+            "url": "https://github.com/e"
+        }
+    ],
+    "main": "",
+    "types": "index.d.ts",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/DefinitelyTyped/DefinitelyTyped.git",
+        "directory": "types/jquery"
+    },
+    "scripts": {},
+    "dependencies": {
+        "@types/madeira": "^1"
+    },
+    "peerDependencies": {
+        "@types/express": "*"
+    },
+    "typesPublisherContentHash": "53300522250468c4161b10d962cac2d9d8f2cfee1b3dfef4b749a7c3ec839275",
+    "typeScriptVersion": "5.0"
+}"
+`;
+
+exports[`mitLicenseText 1`] = `
+"    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE
+"
+`;
+
+exports[`readmeContainsManyDTSFilesDoesNotAmendREADME 1`] = `
+"# Installation
+> \`npm install --save @types/jquery\`
+
+# Summary
+This package contains type definitions for jquery (jquery.org).
+
+# Details
+Files were exported from https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/jquery.
+
+### Additional Details
+ * Last updated: Mon, 09 Dec 2024 20:01:11 GMT
+ * Dependencies: [@types/madeira](https://npmjs.com/package/@types/madeira)
+
+ * Peer dependencies: [@types/express](https://npmjs.com/package/@types/express)
+
+# Credits
+These definitions were written by [A](b@c.d), and [E](https://github.com/e).
+"
+`;
+
+exports[`readmeJquery 1`] = `
+"# Installation
+> \`npm install --save @types/jquery\`
+
+# Summary
+This package contains type definitions for jquery (jquery.org).
+
+# Details
+Files were exported from https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/jquery.
+## [index.d.ts](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/jquery/index.d.ts)
+\`\`\`\`ts
+type T = import("./types");
+
+\`\`\`\`
+
+### Additional Details
+ * Last updated: Mon, 09 Dec 2024 20:01:11 GMT
+ * Dependencies: [@types/madeira](https://npmjs.com/package/@types/madeira)
+
+ * Peer dependencies: [@types/express](https://npmjs.com/package/@types/express)
+
+# Credits
+These definitions were written by [A](b@c.d), and [E](https://github.com/e).
+"
+`;
+
+exports[`readmeMultipleDependencies 1`] = `
+"# Installation
+> \`npm install --save @types/jquery\`
+
+# Summary
+This package contains type definitions for jquery (jquery.org).
+
+# Details
+Files were exported from https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/jquery.
+## [index.d.ts](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/jquery/index.d.ts)
+\`\`\`\`ts
+type T = import("./types");
+
+\`\`\`\`
+
+### Additional Details
+ * Last updated: Mon, 09 Dec 2024 20:01:11 GMT
+ * Dependencies: [@types/example](https://npmjs.com/package/@types/example), [@types/madeira](https://npmjs.com/package/@types/madeira)
+
+ * Peer dependencies: [@types/express](https://npmjs.com/package/@types/express)
+
+# Credits
+These definitions were written by [A](b@c.d), and [E](https://github.com/e).
+"
+`;
+
+exports[`scopedNotNeededPackageJson 1`] = `
+"{
+    "name": "@types/google-cloud__pubsub",
+    "version": "0.26.0",
+    "description": "Stub TypeScript definitions entry for @google-cloud/chubdub, which provides its own types definitions",
+    "main": "",
+    "scripts": {},
+    "license": "MIT",
+    "dependencies": {
+        "@google-cloud/chubdub": "*"
+    },
+    "deprecated": "This is a stub types definition. @google-cloud/chubdub provides its own type definitions, so you do not need this installed."
+}"
+`;

--- a/packages/publisher/test/__snapshots__/generate-packages.test.ts.snap
+++ b/packages/publisher/test/__snapshots__/generate-packages.test.ts.snap
@@ -97,7 +97,7 @@ This package contains type definitions for jquery (jquery.org).
 Files were exported from https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/jquery.
 
 ### Additional Details
- * Last updated: Mon, 09 Dec 2024 20:01:11 GMT
+ * Last updated: Mon, 09 Dec 2024 20:00:00 GMT
  * Dependencies: [@types/madeira](https://npmjs.com/package/@types/madeira)
 
  * Peer dependencies: [@types/express](https://npmjs.com/package/@types/express)
@@ -123,7 +123,7 @@ type T = import("./types");
 \`\`\`\`
 
 ### Additional Details
- * Last updated: Mon, 09 Dec 2024 20:01:11 GMT
+ * Last updated: Mon, 09 Dec 2024 20:00:00 GMT
  * Dependencies: [@types/madeira](https://npmjs.com/package/@types/madeira)
 
  * Peer dependencies: [@types/express](https://npmjs.com/package/@types/express)
@@ -149,7 +149,7 @@ type T = import("./types");
 \`\`\`\`
 
 ### Additional Details
- * Last updated: Mon, 09 Dec 2024 20:01:11 GMT
+ * Last updated: Mon, 09 Dec 2024 20:00:00 GMT
  * Dependencies: [@types/example](https://npmjs.com/package/@types/example), [@types/madeira](https://npmjs.com/package/@types/madeira)
 
  * Peer dependencies: [@types/express](https://npmjs.com/package/@types/express)

--- a/packages/publisher/test/__snapshots__/generate-packages.test.ts.snap
+++ b/packages/publisher/test/__snapshots__/generate-packages.test.ts.snap
@@ -152,7 +152,7 @@ type T = import("./types");
  * Last updated: Mon, 09 Dec 2024 20:00:00 GMT
  * Dependencies: [@types/example](https://npmjs.com/package/@types/example), [@types/madeira](https://npmjs.com/package/@types/madeira)
 
- * Peer dependencies: [@types/express](https://npmjs.com/package/@types/express)
+ * Peer dependencies: [@types/example2](https://npmjs.com/package/@types/example2), [@types/express](https://npmjs.com/package/@types/express)
 
 # Credits
 These definitions were written by [A](b@c.d), and [E](https://github.com/e).

--- a/packages/publisher/test/generate-packages.test.ts
+++ b/packages/publisher/test/generate-packages.test.ts
@@ -71,7 +71,7 @@ function defaultFS() {
   return dt;
 }
 
-const now = new Date("2024-12-09 12:00:00");
+const now = new Date(1733775005612);
 
 testo({
   mitLicenseText() {

--- a/packages/publisher/test/generate-packages.test.ts
+++ b/packages/publisher/test/generate-packages.test.ts
@@ -71,6 +71,8 @@ function defaultFS() {
   return dt;
 }
 
+const now = new Date("2024-12-09 12:00:00");
+
 testo({
   mitLicenseText() {
     const typing = new TypingsData(defaultFS().fs, createRawPackage(License.MIT), /*isLatest*/ true);
@@ -83,20 +85,20 @@ testo({
   readmeJquery() {
     const dt = defaultFS();
     const typing = new TypingsData(dt.fs, createRawPackage(License.Apache20), /*isLatest*/ true);
-    expect(createReadme(typing, dt.pkgFS("jquery"))).toMatchSnapshot();
+    expect(createReadme(typing, dt.pkgFS("jquery"), now)).toMatchSnapshot();
   },
   readmeMultipleDependencies() {
     const dt = defaultFS();
     const typing = new TypingsData(dt.fs, createRawPackage(License.Apache20), /*isLatest*/ true);
     typing.dependencies["@types/example"] = "*";
-    expect(createReadme(typing, dt.pkgFS("jquery"))).toMatchSnapshot();
+    expect(createReadme(typing, dt.pkgFS("jquery"), now)).toMatchSnapshot();
   },
   readmeContainsManyDTSFilesDoesNotAmendREADME() {
     const rawPkg = createRawPackage(License.Apache20);
     const dt = defaultFS();
     dt.pkgDir("jquery").set("other.d.ts", "");
     const typing = new TypingsData(dt.fs, rawPkg, /*isLatest*/ true);
-    expect(createReadme(typing, dt.fs)).toMatchSnapshot();
+    expect(createReadme(typing, dt.fs, now)).toMatchSnapshot();
   },
   basicPackageJson() {
     const typing = new TypingsData(defaultFS().fs, createRawPackage(License.MIT), /*isLatest*/ true);

--- a/packages/publisher/test/generate-packages.test.ts
+++ b/packages/publisher/test/generate-packages.test.ts
@@ -74,134 +74,42 @@ function defaultFS() {
 testo({
   mitLicenseText() {
     const typing = new TypingsData(defaultFS().fs, createRawPackage(License.MIT), /*isLatest*/ true);
-    expect(getLicenseFileText(typing)).toEqual(expect.stringContaining("MIT License"));
+    expect(getLicenseFileText(typing)).toMatchSnapshot();
   },
   apacheLicenseText() {
     const typing = new TypingsData(defaultFS().fs, createRawPackage(License.Apache20), /*isLatest*/ true);
-    expect(getLicenseFileText(typing)).toEqual(expect.stringContaining("Apache License, Version 2.0"));
+    expect(getLicenseFileText(typing)).toMatchSnapshot();
   },
-  basicReadme() {
+  readmeJquery() {
     const dt = defaultFS();
     const typing = new TypingsData(dt.fs, createRawPackage(License.Apache20), /*isLatest*/ true);
-    expect(createReadme(typing, dt.pkgFS("jquery"))).toEqual(
-      expect.stringContaining("This package contains type definitions for"),
-    );
-  },
-  readmeContainsContributors() {
-    const dt = defaultFS();
-    const typing = new TypingsData(dt.fs, createRawPackage(License.Apache20), /*isLatest*/ true);
-    expect(createReadme(typing, dt.pkgFS("jquery"))).toEqual(
-      expect.stringContaining("written by [A](b@c.d), and [E](https://github.com/e)"),
-    );
-  },
-  readmeContainsProjectName() {
-    const dt = defaultFS();
-    const typing = new TypingsData(dt.fs, createRawPackage(License.Apache20), /*isLatest*/ true);
-    expect(createReadme(typing, dt.pkgFS("jquery"))).toEqual(expect.stringContaining("jquery.org"));
-  },
-  readmeOneDependency() {
-    const dt = defaultFS();
-    const typing = new TypingsData(dt.fs, createRawPackage(License.Apache20), /*isLatest*/ true);
-    expect(createReadme(typing, dt.pkgFS("jquery"))).toEqual(
-      expect.stringContaining("Dependencies: [@types/madeira](https://npmjs.com/package/@types/madeira)"),
-    );
+    expect(createReadme(typing, dt.pkgFS("jquery"))).toMatchSnapshot();
   },
   readmeMultipleDependencies() {
     const dt = defaultFS();
     const typing = new TypingsData(dt.fs, createRawPackage(License.Apache20), /*isLatest*/ true);
     typing.dependencies["@types/example"] = "*";
-    expect(createReadme(typing, dt.pkgFS("jquery"))).toEqual(
-      expect.stringContaining(
-        "Dependencies: [@types/example](https://npmjs.com/package/@types/example), [@types/madeira](https://npmjs.com/package/@types/madeira)",
-      ),
-    );
-  },
-  readmeOnePeer() {
-    const dt = defaultFS();
-    const typing = new TypingsData(dt.fs, createRawPackage(License.Apache20), /*isLatest*/ true);
-    expect(createReadme(typing, dt.pkgFS("jquery"))).toEqual(
-      expect.stringContaining("Peer dependencies: [@types/express](https://npmjs.com/package/@types/express)"),
-    );
-  },
-  readmeContainsSingleFileDTS() {
-    const dt = defaultFS();
-    const typing = new TypingsData(dt.fs, createRawPackage(License.Apache20), /*isLatest*/ true);
-    expect(createReadme(typing, dt.pkgFS("jquery"))).toContain("type T = import");
+    expect(createReadme(typing, dt.pkgFS("jquery"))).toMatchSnapshot();
   },
   readmeContainsManyDTSFilesDoesNotAmendREADME() {
     const rawPkg = createRawPackage(License.Apache20);
     const dt = defaultFS();
     dt.pkgDir("jquery").set("other.d.ts", "");
     const typing = new TypingsData(dt.fs, rawPkg, /*isLatest*/ true);
-    expect(createReadme(typing, dt.fs)).not.toContain("type T = import");
+    expect(createReadme(typing, dt.fs)).toMatchSnapshot();
   },
   basicPackageJson() {
     const typing = new TypingsData(defaultFS().fs, createRawPackage(License.MIT), /*isLatest*/ true);
-    expect(createPackageJSON(typing, "1.0")).toEqual(`{
-    "name": "@types/jquery",
-    "version": "1.0",
-    "description": "TypeScript definitions for jquery",
-    "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/jquery",
-    "license": "MIT",
-    "contributors": [
-        {
-            "name": "A",
-            "url": "b@c.d"
-        },
-        {
-            "name": "E",
-            "githubUsername": "e",
-            "url": "https://github.com/e"
-        }
-    ],
-    "main": "",
-    "types": "index.d.ts",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/DefinitelyTyped/DefinitelyTyped.git",
-        "directory": "types/jquery"
-    },
-    "scripts": {},
-    "dependencies": {
-        "@types/madeira": "^1"
-    },
-    "peerDependencies": {
-        "@types/express": "*"
-    },
-    "typesPublisherContentHash": "53300522250468c4161b10d962cac2d9d8f2cfee1b3dfef4b749a7c3ec839275",
-    "typeScriptVersion": "5.0"
-}`);
+    expect(createPackageJSON(typing, "1.0")).toMatchSnapshot();;
   },
   basicNotNeededPackageJson() {
     const s = createNotNeededPackageJSON(createUnneededPackage());
-    expect(s).toEqual(`{
-    "name": "@types/absalom",
-    "version": "1.1.1",
-    "description": "Stub TypeScript definitions entry for alternate, which provides its own types definitions",
-    "main": "",
-    "scripts": {},
-    "license": "MIT",
-    "dependencies": {
-        "alternate": "*"
-    },
-    "deprecated": "This is a stub types definition. alternate provides its own type definitions, so you do not need this installed."
-}`);
+    expect(s).toMatchSnapshot();
   },
   scopedNotNeededPackageJson() {
     const scopedUnneeded = new NotNeededPackage("google-cloud__pubsub", "@google-cloud/chubdub", "0.26.0");
     const s = createNotNeededPackageJSON(scopedUnneeded);
-    expect(s).toEqual(`{
-    "name": "@types/google-cloud__pubsub",
-    "version": "0.26.0",
-    "description": "Stub TypeScript definitions entry for @google-cloud/chubdub, which provides its own types definitions",
-    "main": "",
-    "scripts": {},
-    "license": "MIT",
-    "dependencies": {
-        "@google-cloud/chubdub": "*"
-    },
-    "deprecated": "This is a stub types definition. @google-cloud/chubdub provides its own type definitions, so you do not need this installed."
-}`);
+    expect(s).toMatchSnapshot();
   },
   async versionedPackage() {
     const dt = defaultFS();

--- a/packages/publisher/test/generate-packages.test.ts
+++ b/packages/publisher/test/generate-packages.test.ts
@@ -91,6 +91,7 @@ testo({
     const dt = defaultFS();
     const typing = new TypingsData(dt.fs, createRawPackage(License.Apache20), /*isLatest*/ true);
     typing.dependencies["@types/example"] = "*";
+    typing.peerDependencies["@types/example2"] = "*";
     expect(createReadme(typing, dt.pkgFS("jquery"), now)).toMatchSnapshot();
   },
   readmeContainsManyDTSFilesDoesNotAmendREADME() {


### PR DESCRIPTION
`react-dom` used to look like:

![image](https://github.com/user-attachments/assets/2694e718-9e2d-4a51-9b42-8e189e93d5d1)

But now looks like this after adding peer deps:

![image](https://github.com/user-attachments/assets/0ef774f1-d437-4efa-8794-762f2867365f)

When I added peer deps, I missed that I screwed up this formatting.