### PR TITLE
Revert "Don't load eslintrcs even in expectOnly"

### DIFF
--- a/.changeset/flat-socks-shop.md
+++ b/.changeset/flat-socks-shop.md
@@ -1,0 +1,5 @@
+---
+"@definitelytyped/dtslint": patch
+---
+
+Revert eslintrc loading change

--- a/packages/dtslint/src/lint.ts
+++ b/packages/dtslint/src/lint.ts
@@ -112,35 +112,23 @@ function getEslintOptions(
     ],
   };
 
-  // Always disable cascading .eslintrc.* discovery. Contributor-authored config files in
-  // types/<pkg>/ would otherwise be loaded by ESLint 8's legacy eslintrc engine, which
-  // resolves `extends` and `parser` (including in `overrides[]`) via
-  // createRequire(configFilePath).resolve(value) and require()s the result. Since dtslint has
-  // no file-extension allowlist, a contributor could ship a `.cjs` payload alongside
-  // `.eslintrc.json` and obtain arbitrary code execution in the lint process.
-  const baseOverrideConfig = {
-    plugins: ["@definitelytyped", "@typescript-eslint", "jsdoc"],
-    parser: "@typescript-eslint/parser",
-    parserOptions: {
-      project: true,
-      warnOnUnsupportedTypeScriptVersion: false,
-    },
-    ...overrideConfig,
-  };
-
   if (expectOnly) {
     return {
       useEslintrc: false,
-      overrideConfig: baseOverrideConfig,
+      overrideConfig: {
+        plugins: ["@definitelytyped", "@typescript-eslint", "jsdoc"],
+        parser: "@typescript-eslint/parser",
+        parserOptions: {
+          project: true,
+          warnOnUnsupportedTypeScriptVersion: false,
+        },
+        ...overrideConfig,
+      },
     };
   }
 
   return {
-    useEslintrc: false,
-    overrideConfig: {
-      ...baseOverrideConfig,
-      extends: ["plugin:@definitelytyped/all"],
-    },
+    overrideConfig,
   };
 }
 


### PR DESCRIPTION
This reverts commit 5b4f002.

This was wrong and stopped eslintrcs in the repo from working entirely. Just revert it; loading eslintrc in the repo is not a vector we care about.