### PR TITLE
Add @aws-sdk/client-dynamdb to allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -1,5 +1,6 @@
 @adobe/ccweb-add-on-sdk-types
 @apollo/client
+@aws-sdk/client-dynamdb
 @aws-sdk/client-s3
 @aws-sdk/client-ses
 @aws-sdk/client-sesv2


### PR DESCRIPTION
In order to fix incoherent definitions in @types/aws-lambda, see https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/67358