### PR TITLE
Add @wordpress/blocks to allowed dependencies

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -562,6 +562,7 @@
 @vue/test-utils
 @webgpu/types
 @wordpress/api-fetch
+@wordpress/blocks
 @wordpress/components
 @wordpress/core-data
 @wordpress/data


### PR DESCRIPTION
## Summary

- Add `@wordpress/blocks` to `allowedPackageJsonDependencies.txt`

`@types/wordpress__blocks` is being removed from DefinitelyTyped (DefinitelyTyped/DefinitelyTyped#74886) because `@wordpress/blocks` ships its own types since v15.17.0. The dependent package `@types/wordpress__block-editor` now needs to list `@wordpress/blocks` as a direct dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)