### PR TITLE
feat: Remove use-sync-external-store from expectedNpmVersionFailures.txt

### DIFF
--- a/packages/dtslint/expectedNpmVersionFailures.txt
+++ b/packages/dtslint/expectedNpmVersionFailures.txt
@@ -421,7 +421,6 @@ url-join/v0
 urlparser
 urlrouter
 usage
-use-sync-external-store
 user-agents
 user-event
 utils-merge


### PR DESCRIPTION
For once https://github.com/DefinitelyTyped/DefinitelyTyped/pull/72360 landed