### PR TITLE
Fix monorepo publishing task

### DIFF
--- a/.github/workflows/version-or-publish.yml
+++ b/.github/workflows/version-or-publish.yml
@@ -2,7 +2,7 @@
 # - changesets will publish packages when that PR is merged
 # (it's confusing because the same action does two super different things)
 
-name: Format, Version or Publish Packages
+name: Version or Publish Packages
 
 on:
   workflow_dispatch:
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
         with:
           fetch-depth: 0
+          token: ${{ secrets.TYPESCRIPT_BOT_TOKEN }}
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: 20


### PR DESCRIPTION
I broke this in #1158. We still need this token for pushing to the branch for versioning, not just formatting.