### PR TITLE
feat: Remove pkg from expectedNpmVersionFailures by hacking dtslint

### DIFF
--- a/packages/dtslint/expectedNpmVersionFailures.txt
+++ b/packages/dtslint/expectedNpmVersionFailures.txt
@@ -1,6 +1,5 @@
 akumina-core
 akumina-core/v4
-allure-js-commons
 amcharts
 amplifier
 amplify
@@ -40,7 +39,6 @@ bitcoin-computer__lib
 blissfuljs
 bluebird-global
 boolify-string
-bootstrap-datepicker
 bootstrap-maxlength
 bootstrap-switch
 bootstrap-touchspin
@@ -55,7 +53,6 @@ carbon__layout
 carbon__motion
 carbon__themes
 carbon__type
-chai-datetime
 chartjs-plugin-doughnutlabel-rebourne
 chessboardjs
 chui
@@ -105,9 +102,7 @@ ember/v1
 ember/v2
 ember/v3
 emissary
-emscripten
 engine-check
-epub
 eq.js
 es6-weak-map
 esbuild-plugin-import-map
@@ -133,14 +128,12 @@ flowjs
 fm-websync
 foundation
 ftdomdelegate
-gamedig
 generic-functions
 gensync
 gently
 git
 glidejs
 go
-google-closure-compiler
 google-libphonenumber
 google-one-tap
 graphql-resolve-batch
@@ -152,7 +145,6 @@ guid
 gulp-changed
 gulp-cheerio
 gulp-coffeeify
-gulp-espower
 gulp-load-plugins
 gulp-mocha
 gulp-ng-annotate
@@ -164,7 +156,6 @@ hasher
 hashset
 hashtable
 hasura
-hellosign-sdk
 heroku-logger
 hmscore__react-native-hms-push
 hookrouter
@@ -173,8 +164,6 @@ hyperscript
 ignore-by-default
 imagemagick
 imagemapster
-inherits
-iniparser
 ion-rangeslider/v1
 isomorphic-fetch
 istanbul-middleware
@@ -204,7 +193,6 @@ jquery.ui.layout
 jquery.uniform
 jquery/v1
 jquery/v2
-jqueryui
 js-clipper
 js-schema
 js-url
@@ -237,19 +225,12 @@ leaflet-editable/v0
 leaflet-gpx
 leaflet-label
 leaflet.awesome-markers/v0
-lerna__collect-updates
-lerna__package
-lerna__package-graph
-lerna__project
-lerna__query-graph
-lerna__run-topologically
 level-sublevel
 line-reader
 lls
 logg
 lowlight
 macaca-circular-json
-magic-number
 maildev
 mapbox
 markdown-it-lazy-headers
@@ -260,7 +241,6 @@ mathjax
 mdast
 mem-cache
 messenger
-method-override
 microservice-utilities
 mina
 mixpanel
@@ -303,7 +283,6 @@ passport-weibo
 pathfinding
 phonegap
 phonegap-facebook-plugin
-phonegap-nfc
 phonegap-plugin-barcodescanner
 photoshop
 pi-spi
@@ -316,7 +295,6 @@ pouchdb-http
 preact-i18n
 precise
 preloadjs
-prismic-dom
 promise-pg
 promise-pool
 promise-sftp
@@ -335,7 +313,6 @@ react-document-meta
 react-facebook-login-component
 react-infinite
 react-input-mask
-react-jsonschema-form
 react-key-handler
 react-linkify
 react-native-bluetooth-serial
@@ -356,7 +333,6 @@ react-svg-pan-zoom-loader
 react-swf
 react-tap-event-plugin
 react-touch
-react-user-tour
 readmore-js
 recharts-scale
 redux-form/v7
@@ -423,11 +399,9 @@ urlrouter
 usage
 user-agents
 user-event
-utils-merge
 uws
 venn
 viewporter
-vision/v4
 vscode
 vue-datetime
 waitme
@@ -446,7 +420,6 @@ wrench
 xmltojson
 xmpp__jid
 xsockets
-xss-filters
 yandex-money-sdk
 zengin-code
 zmq


### PR DESCRIPTION
Aim to remove unneeded packages from `expectedNpmVersionFailures.txt`, by hacking current dtslint implementation to check whether or not target packages will emit `"... can be removed from expectedNpmVersionFailures.txt in ..."` warning.

<details>
  <summary>
      Step 1. Add <code>packages/dtslint/src/check-package-in-expectedVersionFailures.ts</code> into <b>DT-tools repo</b>, and run <code>pnpm build</code>. <i>Note: Core logics are copied from <code>packages/dtslint/src/index.ts</code>. Hope they are correcly done :)</i>
  </summary>

