### PR TITLE
Add eslint to allowed packages

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -650,6 +650,7 @@ ember-source
 eris
 es-to-primitive
 esbuild
+eslint
 eslint-visitor-keys
 ethers
 eventemitter2


### PR DESCRIPTION
Related PR: DefinitelyTyped/DefinitelyTyped#73093

A few types from the eslint package are used to define a plugin here. The `@types/eslint` package no longer exists (removed in DefinitelyTyped/DefinitelyTyped#70735), so that can't be used.