### PR TITLE
Add `assertion-error` to allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -589,6 +589,7 @@ apollo-link
 apollo-link-http-common
 arweave
 asn1js
+assertion-error
 ast-types
 async-done
 autoprefixer


### PR DESCRIPTION
Related PR: DefinitelyTyped/DefinitelyTyped#73830

The `chai` package uses and re-exports the `AssertionError` class from this package.