### PR TITLE
chore: add eslint plugin to allowed list

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -653,6 +653,7 @@ eris
 es-to-primitive
 esbuild
 eslint
+eslint-plugin-playwright
 eslint-visitor-keys
 ethers
 eventemitter2


### PR DESCRIPTION
Add `eslint-plugin-playwright` package to the allowed list.

This is based on the suggestion in this [CI failure](https://github.com/DefinitelyTyped/DefinitelyTyped/actions/runs/16078163646/job/45377935501) for this [PR in DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/73198) repo.