### PR TITLE
feat: add mc-server-management to allowedPackageJsonDependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -742,6 +742,7 @@ mali
 mapbox-gl
 markdownlint
 marked
+mc-server-management
 meshoptimizer
 metascraper
 meteor-typings


### PR DESCRIPTION
Hey,

this PR adds the mc-server-management package to the allowedPackageJsonDependencies file.
It will be needed for v2 of the @types/exaroton package.
The package was added to the exaroton package in this commit: exaroton/node-exaroton-api@20be6c8