### PR TITLE
Add @dimforge/rapier3d-compat to allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -11,6 +11,7 @@
 @babel/types
 @bitcoin-computer/nakamotojs
 @commander-js/extra-typings
+@dimforge/rapier3d-compat
 @elastic/elasticsearch
 @electron/get
 @ember/test-helpers


### PR DESCRIPTION
three.js uses it in some of their addons (https://github.com/three-types/three-ts-types/pull/1602)