### PR TITLE
Add `@sass/types` and `sass-embedded` to allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -542,6 +542,7 @@
 @react-navigation/native
 @react-navigation/stack
 @redux-saga/types
+@sass/types
 @sentry/browser
 @serverless/typescript
 @sinonjs/fake-timers
@@ -842,6 +843,7 @@ rrule
 rxjs
 safe-buffer
 sass
+sass-embedded
 scroll-behavior
 scroll-into-view-if-needed
 semantic-ui-react


### PR DESCRIPTION
In https://github.com/DefinitelyTyped/DefinitelyTyped/pull/73736, I defined the type declarations for `gulp-sass` v6.

In those type declarations, I'm using the `@sass/types` package, which is a new type-only package published by the Sass team with declarations from the official Sass JS API.
`sass-embedded` is used only as dev dependency, to ensure that `gulp-sass` types indeed work both for using `gulp-sass` with `sass` and for using it with `sass-embedded`.