### PR TITLE
Warn on unsupported versions but validate, skip tests

### DIFF
--- a/.changeset/dull-balloons-look.md
+++ b/.changeset/dull-balloons-look.md
@@ -1,0 +1,6 @@
+---
+"@definitelytyped/header-parser": patch
+"@definitelytyped/dtslint": patch
+---
+
+Warn on unsupported versions but validate, skip tests

--- a/packages/dtslint/src/index.ts
+++ b/packages/dtslint/src/index.ts
@@ -211,7 +211,9 @@ async function runTests(
       const supportedTypesVersions = typesVersions.filter(TypeScriptVersion.isSupported);
       if (supportedTypesVersions.length !== typesVersions.length) {
         const unsupportedTypesVersions = typesVersions.filter((v) => !TypeScriptVersion.isSupported(v));
-        warnings.push(`Package ${packageName} has unsupported TypeScript versions that will not be tested: ${unsupportedTypesVersions.join(", ")}`);
+        warnings.push(
+          `Package ${packageName} has unsupported TypeScript versions that will not be tested: ${unsupportedTypesVersions.join(", ")}`,
+        );
       }
       const lows = [TypeScriptVersion.lowest, ...supportedTypesVersions.map(next)];
       const his = [...supportedTypesVersions, TypeScriptVersion.latest];

--- a/packages/dtslint/src/index.ts
+++ b/packages/dtslint/src/index.ts
@@ -208,8 +208,13 @@ async function runTests(
       // associated ts3.2, ts3.5, ts3.6 directories, for
       // <=3.2, <=3.5, <=3.6 respectively; the root level is for 3.7 and above.
       // so this code needs to generate ranges [lowest-3.2, 3.3-3.5, 3.6-3.6, 3.7-latest]
-      const lows = [TypeScriptVersion.lowest, ...typesVersions.map(next)];
-      const his = [...typesVersions, TypeScriptVersion.latest];
+      const supportedTypesVersions = typesVersions.filter(TypeScriptVersion.isSupported);
+      if (supportedTypesVersions.length !== typesVersions.length) {
+        const unsupportedTypesVersions = typesVersions.filter((v) => !TypeScriptVersion.isSupported(v));
+        warnings.push(`Package ${packageName} has unsupported TypeScript versions that will not be tested: ${unsupportedTypesVersions.join(", ")}`);
+      }
+      const lows = [TypeScriptVersion.lowest, ...supportedTypesVersions.map(next)];
+      const his = [...supportedTypesVersions, TypeScriptVersion.latest];
       assert.strictEqual(lows.length, his.length);
       for (let i = 0; i < lows.length; i++) {
         const low = maxVersion(minVersion, lows[i]);

--- a/packages/header-parser/src/index.ts
+++ b/packages/header-parser/src/index.ts
@@ -340,10 +340,7 @@ export function getTypesVersions(dirPath: string): readonly AllTypeScriptVersion
     if (!TypeScriptVersion.isTypeScriptVersion(version)) {
       throw new Error(`There is an entry named ${name}, but ${version} is not a valid TypeScript version.`);
     }
-    // if (!TypeScriptVersion.isSupported(version)) {
-    //   // return undefined;
-    //   throw new Error(`At ${dirPath}/${name}: TypeScript version ${version} is not supported on Definitely Typed.`);
-    // }
+
     return version;
   });
 }

--- a/packages/header-parser/src/index.ts
+++ b/packages/header-parser/src/index.ts
@@ -340,7 +340,9 @@ export function getTypesVersions(dirPath: string): readonly AllTypeScriptVersion
     if (!TypeScriptVersion.isTypeScriptVersion(version)) {
       throw new Error(`There is an entry named ${name}, but ${version} is not a valid TypeScript version.`);
     }
-
+    // if (!TypeScriptVersion.isSupported(version)) {
+    //   throw new Error(`At ${dirPath}/${name}: TypeScript version ${version} is not supported on Definitely Typed.`);
+    // }
     return version;
   });
 }

--- a/packages/header-parser/src/index.ts
+++ b/packages/header-parser/src/index.ts
@@ -327,7 +327,7 @@ export function validatePackageJson(
   }
 }
 
-export function getTypesVersions(dirPath: string): readonly TypeScriptVersion[] {
+export function getTypesVersions(dirPath: string): readonly AllTypeScriptVersion[] {
   return mapDefined(fs.readdirSync(dirPath), (name) => {
     if (name === "tsconfig.json") {
       return undefined;
@@ -340,9 +340,10 @@ export function getTypesVersions(dirPath: string): readonly TypeScriptVersion[] 
     if (!TypeScriptVersion.isTypeScriptVersion(version)) {
       throw new Error(`There is an entry named ${name}, but ${version} is not a valid TypeScript version.`);
     }
-    if (!TypeScriptVersion.isSupported(version)) {
-      throw new Error(`At ${dirPath}/${name}: TypeScript version ${version} is not supported on Definitely Typed.`);
-    }
+    // if (!TypeScriptVersion.isSupported(version)) {
+    //   // return undefined;
+    //   throw new Error(`At ${dirPath}/${name}: TypeScript version ${version} is not supported on Definitely Typed.`);
+    // }
     return version;
   });
 }


### PR DESCRIPTION
I very much don't like this, but this makes it a warning (not a hard error) to leave older types versions behind untested.

See also DefinitelyTyped/DefinitelyTyped#72320