### PR TITLE
Support more than one project

### DIFF
--- a/packages/definitions-parser/src/packages.ts
+++ b/packages/definitions-parser/src/packages.ts
@@ -551,7 +551,7 @@ export class TypingsData extends PackageBase {
     ));
   }
   get projectName(): string | undefined {
-    return this.data.header.projects[0];
+    return this.data.header.projects.length === 0 ? undefined : this.data.header.projects.join(", ");
   }
   get type() {
     return this.data.type;

--- a/packages/definitions-parser/test/packages.test.ts
+++ b/packages/definitions-parser/test/packages.test.ts
@@ -180,6 +180,42 @@ describe(TypingsData, () => {
     expect(data.isNotNeeded()).toBe(false);
   });
 
+  describe("project", () => {
+    it("returns the name of the only project", () => {
+      expect(data.projectName).toBe("zombo.com");
+    });
+
+    it("returns multiple project names as a comma-separated string", () => {
+      const versions = createTypingsVersionRaw(
+        "known",
+        {},
+        {},
+        {},
+        {
+          projects: ["zombo.com", "zombo.org"],
+        },
+      );
+      data = new TypingsData(createMockDT().fs, versions["1.0"], false);
+
+      expect(data.projectName).toBe("zombo.com, zombo.org");
+    });
+
+    it("returns undefined if no project is set", () => {
+      const versions = createTypingsVersionRaw(
+        "known",
+        {},
+        {},
+        {},
+        {
+          projects: [],
+        },
+      );
+      data = new TypingsData(createMockDT().fs, versions["1.0"], false);
+
+      expect(data.projectName).toBeUndefined();
+    });
+  });
+
   describe("desc", () => {
     it("returns the name if latest version", () => {
       expect(data.desc).toBe("@types/known");

--- a/packages/definitions-parser/test/utils.ts
+++ b/packages/definitions-parser/test/utils.ts
@@ -1,4 +1,4 @@
-import { License } from "@definitelytyped/header-parser";
+import { Header, License } from "@definitelytyped/header-parser";
 import { TypingsVersionsRaw, getMangledNameForScopedPackage } from "../src/packages";
 import { atTypesSlash } from "@definitelytyped/utils";
 
@@ -13,6 +13,7 @@ export function createTypingsVersionRaw(
   dependencies: { readonly [name: string]: string },
   devDependencies: { readonly [name: string]: string },
   peerDependencies?: { readonly [name: string]: string },
+  headerOverrides: Partial<Header> = {},
 ): TypingsVersionsRaw {
   return {
     "1.0": {
@@ -25,6 +26,7 @@ export function createTypingsVersionRaw(
         nonNpm: false,
         projects: ["zombo.com"],
         tsconfigs: ["tsconfig.json"],
+        ...headerOverrides,
       },
       typesVersions: [],
       license: License.MIT,


### PR DESCRIPTION
This PR adds support for more than one project in the `projects` array, concatenated into a single string.