### PR TITLE
feat: add useragent and fastify-user-agent to allowed dependencies list

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -736,6 +736,7 @@ express-graphql
 express-rate-limit
 fast-glob
 fastify
+fastify-user-agent
 fflate
 filestack-js
 final-form
@@ -946,6 +947,7 @@ typescript-tuple
 undici-types
 unified
 url-pattern
+useragent
 utility-types
 vega-typings
 vfile-message


### PR DESCRIPTION
I am working on adding `@types/fastify-user-agent` to DefinitelyTyped, but first need to add `useragent` and `fastify-user-agent` dependencies to the allow list.

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71921

```
Error: fastify-user-agent: In package.json: Dependency fastify-user-agent not in the allowed dependencies list.
Please make a pull request to microsoft/DefinitelyTyped-tools adding it to `packages/definitions-parser/allowedPackageJsonDependencies.txt`.
In package.json: Dependency useragent not in the allowed dependencies list.
Please make a pull request to microsoft/DefinitelyTyped-tools adding it to `packages/definitions-parser/allowedPackageJsonDependencies.txt`.
    at prepareAffectedPackages 
```