### PR TITLE
add `mock-property` to the list of allowed deps

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -811,6 +811,7 @@ metascraper
 meteor-typings
 middy
 minipass
+mock-property
 moment
 moment-range
 moment-timezone


### PR DESCRIPTION
This unblocks https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71428 (and it's already a dep of `tape`, so anyone with `@types/tape` should already have it)