```ts
#!/usr/bin/env node

import { getTypesVersions } from "@definitelytyped/header-parser";
import fs from "fs";
import { basename, dirname, join as joinPaths } from "path";
import {
  checkNpmVersionAndGetMatchingImplementationPackage,
  checkPackageJson,
} from "./checks";
import { packageDirectoryNameWithVersionFromPath, packageNameFromPath } from "./util";

async function main(): Promise<
  | { isRemovableFromExpectedNpmVersionFailures: boolean } 
  | void
> {
  const args = process.argv.slice(2);
  let dirPath = process.cwd();

  console.log(`dtslint@${require("../package.json").version}`);
  if (args.length === 1 && args[0] === "types") {
    console.log(
      "Please provide a package name to test.\nTo test all changed packages at once, run `pnpm run test-all`.",
    );
    process.exit(1);
  }

  for (const arg of args) {
    switch (arg) {
      default: {
        if (arg.startsWith("--")) {
          console.error(`Unknown option '${arg}'`);
          process.exit(1);
        }

        const path =
          arg.indexOf("@") === 0 && arg.indexOf("/") !== -1
            ? // we have a scoped module, e.g. @bla/foo
              // which should be converted to   bla__foo
              arg.slice(1).replace("/", "__")
            : arg;
        dirPath = joinPaths(dirPath, path);
      }
    }
  }

  const { 
    isRemovableFromExpectedNpmVersionFailures,
  } = await checkPackageInExpectedVersionFailures(dirPath);
  
  console.log(
    `${dirPath} isRemovableFromExpectedNpmVersionFailures? ${isRemovableFromExpectedNpmVersionFailures}`
  );
}

/**
 * @returns Warning text - should be displayed during the run, but does not indicate failure.
 */
async function checkPackageInExpectedVersionFailures(
  dirPath: string,
): Promise<{ isRemovableFromExpectedNpmVersionFailures: boolean }> {
  // Assert that we're really on DefinitelyTyped.
  const dtRoot = findDTRoot(dirPath);
  const packageName = packageNameFromPath(dirPath);
  const packageDirectoryNameWithVersion = packageDirectoryNameWithVersionFromPath(dirPath);
  assertPathIsInDefinitelyTyped(dirPath, dtRoot);
  assertPathIsNotBanned(packageName);
  assertPackageIsNotDeprecated(
    packageName,
    await fs.promises.readFile(joinPaths(dtRoot, "notNeededPackages.json"), "utf-8"),
  );

  const typesVersions = getTypesVersions(dirPath);
  const packageJson = checkPackageJson(dirPath, typesVersions);
  if (Array.isArray(packageJson)) {
    throw new Error("\n\t* " + packageJson.join("\n\t* "));
  }

  const warnings: string[] = [];

  const result = await checkNpmVersionAndGetMatchingImplementationPackage(
    packageJson,
    packageDirectoryNameWithVersion,
  );

  warnings.push(...result.warnings);

  return { 
    isRemovableFromExpectedNpmVersionFailures: warnings.some(warning => (
      warning.includes(" can be removed from expectedNpmVersionFailures.txt in ")
    )), 
  };
}

function findDTRoot(dirPath: string) {
  let path = dirPath;
  while (basename(path) !== "types" && dirname(path) !== "." && dirname(path) !== "/") {
    path = dirname(path);
  }
  return dirname(path);
}

function assertPathIsInDefinitelyTyped(dirPath: string, dtRoot: string): void {
  // TODO: It's not clear whether this assertion makes sense, and it's broken on Azure Pipelines (perhaps because DT isn't cloned into DefinitelyTyped)
  // Re-enable it later if it makes sense.
  // if (basename(dtRoot) !== "DefinitelyTyped")) {
  if (!fs.existsSync(joinPaths(dtRoot, "types"))) {
    throw new Error(
      "Since this type definition includes a header (a comment starting with `// Type definitions for`), " +
        "assumed this was a DefinitelyTyped package.\n" +
        "But it is not in a `DefinitelyTyped/types/xxx` directory: " +
        dirPath,
    );
  }
}

/**
 * Starting at some point in time, npm has banned all new packages whose names
 * contain the word `download`. However, some older packages exist that still
 * contain this name.
 * @NOTE for contributors: The list of literal exceptions below should ONLY be
 * extended with packages for which there already exists a corresponding type
 * definition package in the `@types` scope. More information:
 * https://github.com/microsoft/DefinitelyTyped-tools/pull/381.
 */
