### PR TITLE
Drop TS 5.3, 5.4, and 5.5

### DIFF
--- a/.changeset/silly-hounds-show.md
+++ b/.changeset/silly-hounds-show.md
@@ -1,0 +1,6 @@
+---
+"@definitelytyped/typescript-packages": patch
+"@definitelytyped/typescript-versions": patch
+---
+
+Drop TS 5.3, 5.4, and 5.5

--- a/packages/publisher/test/__snapshots__/generate-packages.test.ts.snap
+++ b/packages/publisher/test/__snapshots__/generate-packages.test.ts.snap
@@ -57,7 +57,7 @@ exports[`basicPackageJson 1`] = `
         "@types/express": "*"
     },
     "typesPublisherContentHash": "53300522250468c4161b10d962cac2d9d8f2cfee1b3dfef4b749a7c3ec839275",
-    "typeScriptVersion": "5.3"
+    "typeScriptVersion": "5.6"
 }"
 `;
 

--- a/packages/typescript-packages/package.json
+++ b/packages/typescript-packages/package.json
@@ -22,9 +22,6 @@
   },
   "dependencies": {
     "@definitelytyped/typescript-versions": "workspace:*",
-    "typescript-5.3": "npm:typescript@~5.3.0-0",
-    "typescript-5.4": "npm:typescript@~5.4.0-0",
-    "typescript-5.5": "npm:typescript@~5.5.0-0",
     "typescript-5.6": "npm:typescript@~5.6.0-0",
     "typescript-5.7": "npm:typescript@~5.7.0-0",
     "typescript-5.8": "npm:typescript@~5.8.0-0",

--- a/packages/typescript-versions/src/index.ts
+++ b/packages/typescript-versions/src/index.ts
@@ -81,7 +81,7 @@ export namespace TypeScriptVersion {
     "5.2",
     "5.3",
     "5.4",
-    "5.5"
+    "5.5",
   ] as const;
   export const all: readonly AllTypeScriptVersion[] = [...unsupported, ...supported];
   export const lowest = supported[0];

--- a/packages/typescript-versions/src/index.ts
+++ b/packages/typescript-versions/src/index.ts
@@ -41,7 +41,7 @@ export type AllTypeScriptVersion = UnsupportedTypeScriptVersion | TypeScriptVers
 
 export namespace TypeScriptVersion {
   /** Add to this list when a version actually ships.  */
-  export const shipped = ["5.3", "5.4", "5.5", "5.6", "5.7", "5.8", "5.9", "6.0"] as const;
+  export const shipped = ["5.6", "5.7", "5.8", "5.9", "6.0"] as const;
   /** Add to this list when a version is available as typescript@next */
   export const supported = [...shipped] as const;
   /** Add to this list when it will no longer be supported on Definitely Typed */
@@ -79,6 +79,9 @@ export namespace TypeScriptVersion {
     "5.0",
     "5.1",
     "5.2",
+    "5.3",
+    "5.4",
+    "5.5"
   ] as const;
   export const all: readonly AllTypeScriptVersion[] = [...unsupported, ...supported];
   export const lowest = supported[0];

--- a/packages/typescript-versions/test/index.test.ts
+++ b/packages/typescript-versions/test/index.test.ts
@@ -18,10 +18,10 @@ describe("all", () => {
 
 describe("isSupported", () => {
   it("works", () => {
-    expect(TypeScriptVersion.isSupported("5.6")).toBeTruthy();
+    expect(TypeScriptVersion.isSupported("5.9")).toBeTruthy();
   });
-  it("supports 5.3", () => {
-    expect(TypeScriptVersion.isSupported("5.3")).toBeTruthy();
+  it("supports 5.6", () => {
+    expect(TypeScriptVersion.isSupported("5.6")).toBeTruthy();
   });
   it("does not support 4.0", () => {
     expect(!TypeScriptVersion.isSupported("4.0")).toBeTruthy();
@@ -30,7 +30,7 @@ describe("isSupported", () => {
 
 describe("isTypeScriptVersion", () => {
   it("accepts in-range", () => {
-    expect(TypeScriptVersion.isTypeScriptVersion("5.3")).toBeTruthy();
+    expect(TypeScriptVersion.isTypeScriptVersion("5.6")).toBeTruthy();
   });
   it("rejects out-of-range", () => {
     expect(TypeScriptVersion.isTypeScriptVersion("101.1")).toBeFalsy();
@@ -42,19 +42,16 @@ describe("isTypeScriptVersion", () => {
 
 describe("range", () => {
   it("works", () => {
-    expect(TypeScriptVersion.range("5.3")).toEqual(["5.3", "5.4", "5.5", "5.6", "5.7", "5.8", "5.9", "6.0"]);
+    expect(TypeScriptVersion.range("5.6")).toEqual(["5.6", "5.7", "5.8", "5.9", "6.0"]);
   });
-  it("includes 5.3 onwards", () => {
-    expect(TypeScriptVersion.range("5.3")).toEqual(TypeScriptVersion.supported);
+  it("includes 5.6 onwards", () => {
+    expect(TypeScriptVersion.range("5.6")).toEqual(TypeScriptVersion.supported);
   });
 });
 
 describe("tagsToUpdate", () => {
   it("works", () => {
-    expect(TypeScriptVersion.tagsToUpdate("5.3")).toEqual([
-      "ts5.3",
-      "ts5.4",
-      "ts5.5",
+    expect(TypeScriptVersion.tagsToUpdate("5.6")).toEqual([
       "ts5.6",
       "ts5.7",
       "ts5.8",
@@ -63,8 +60,8 @@ describe("tagsToUpdate", () => {
       "latest",
     ]);
   });
-  it("allows 5.3 onwards", () => {
-    expect(TypeScriptVersion.tagsToUpdate("5.3")).toEqual(
+  it("allows 5.6 onwards", () => {
+    expect(TypeScriptVersion.tagsToUpdate("5.6")).toEqual(
       TypeScriptVersion.supported.map((s) => "ts" + s).concat("latest"),
     );
   });

--- a/packages/typescript-versions/test/index.test.ts
+++ b/packages/typescript-versions/test/index.test.ts
@@ -51,14 +51,7 @@ describe("range", () => {
 
 describe("tagsToUpdate", () => {
   it("works", () => {
-    expect(TypeScriptVersion.tagsToUpdate("5.6")).toEqual([
-      "ts5.6",
-      "ts5.7",
-      "ts5.8",
-      "ts5.9",
-      "ts6.0",
-      "latest",
-    ]);
+    expect(TypeScriptVersion.tagsToUpdate("5.6")).toEqual(["ts5.6", "ts5.7", "ts5.8", "ts5.9", "ts6.0", "latest"]);
   });
   it("allows 5.6 onwards", () => {
     expect(TypeScriptVersion.tagsToUpdate("5.6")).toEqual(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -440,15 +440,6 @@ importers:
       '@definitelytyped/typescript-versions':
         specifier: workspace:*
         version: link:../typescript-versions
-      typescript-5.3:
-        specifier: npm:typescript@~5.3.0-0
-        version: typescript@5.3.3
-      typescript-5.4:
-        specifier: npm:typescript@~5.4.0-0
-        version: typescript@5.4.5
-      typescript-5.5:
-        specifier: npm:typescript@~5.5.0-0
-        version: typescript@5.5.4
       typescript-5.6:
         specifier: npm:typescript@~5.6.0-0
         version: typescript@5.6.3
@@ -4914,11 +4905,6 @@ packages:
   typed-array-length@1.0.7:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
-
-  typescript@5.3.3:
-    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
 
   typescript@5.4.5:
     resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
@@ -10542,8 +10528,6 @@ snapshots:
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
-
-  typescript@5.3.3: {}
 
   typescript@5.4.5: {}
 


### PR DESCRIPTION
TypeScript has lagged on releases due to the port. But that means we left versions of TS supported on DT that would normally have fallen off.

Just drop 5.3, 5.4, and 5.5 now, even though that brings us to fewer than 10 supported versions, as though we had just been releasing TS this whole time.

This should enable people to start using things like `NoInfer`.