### PR TITLE
Remove support for TS 5.1

### DIFF
--- a/.changeset/large-houses-hunt.md
+++ b/.changeset/large-houses-hunt.md
@@ -1,0 +1,6 @@
+---
+"@definitelytyped/typescript-packages": patch
+"@definitelytyped/typescript-versions": patch
+---
+
+Remove support for TS 5.1

--- a/packages/publisher/test/__snapshots__/generate-packages.test.ts.snap
+++ b/packages/publisher/test/__snapshots__/generate-packages.test.ts.snap
@@ -57,7 +57,7 @@ exports[`basicPackageJson 1`] = `
         "@types/express": "*"
     },
     "typesPublisherContentHash": "53300522250468c4161b10d962cac2d9d8f2cfee1b3dfef4b749a7c3ec839275",
-    "typeScriptVersion": "5.1"
+    "typeScriptVersion": "5.2"
 }"
 `;
 

--- a/packages/typescript-packages/package.json
+++ b/packages/typescript-packages/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@definitelytyped/typescript-versions": "workspace:*",
-    "typescript-5.1": "npm:typescript@~5.1.0-0",
     "typescript-5.2": "npm:typescript@~5.2.0-0",
     "typescript-5.3": "npm:typescript@~5.3.0-0",
     "typescript-5.4": "npm:typescript@~5.4.0-0",

--- a/packages/typescript-versions/src/index.ts
+++ b/packages/typescript-versions/src/index.ts
@@ -41,7 +41,7 @@ export type AllTypeScriptVersion = UnsupportedTypeScriptVersion | TypeScriptVers
 
 export namespace TypeScriptVersion {
   /** Add to this list when a version actually ships.  */
-  export const shipped = ["5.1", "5.2", "5.3", "5.4", "5.5", "5.6", "5.7", "5.8"] as const;
+  export const shipped = ["5.2", "5.3", "5.4", "5.5", "5.6", "5.7", "5.8"] as const;
   /** Add to this list when a version is available as typescript@next */
   export const supported = [...shipped, "5.9"] as const;
   /** Add to this list when it will no longer be supported on Definitely Typed */
@@ -77,6 +77,7 @@ export namespace TypeScriptVersion {
     "4.8",
     "4.9",
     "5.0",
+    "5.1",
   ] as const;
   export const all: readonly AllTypeScriptVersion[] = [...unsupported, ...supported];
   export const lowest = supported[0];

--- a/packages/typescript-versions/test/index.test.ts
+++ b/packages/typescript-versions/test/index.test.ts
@@ -18,19 +18,19 @@ describe("all", () => {
 
 describe("isSupported", () => {
   it("works", () => {
-    expect(TypeScriptVersion.isSupported("5.6")).toBeTruthy();
+    expect(TypeScriptVersion.isSupported("5.8")).toBeTruthy();
   });
-  it("supports 5.1", () => {
-    expect(TypeScriptVersion.isSupported("5.1")).toBeTruthy();
+  it("supports 5.2", () => {
+    expect(TypeScriptVersion.isSupported("5.2")).toBeTruthy();
   });
-  it("does not support 4.0", () => {
-    expect(!TypeScriptVersion.isSupported("4.0")).toBeTruthy();
+  it("does not support 5.0", () => {
+    expect(!TypeScriptVersion.isSupported("5.0")).toBeTruthy();
   });
 });
 
 describe("isTypeScriptVersion", () => {
   it("accepts in-range", () => {
-    expect(TypeScriptVersion.isTypeScriptVersion("5.1")).toBeTruthy();
+    expect(TypeScriptVersion.isTypeScriptVersion("5.2")).toBeTruthy();
   });
   it("rejects out-of-range", () => {
     expect(TypeScriptVersion.isTypeScriptVersion("101.1")).toBeFalsy();
@@ -42,17 +42,16 @@ describe("isTypeScriptVersion", () => {
 
 describe("range", () => {
   it("works", () => {
-    expect(TypeScriptVersion.range("5.2")).toEqual(["5.2", "5.3", "5.4", "5.5", "5.6", "5.7", "5.8", "5.9"]);
+    expect(TypeScriptVersion.range("5.3")).toEqual(["5.3", "5.4", "5.5", "5.6", "5.7", "5.8", "5.9"]);
   });
-  it("includes 5.1 onwards", () => {
-    expect(TypeScriptVersion.range("5.1")).toEqual(TypeScriptVersion.supported);
+  it("includes 5.2 onwards", () => {
+    expect(TypeScriptVersion.range("5.2")).toEqual(TypeScriptVersion.supported);
   });
 });
 
 describe("tagsToUpdate", () => {
   it("works", () => {
-    expect(TypeScriptVersion.tagsToUpdate("5.2")).toEqual([
-      "ts5.2",
+    expect(TypeScriptVersion.tagsToUpdate("5.3")).toEqual([
       "ts5.3",
       "ts5.4",
       "ts5.5",
@@ -64,7 +63,7 @@ describe("tagsToUpdate", () => {
     ]);
   });
   it("allows 5.1 onwards", () => {
-    expect(TypeScriptVersion.tagsToUpdate("5.1")).toEqual(
+    expect(TypeScriptVersion.tagsToUpdate("5.2")).toEqual(
       TypeScriptVersion.supported.map((s) => "ts" + s).concat("latest"),
     );
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -436,9 +436,6 @@ importers:
       '@definitelytyped/typescript-versions':
         specifier: workspace:*
         version: link:../typescript-versions
-      typescript-5.1:
-        specifier: npm:typescript@~5.1.0-0
-        version: typescript@5.1.6
       typescript-5.2:
         specifier: npm:typescript@~5.2.0-0
         version: typescript@5.2.2
@@ -4752,11 +4749,6 @@ packages:
 
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
-
-  typescript@5.1.6:
-    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
-    engines: {node: '>=14.17'}
-    hasBin: true
 
   typescript@5.2.2:
     resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
@@ -10292,8 +10284,6 @@ snapshots:
       possible-typed-array-names: 1.0.0
 
   typedarray@0.0.6: {}
-
-  typescript@5.1.6: {}
 
   typescript@5.2.2: {}
 


### PR DESCRIPTION
The support window ends on 2025-06-01.