### PR TITLE
Support TS 5.9

### DIFF
--- a/.changeset/little-pugs-lick.md
+++ b/.changeset/little-pugs-lick.md
@@ -1,0 +1,6 @@
+---
+"@definitelytyped/typescript-packages": patch
+"@definitelytyped/typescript-versions": patch
+---
+
+Support TS 5.9

--- a/packages/typescript-packages/package.json
+++ b/packages/typescript-packages/package.json
@@ -30,6 +30,7 @@
     "typescript-5.5": "npm:typescript@~5.5.0-0",
     "typescript-5.6": "npm:typescript@~5.6.0-0",
     "typescript-5.7": "npm:typescript@~5.7.0-0",
-    "typescript-5.8": "npm:typescript@~5.8.0-0"
+    "typescript-5.8": "npm:typescript@~5.8.0-0",
+    "typescript-5.9": "npm:typescript@~5.9.0-0"
   }
 }

--- a/packages/typescript-versions/src/index.ts
+++ b/packages/typescript-versions/src/index.ts
@@ -43,7 +43,7 @@ export namespace TypeScriptVersion {
   /** Add to this list when a version actually ships.  */
   export const shipped = ["5.0", "5.1", "5.2", "5.3", "5.4", "5.5", "5.6", "5.7"] as const;
   /** Add to this list when a version is available as typescript@next */
-  export const supported = [...shipped, "5.8"] as const;
+  export const supported = [...shipped, "5.8", "5.9"] as const;
   /** Add to this list when it will no longer be supported on Definitely Typed */
   export const unsupported = [
     "2.0",

--- a/packages/typescript-versions/test/index.test.ts
+++ b/packages/typescript-versions/test/index.test.ts
@@ -42,7 +42,7 @@ describe("isTypeScriptVersion", () => {
 
 describe("range", () => {
   it("works", () => {
-    expect(TypeScriptVersion.range("5.1")).toEqual(["5.1", "5.2", "5.3", "5.4", "5.5", "5.6", "5.7", "5.8"]);
+    expect(TypeScriptVersion.range("5.1")).toEqual(["5.1", "5.2", "5.3", "5.4", "5.5", "5.6", "5.7", "5.8", "5.9"]);
   });
   it("includes 5.0 onwards", () => {
     expect(TypeScriptVersion.range("5.0")).toEqual(TypeScriptVersion.supported);
@@ -60,6 +60,7 @@ describe("tagsToUpdate", () => {
       "ts5.6",
       "ts5.7",
       "ts5.8",
+      "ts5.9",
       "latest",
     ]);
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -463,6 +463,9 @@ importers:
       typescript-5.8:
         specifier: npm:typescript@~5.8.0-0
         version: typescript@5.8.0-dev.20241123
+      typescript-5.9:
+        specifier: npm:typescript@~5.9.0-0
+        version: typescript@5.9.0-dev.20250219
 
   packages/typescript-versions: {}
 
@@ -4795,6 +4798,11 @@ packages:
 
   typescript@5.8.0-dev.20241123:
     resolution: {integrity: sha512-9+P/Jtdlzl8CkmGg80mFnyjyqVEccRfQZYwvL1rRBctJ2PN3OfeuDq9YFJcv5tRZ3Y59+AuHiADSJpoRUKvVaQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@5.9.0-dev.20250219:
+    resolution: {integrity: sha512-BzBFdaj0tnTp9fp9pu1rgi7vt3u7z6EDL3IbjTgkf5GvpXTjWmQkE633De5S3ySeNL6dyZvBeVvLCKXKcOvbQA==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -10310,6 +10318,8 @@ snapshots:
   typescript@5.7.2: {}
 
   typescript@5.8.0-dev.20241123: {}
+
+  typescript@5.9.0-dev.20250219: {}
 
   unbox-primitive@1.0.2:
     dependencies:


### PR DESCRIPTION
Nightly is now 5.9; start testing it.