### PR TITLE
Place all versions of a single package into the same shard

### DIFF
--- a/.changeset/ten-crews-thank.md
+++ b/.changeset/ten-crews-thank.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/dtslint-runner": patch
+---
+
+Place all versions of a single package into the same shard

--- a/packages/dtslint-runner/src/main.ts
+++ b/packages/dtslint-runner/src/main.ts
@@ -54,7 +54,7 @@ export async function runDTSLint({
   const expectedFailures = getExpectedFailures(onlyRunAffectedPackages, dependents);
 
   const allPackages = [...packageNames, ...attwChanges, ...dependents];
-  const testedPackages = shard ? allPackages.filter((_, i) => i % shard.count === shard.id - 1) : allPackages;
+  const testedPackages = getTestedPackages(shard, allPackages);
 
   const dtslintArgs = [
     "--listen",
@@ -203,4 +203,37 @@ async function cloneDefinitelyTyped(cwd: string, sha: string | undefined): Promi
     console.log(`${switchCmd[0]} ${switchCmd[1].join(" ")}`);
     await execAndThrowErrors(switchCmd[0], switchCmd[1], cwd);
   }
+}
+
+function getTestedPackages(shard: { id: number; count: number } | undefined, packages: string[]) {
+  if (!shard) {
+    return packages;
+  }
+  
+  // When sharding packages, keep versioned packages together to avoid failing
+  // multiple CI jobs on issues that affect all versions of a package.
+
+  const groups = new Map<string, string[]>();
+  
+  for (const pkg of packages) {
+    const prefix = pkg.split("/")[0];
+    const group = groups.get(prefix);
+    if (group) {
+      group.push(pkg);
+    } else {
+      groups.set(prefix, [pkg]);
+    }
+  }
+
+  const shardedPackages: string[] = [];
+
+  let i = 0;
+  for (const group of groups.values()) {
+    if (i % shard.count === shard.id - 1) {
+      shardedPackages.push(...group);
+    }
+    i++;
+  }
+
+  return shardedPackages;
 }

--- a/packages/dtslint-runner/src/main.ts
+++ b/packages/dtslint-runner/src/main.ts
@@ -209,12 +209,12 @@ function getTestedPackages(shard: { id: number; count: number } | undefined, pac
   if (!shard) {
     return packages;
   }
-  
+
   // When sharding packages, keep versioned packages together to avoid failing
   // multiple CI jobs on issues that affect all versions of a package.
 
   const groups = new Map<string, string[]>();
-  
+
   for (const pkg of packages) {
     const prefix = pkg.split("/")[0];
     const group = groups.get(prefix);


### PR DESCRIPTION
This has bugged me for a while; when a package breaks (e.g. react right now), we're effectively guaranteed to place all of that package's versions into different shards, so CI will have failures spread across multiple logs. That's pretty annoying to gauge how broken something is.

This PR modifies our shading algorithm to group packages and then shard on those groups, placing `react`/`react/v18`, or `node`/`node/v20`/`node/v18`, etc, all in the same shard to fail together.

Probably it'd also be worth it to place something like `react` with `react-dom`, since those are also pretty much guaranteed to be in separate CI jobs.

Another fix would be to _not_ round robin shard the packages, instead group them directly alphabetically, however I think that might have the negative effect of making CI run longer as we'd end up in a situation like "all react packages are located on the same few shards" and take more time to run than other jobs.

This grouping thing I think is the "least bad" to at least get the same package into the same log.