### PR TITLE
add svgo to allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -855,6 +855,7 @@ ssim.js
 styled-components
 stylelint
 svelte
+svgo
 sw-toolbox
 swagger-parser
 tailwindcss


### PR DESCRIPTION
they ship their own types now.

will enable [this PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/73174) to be merged