### PR TITLE
Return 400 error on bad JSON in mergebot

### DIFF
--- a/packages/mergebot/src/functions/discussions-trigger.ts
+++ b/packages/mergebot/src/functions/discussions-trigger.ts
@@ -12,7 +12,12 @@ import { fetchFile } from "../util/fetchFile";
 app.http("Discussions-Trigger", {
   methods: ["GET", "POST"],
   handler: async (req, context) => {
-    const body = (await req.json()) as DiscussionWebhook;
+    let body: DiscussionWebhook;
+    try {
+      body = (await req.json()) as DiscussionWebhook;
+    } catch {
+      return reply(context, 400, "Invalid JSON");
+    }
     httpLog(context, req.headers, body);
 
     if (!(await shouldRunRequest(context, req.headers, body, canHandleRequest))) {

--- a/packages/mergebot/src/functions/pr-trigger.ts
+++ b/packages/mergebot/src/functions/pr-trigger.ts
@@ -46,7 +46,12 @@ class IgnoredBecause {
 }
 
 async function httpTrigger(req: HttpRequest, context: InvocationContext) {
-  const body = (await req.json()) as any;
+  let body: any;
+  try {
+    body = (await req.json()) as any;
+  } catch {
+    return reply(context, 400, "Invalid JSON");
+  }
   httpLog(context, req.headers, body);
   const evName = req.headers.get("x-github-event"),
     evAction = body.action;


### PR DESCRIPTION
Makes the app less unhappy on bad inputs / timeouts.