function assertPathIsNotBanned(packageName: string) {
  if (
    /(^|\W)download($|\W)/.test(packageName) &&
    packageName !== "download" &&
    packageName !== "downloadjs" &&
    packageName !== "s3-download-stream"
  ) {
    // Since npm won't release their banned-words list, we'll have to manually add to this list.
    throw new Error(`${packageName}: Contains the word 'download', which is banned by npm.`);
  }
}

export function assertPackageIsNotDeprecated(packageName: string, notNeededPackages: string) {
  const unneeded = JSON.parse(notNeededPackages).packages;
  if (Object.keys(unneeded).includes(packageName)) {
    throw new Error(`${packageName}: notNeededPackages.json has an entry for ${packageName}.
That means ${packageName} ships its own types, and @types/${packageName} was deprecated and removed from Definitely Typed.
If you want to re-add @types/${packageName}, please remove its entry from notNeededPackages.json.`);
  }
}

if (require.main === module) {
  main().catch((err) => {
    console.error(err.stack);
    process.exit(1);
  });
} else {
  module.exports = checkPackageInExpectedVersionFailures;
}
```

</details>

<details>
  <summary>
      Step 2. Add <code>update-expectedNpmVersionFailures-by-dtslint.js</code> into <b>DT repo</b>, and run <code>node ./update-expectedNpmVersionFailures-by-dtslint.js</code>. <i>Note: Async network calls firing in length-50 batches may (or may not) be too aggressive. Use it with cautious if you need to.</i>
  </summary>

```js
import fs from 'node:fs';
import { cwd } from 'node:process';
import { basename, dirname, join as joinPaths } from "node:path";

import checkPackageInExpectedVersionFailures from '../DefinitelyTyped-tools/packages/dtslint/dist/check-package-in-expectedVersionFailures.js';

const ATTW_PATH = './attw.json';
const EXPECTED_NPM_VERSION_FAILURES_PATH = '../DefinitelyTyped-tools/packages/dtslint/expectedNpmVersionFailures.txt';

const attw = fs.readFileSync(ATTW_PATH, { encoding: 'utf-8' });
const attwFailedPackageSet = new Set(JSON.parse(attw).failingPackages);

const currentExpectedNpmVersionFailures = (
    fs.readFileSync(
        EXPECTED_NPM_VERSION_FAILURES_PATH,
        { encoding: 'utf-8' },
    )
);
let updatedExpectedNpmVersionFailures;

{
    const currentDtToolsFailedPackageList = currentExpectedNpmVersionFailures.split('\n').filter(Boolean);
    const updatedDtToolsFailedPackageList = [];

    const REQ_BATCH_SIZE = 50;
    for (let i = 0; i < currentDtToolsFailedPackageList.length / REQ_BATCH_SIZE; i++) {
        const currentDtToolsFailedPackageBatch = currentDtToolsFailedPackageList.slice(i * REQ_BATCH_SIZE, (i + 1) * REQ_BATCH_SIZE);

        await Promise.all(currentDtToolsFailedPackageBatch.map(async currentDtToolsFailedPackage => {
            if (currentDtToolsFailedPackage === '') {
                updatedDtToolsFailedPackageList.push(currentDtToolsFailedPackage);
                return;
            }

            const {
                isRemovableFromExpectedNpmVersionFailures
            } = await checkPackageInExpectedVersionFailures(joinPaths(cwd(), 'types', currentDtToolsFailedPackage));
            if (!isRemovableFromExpectedNpmVersionFailures) {
                updatedDtToolsFailedPackageList.push(currentDtToolsFailedPackage);
            }
        }));
    }


    updatedExpectedNpmVersionFailures = (
        updatedDtToolsFailedPackageList
            .sort((a, b) => a.localeCompare(b))
            .join('\n')

    );
}

fs.writeFileSync(
    EXPECTED_NPM_VERSION_FAILURES_PATH,
    updatedExpectedNpmVersionFailures + '\n',
    { encoding: 'utf-8' }
);
```
</details>

Then packages emitting warning `"... can be removed from expectedNpmVersionFailures.txt in ..."` will be removed from `expectedNpmVersionFailures.txt`, as the warning suggests.

It may be possible to integrate these scripts into DT(-tools), to set up regular job for updating `expectedNpmVersionFailures.txt` in DT-tools, but it will need DT(-tools)'s maintainers' comment on how to properly do so.
